### PR TITLE
Add neovim project config and gitignore data directories

### DIFF
--- a/.exrc
+++ b/.exrc
@@ -1,0 +1,60 @@
+" Decision Theatre - Vim/Neovim Project Configuration
+" ===================================================
+" Project-specific settings and keybindings
+" Note: For full which-key integration, see .nvim.lua
+
+" Enable project-local config
+set exrc
+set secure
+
+" Go settings
+autocmd FileType go setlocal tabstop=4 shiftwidth=4 noexpandtab
+
+" TypeScript/JavaScript settings
+autocmd FileType typescript,typescriptreact,javascript,javascriptreact setlocal tabstop=2 shiftwidth=2 expandtab
+
+" Project keybindings (legacy vim - use .nvim.lua for which-key)
+" All under <leader>p prefix
+
+" Build
+nnoremap <leader>pba :!make app<CR>
+nnoremap <leader>pbb :!make build-backend<CR>
+nnoremap <leader>pbf :!make build-frontend<CR>
+nnoremap <leader>pbc :!make clean<CR>
+
+" Dev
+nnoremap <leader>pda :terminal make dev-all<CR>
+nnoremap <leader>pdb :terminal make dev-backend<CR>
+nnoremap <leader>pdf :terminal make dev-frontend<CR>
+nnoremap <leader>pdr :terminal nix run<CR>
+
+" Test
+nnoremap <leader>ptg :terminal make test<CR>
+nnoremap <leader>ptf :terminal make test-frontend<CR>
+nnoremap <leader>pta :terminal make test-all<CR>
+
+" Quality
+nnoremap <leader>pqf :!make fmt<CR>
+nnoremap <leader>pql :terminal make lint<CR>
+nnoremap <leader>pqc :terminal make check<CR>
+
+" Docs
+nnoremap <leader>pob :!make docs<CR>
+nnoremap <leader>pos :terminal make docs-serve<CR>
+
+" Packaging
+nnoremap <leader>pka :terminal make packages<CR>
+nnoremap <leader>pkl :terminal make packages-linux<CR>
+
+" Data
+nnoremap <leader>pxg :terminal make geopackage<CR>
+nnoremap <leader>pxp :terminal make datapack<CR>
+
+" Git
+nnoremap <leader>pgs :!git status<CR>
+nnoremap <leader>pgd :!git diff<CR>
+nnoremap <leader>pgl :!git log --oneline -20<CR>
+
+" Info
+nnoremap <leader>pi :!make info<CR>
+nnoremap <leader>ph :!make help<CR>

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ data/*.mbtiles
 data/*.parquet
 data/*.geoparquet
 data/*.json
+data/images/
+data/sites/
 
 # Large resource files
 *.mbtiles

--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,0 +1,142 @@
+-- Decision Theatre - Neovim Project Configuration
+-- ================================================
+-- Project-specific keybindings under <leader>p
+-- All commands run inside nix develop environment
+
+local ok, wk = pcall(require, "which-key")
+if not ok then
+  vim.notify("which-key not found, skipping project keybindings", vim.log.levels.WARN)
+  return
+end
+
+-- Helper to run commands in a terminal
+local function term_cmd(cmd, title)
+  return function()
+    vim.cmd("vsplit | terminal " .. cmd)
+    vim.cmd("startinsert")
+    if title then
+      vim.api.nvim_buf_set_name(0, title)
+    end
+  end
+end
+
+-- Helper to run commands silently and notify
+local function silent_cmd(cmd)
+  return function()
+    vim.fn.jobstart(cmd, {
+      on_exit = function(_, code)
+        if code == 0 then
+          vim.notify("Command completed: " .. cmd, vim.log.levels.INFO)
+        else
+          vim.notify("Command failed: " .. cmd, vim.log.levels.ERROR)
+        end
+      end,
+    })
+  end
+end
+
+wk.add({
+  { "<leader>p", group = "Project (Decision Theatre)" },
+
+  -- Build commands
+  { "<leader>pb", group = "Build" },
+  { "<leader>pba", term_cmd("make app", "Build App"), desc = "Build full app (nix)" },
+  { "<leader>pbb", term_cmd("make build-backend", "Build Backend"), desc = "Build backend only" },
+  { "<leader>pbf", term_cmd("make build-frontend", "Build Frontend"), desc = "Build frontend only" },
+  { "<leader>pbd", term_cmd("make build-docs", "Build Docs"), desc = "Build docs (embed)" },
+  { "<leader>pbc", term_cmd("make clean", "Clean"), desc = "Clean build artifacts" },
+
+  -- Development commands
+  { "<leader>pd", group = "Dev" },
+  { "<leader>pda", term_cmd("make dev-all", "Dev All"), desc = "Full dev stack (air + vite)" },
+  { "<leader>pdb", term_cmd("make dev-backend", "Dev Backend"), desc = "Backend hot-reload (air)" },
+  { "<leader>pdf", term_cmd("make dev-frontend", "Dev Frontend"), desc = "Frontend HMR (vite)" },
+  { "<leader>pdr", term_cmd("nix run", "Nix Run"), desc = "Run via nix" },
+
+  -- Testing commands
+  { "<leader>pt", group = "Test" },
+  { "<leader>ptg", term_cmd("make test", "Go Tests"), desc = "Go tests + coverage" },
+  { "<leader>ptf", term_cmd("make test-frontend", "Frontend Tests"), desc = "Frontend tests (vitest)" },
+  { "<leader>pta", term_cmd("make test-all", "All Tests"), desc = "All tests" },
+
+  -- Code quality
+  { "<leader>pq", group = "Quality" },
+  { "<leader>pqf", term_cmd("make fmt", "Format"), desc = "Format code (go fmt)" },
+  { "<leader>pql", term_cmd("make lint", "Lint"), desc = "Lint (golangci-lint)" },
+  { "<leader>pqc", term_cmd("make check", "Check"), desc = "Full check (fmt + lint + test)" },
+  { "<leader>pqt", silent_cmd("make deps"), desc = "Tidy dependencies (go mod tidy)" },
+
+  -- Documentation
+  { "<leader>po", group = "Docs" },
+  { "<leader>pob", term_cmd("make docs", "Build Docs"), desc = "Build docs (mkdocs)" },
+  { "<leader>pos", term_cmd("make docs-serve", "Serve Docs"), desc = "Serve docs (localhost:8000)" },
+  { "<leader>por", term_cmd("make docs-requirements-serve", "Requirements Docs"), desc = "Serve requirements docs" },
+  { "<leader>poo", silent_cmd("xdg-open http://localhost:8000"), desc = "Open docs in browser" },
+
+  -- Packaging
+  { "<leader>pk", group = "Package" },
+  { "<leader>pka", term_cmd("make packages", "All Packages"), desc = "Build all packages" },
+  { "<leader>pkl", term_cmd("make packages-linux", "Linux Packages"), desc = "Linux packages" },
+  { "<leader>pkw", term_cmd("make packages-windows", "Windows Packages"), desc = "Windows packages" },
+  { "<leader>pkd", term_cmd("make packages-darwin", "Darwin Packages"), desc = "macOS packages" },
+
+  -- Data
+  { "<leader>px", group = "Data" },
+  { "<leader>pxg", term_cmd("make geopackage", "Build GeoPackage"), desc = "Build datapack.gpkg" },
+  { "<leader>pxp", term_cmd("make datapack", "Package Data"), desc = "Package data (.zip)" },
+  { "<leader>pxl", term_cmd("make list-datapack", "List Datapack"), desc = "List datapack contents" },
+
+  -- Design system
+  { "<leader>ps", group = "Design System" },
+  { "<leader>pse", term_cmd("make design-export", "Design Export"), desc = "Export design tokens" },
+  { "<leader>psi", term_cmd("make design-import", "Design Import"), desc = "Import design tokens" },
+  { "<leader>psp", term_cmd("make design-preview", "Design Preview"), desc = "Preview design import" },
+
+  -- Git/Release
+  { "<leader>pg", group = "Git/Release" },
+  { "<leader>pgr", term_cmd("./scripts/create-new-release.sh", "Release"), desc = "Create new release" },
+  { "<leader>pgs", term_cmd("git status", "Git Status"), desc = "Git status" },
+  { "<leader>pgd", term_cmd("git diff", "Git Diff"), desc = "Git diff" },
+  { "<leader>pgl", term_cmd("git log --oneline -20", "Git Log"), desc = "Git log (last 20)" },
+
+  -- Nix
+  { "<leader>pn", group = "Nix" },
+  { "<leader>pnb", term_cmd("nix build", "Nix Build"), desc = "Nix build" },
+  { "<leader>pnf", term_cmd("nix build .#frontend", "Nix Frontend"), desc = "Nix build frontend" },
+  { "<leader>pnc", term_cmd("nix flake check", "Nix Check"), desc = "Nix flake check" },
+  { "<leader>pnu", term_cmd("nix flake update", "Nix Update"), desc = "Nix flake update" },
+
+  -- Info/Help
+  { "<leader>pi", term_cmd("make info", "Project Info"), desc = "Project info" },
+  { "<leader>ph", term_cmd("make help", "Project Help"), desc = "Makefile help" },
+})
+
+-- LSP settings for Go
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "go",
+  callback = function()
+    vim.opt_local.tabstop = 4
+    vim.opt_local.shiftwidth = 4
+    vim.opt_local.expandtab = false
+  end,
+})
+
+-- LSP settings for TypeScript/JavaScript (frontend)
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "typescript", "typescriptreact", "javascript", "javascriptreact" },
+  callback = function()
+    vim.opt_local.tabstop = 2
+    vim.opt_local.shiftwidth = 2
+    vim.opt_local.expandtab = true
+  end,
+})
+
+-- Auto-format Go files on save
+vim.api.nvim_create_autocmd("BufWritePre", {
+  pattern = "*.go",
+  callback = function()
+    vim.lsp.buf.format({ async = false })
+  end,
+})
+
+vim.notify("Decision Theatre project config loaded. Use <leader>p for project commands.", vim.log.levels.INFO)


### PR DESCRIPTION
## Summary

- Add `.nvim.lua` with which-key bindings under `<leader>p` for all project tasks
- Add `.exrc` for legacy vim fallback keybindings  
- Gitignore `data/images/` and `data/sites/` directories (user-generated data)

### Neovim Keybindings

| Prefix | Group | Bindings |
|--------|-------|----------|
| `<leader>pb` | Build | `a` app, `b` backend, `f` frontend, `d` docs, `c` clean |
| `<leader>pd` | Dev | `a` dev-all, `b` backend, `f` frontend, `r` nix run |
| `<leader>pt` | Test | `g` go tests, `f` frontend, `a` all |
| `<leader>pq` | Quality | `f` format, `l` lint, `c` check, `t` tidy deps |
| `<leader>po` | Docs | `b` build, `s` serve, `r` requirements, `o` open browser |
| `<leader>pk` | Package | `a` all, `l` linux, `w` windows, `d` darwin |
| `<leader>px` | Data | `g` geopackage, `p` datapack, `l` list |
| `<leader>ps` | Design | `e` export, `i` import, `p` preview |
| `<leader>pg` | Git | `r` release, `s` status, `d` diff, `l` log |
| `<leader>pn` | Nix | `b` build, `f` frontend, `c` check, `u` update |
| `<leader>pi` | Info | Project info |
| `<leader>ph` | Help | Makefile help |

## Test plan

- [ ] Open project in neovim with which-key installed
- [ ] Verify `<leader>p` shows project command menu
- [ ] Test a few keybindings (e.g., `<leader>phi` for help)
- [ ] Verify data directories are properly ignored by git