### PR TITLE
fix: close three P0 holes in the HTTP surface

### DIFF
--- a/deployments/nginx.conf
+++ b/deployments/nginx.conf
@@ -8,7 +8,13 @@ upstream decision_theatre {
     keepalive 16;
 }
 
-client_max_body_size 2g;
+# Matches internal/server/bodylimit.go's LargeMaxBodyBytes, with a little room
+# for multipart overhead. It was 2g, which let a single request make the Go
+# process buffer two gigabytes; nothing this application accepts is close.
+#
+# Raise both together or neither: a larger value here only means the request
+# travels further before the application refuses it.
+client_max_body_size 40m;
 
 # The choropleth JSON response (the app's largest payload - several MB of
 # dissolved catchment polygons at min zoom) compresses ~3-4x with gzip,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,21 @@ type Config struct {
 	DataDir      string
 	ResourcesDir string
 	Version      string
+
+	// DesktopMode is true only when the process owns a desktop session and has
+	// opened the embedded WebView window.
+	//
+	// It gates routes that are meaningless — and dangerous — without one.
+	// /api/dialog/open-file calls zenity, which opens a native file picker on
+	// whatever desktop the process is attached to and blocks until a human
+	// answers it. On the hosted deployment nginx proxies every path, so that
+	// endpoint was internet-reachable: a stranger could pop a window on the
+	// server's desktop, and every call held a server goroutine for as long as
+	// the dialog stood open.
+	//
+	// The zero value is the safe one. A caller that forgets to set it gets the
+	// server build, without the desktop-only routes.
+	DesktopMode bool
 }
 
 // Settings holds persistent user settings saved to disk

--- a/internal/server/bodylimit.go
+++ b/internal/server/bodylimit.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kartoza/decision-theatre/internal/httputil"
+)
+
+// Request body limits.
+//
+// Every JSON handler decoded straight from r.Body with no cap, and nginx was
+// configured to pass bodies up to 2 GB, so one POST could make the process
+// buffer two gigabytes. There is no legitimate request anywhere near that size.
+//
+// The limits below are generous against real payloads and small against an
+// attack. Raise one only with a payload that needs it, and say which.
+const (
+	// DefaultMaxBodyBytes covers every JSON handler: a few identifiers, some
+	// numbers, occasionally a list of catchment ids.
+	DefaultMaxBodyBytes int64 = 1 << 20 // 1 MiB
+
+	// LargeMaxBodyBytes covers the handlers that carry geometry or an inline
+	// image. A site boundary drawn by hand is tens of kilobytes; one dissolved
+	// from several hundred catchments, or a base64 thumbnail, is larger.
+	//
+	// Measured against the fixtures in this repository the worst case is a few
+	// megabytes, so this leaves roughly an order of magnitude of headroom.
+	LargeMaxBodyBytes int64 = 32 << 20 // 32 MiB
+)
+
+// largeBodyPaths are the request paths allowed LargeMaxBodyBytes.
+//
+// Matched as suffixes on the cleaned path so the {id} segment does not need
+// enumerating. Deliberately a list rather than a prefix on /api: an endpoint
+// gets the larger allowance by being named here, not by accident.
+var largeBodyPaths = []string{
+	"/sites",                     // create, with geometry
+	"/sites/dissolve-catchments", // a list of catchment ids in, geometry out
+}
+
+// largeBodySuffixes are path endings allowed LargeMaxBodyBytes, so that
+// /api/sites/{id} and /api/sites/{id}/indicators do not need the id spelled out.
+var largeBodySuffixes = []string{
+	"/indicators",
+	"/catchments",
+}
+
+// maxBytesForPath returns the limit that applies to a request path.
+func maxBytesForPath(path string) int64 {
+	trimmed := strings.TrimSuffix(path, "/")
+
+	for _, p := range largeBodyPaths {
+		if trimmed == p || strings.HasSuffix(trimmed, p) {
+			return LargeMaxBodyBytes
+		}
+	}
+	for _, suffix := range largeBodySuffixes {
+		if strings.HasSuffix(trimmed, suffix) {
+			return LargeMaxBodyBytes
+		}
+	}
+
+	// An /api/sites/{id} update carries the whole site, geometry included.
+	if strings.Contains(trimmed, "/sites/") {
+		return LargeMaxBodyBytes
+	}
+
+	return DefaultMaxBodyBytes
+}
+
+// limitRequestBody caps how much a handler can read from a request.
+//
+// http.MaxBytesReader makes the read fail past the limit rather than letting the
+// handler buffer without bound. On its own that surfaces as a decode error and a
+// 500, which describes the wrong thing: the request is at fault, not the server.
+// So the limit is also checked against Content-Length up front, where it is
+// declared, and answered with 413.
+//
+// A chunked request declares no length. MaxBytesReader still stops the read, and
+// the handler's decode error is then a 400 rather than a 413 — the request is
+// still refused, which is what matters.
+func limitRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil || r.Body == http.NoBody {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		limit := maxBytesForPath(r.URL.Path)
+
+		// Refuse a declared oversize before reading a byte of it.
+		if r.ContentLength > limit {
+			httputil.RespondError(w, http.StatusRequestEntityTooLarge,
+				"request body is too large")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, limit)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/bodylimit_test.go
+++ b/internal/server/bodylimit_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Every JSON handler used to decode straight from r.Body with no cap, and nginx
+// passed bodies up to 2 GB, so one POST could make the process buffer two
+// gigabytes.
+
+func TestMaxBytesForPath(t *testing.T) {
+	cases := map[string]int64{
+		// Small: identifiers and numbers.
+		"/api/datapack/install": DefaultMaxBodyBytes,
+		"/api/datapack/status":  DefaultMaxBodyBytes,
+		"/api/metadata/units":   DefaultMaxBodyBytes,
+		"/api/health":           DefaultMaxBodyBytes,
+		"/api/dialog/open-file": DefaultMaxBodyBytes,
+		// A GET carrying no body; the default limit is the right answer.
+		"/api/catchments/geometry/1121879850": DefaultMaxBodyBytes,
+
+		// Large: geometry or an inline image.
+		"/api/sites":                          LargeMaxBodyBytes,
+		"/api/sites/":                         LargeMaxBodyBytes,
+		"/api/sites/dissolve-catchments":      LargeMaxBodyBytes,
+		"/api/sites/abc-123":                  LargeMaxBodyBytes,
+		"/api/sites/abc-123/indicators":       LargeMaxBodyBytes,
+		"/api/sites/abc-123/indicators/reset": LargeMaxBodyBytes,
+		"/api/sites/abc-123/catchments":       LargeMaxBodyBytes,
+	}
+
+	for path, want := range cases {
+		if got := maxBytesForPath(path); got != want {
+			t.Errorf("maxBytesForPath(%q) = %d, want %d", path, got, want)
+		}
+	}
+}
+
+// A declared oversize is refused before any of it is read, and with the status
+// that describes the fault: 413, not 500.
+func TestOversizedBodyIsRejectedWith413(t *testing.T) {
+	var reached bool
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := strings.NewReader(strings.Repeat("x", 16))
+	req := httptest.NewRequest(http.MethodPost, "/api/datapack/install", body)
+	// Declare more than the limit; the handler must not run.
+	req.ContentLength = DefaultMaxBodyBytes + 1
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	if reached {
+		t.Error("the handler ran for a body that was already too large")
+	}
+}
+
+// A body within the limit is untouched — the cap must not break normal requests.
+func TestBodyWithinLimitPassesThrough(t *testing.T) {
+	const payload = `{"path":"/tmp/pack.zip"}`
+
+	var seen string
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, len(payload))
+		n, _ := r.Body.Read(buf)
+		seen = string(buf[:n])
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/datapack/install", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if seen != payload {
+		t.Errorf("handler read %q, want %q", seen, payload)
+	}
+}
+
+// An undeclared body — chunked, no Content-Length — cannot be caught up front,
+// so MaxBytesReader must still stop the read. The request is refused either way.
+func TestUndeclaredOversizedBodyStopsAtTheLimit(t *testing.T) {
+	var readErr error
+	var read int
+
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Body.Read(buf)
+			read += n
+			if err != nil {
+				readErr = err
+				return
+			}
+		}
+	}))
+
+	// Twice the limit, with the length hidden.
+	req := httptest.NewRequest(http.MethodPost, "/api/datapack/install",
+		strings.NewReader(strings.Repeat("x", int(DefaultMaxBodyBytes*2))))
+	req.ContentLength = -1
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if readErr == nil {
+		t.Fatal("the handler read an unbounded body to completion")
+	}
+	if int64(read) > DefaultMaxBodyBytes {
+		t.Errorf("handler read %d bytes, more than the %d limit", read, DefaultMaxBodyBytes)
+	}
+}
+
+// The larger allowance must genuinely apply, or saving a site with geometry
+// breaks.
+func TestLargeLimitAppliesToSiteGeometry(t *testing.T) {
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Comfortably over the default limit, comfortably under the large one.
+	size := DefaultMaxBodyBytes * 4
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/abc-123",
+		strings.NewReader(strings.Repeat("x", int(size))))
+	req.ContentLength = size
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("a %d-byte site update was refused with %d; the large limit is not applying",
+			size, rec.Code)
+	}
+}
+
+// And the larger allowance is still an allowance.
+func TestLargeLimitIsStillBounded(t *testing.T) {
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/abc-123", strings.NewReader("x"))
+	req.ContentLength = LargeMaxBodyBytes + 1
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want %d for a body over the large limit",
+			rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// The limits are only meaningful if they are smaller than what nginx passes
+// through. This guards the pair from drifting apart.
+func TestLimitsAreSaneRelativeToEachOther(t *testing.T) {
+	if DefaultMaxBodyBytes >= LargeMaxBodyBytes {
+		t.Errorf("the default limit (%d) should be below the large one (%d)",
+			DefaultMaxBodyBytes, LargeMaxBodyBytes)
+	}
+	// 40m in deployments/nginx.conf.
+	const nginxLimit int64 = 40 << 20
+	if LargeMaxBodyBytes > nginxLimit {
+		t.Errorf("LargeMaxBodyBytes (%d) exceeds nginx's client_max_body_size (%d); "+
+			"requests would be refused by the proxy with a less useful error",
+			LargeMaxBodyBytes, nginxLimit)
+	}
+}
+
+func TestNoBodyIsNotRejected(t *testing.T) {
+	handler := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("a GET with no body was refused with %d", rec.Code)
+	}
+}
+
+// Guards the shape of the middleware rather than one path: whatever the routing
+// looks like later, no path may be unbounded.
+func TestEveryPathHasALimit(t *testing.T) {
+	for _, p := range []string{
+		"/", "/api", "/api/anything", "/api/sites", "/data/images/x.png",
+		"/docs/index.html", "/tiles/africa/1/2/3.pbf",
+		fmt.Sprintf("/api/%s", strings.Repeat("deep/", 20)),
+	} {
+		if got := maxBytesForPath(p); got <= 0 {
+			t.Errorf("maxBytesForPath(%q) = %d; every path must be bounded", p, got)
+		}
+	}
+}

--- a/internal/server/datapack.go
+++ b/internal/server/datapack.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -428,13 +429,38 @@ func (s *Server) handleExecutableDownload(w http.ResponseWriter, r *http.Request
 
 // handleFileDialog opens a native OS file picker and returns the selected path.
 // This is needed because the webview cannot expose native file paths to JavaScript.
+// fileDialogTimeout bounds how long a file picker may stand open.
+//
+// zenity blocks until a human answers. Without a bound, a dialog nobody notices
+// holds its request goroutine — and the HTTP connection — indefinitely. Two
+// minutes is long enough to find a file on a slow filesystem and short enough
+// that a forgotten dialog frees itself.
+const fileDialogTimeout = 2 * time.Minute
+
+// handleFileDialog opens a native file picker. Registered only in desktop mode;
+// see config.Config.DesktopMode for why.
 func (s *Server) handleFileDialog(w http.ResponseWriter, r *http.Request) {
+	// Tied to the request as well as the timeout, so a client that gives up
+	// takes the dialog with it.
+	ctx, cancel := context.WithTimeout(r.Context(), fileDialogTimeout)
+	defer cancel()
+
 	path, err := zenity.SelectFile(
+		zenity.Context(ctx),
 		zenity.Title("Select Data Pack"),
 		zenity.FileFilters{
 			{Name: "Data Packs", Patterns: []string{"*.zip", "*.7z"}},
 		},
 	)
+
+	// A timeout and a cancelled request both arrive as a context error. Neither
+	// is a server fault, and neither should be reported as one.
+	if ctx.Err() != nil {
+		httputil.RespondError(w, http.StatusRequestTimeout,
+			"the file dialog was closed without a selection")
+		return
+	}
+
 	if err == zenity.ErrCanceled {
 		httputil.RespondJSON(w, http.StatusOK, map[string]interface{}{"path": ""})
 		return

--- a/internal/server/desktoproutes_test.go
+++ b/internal/server/desktoproutes_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+)
+
+// /api/dialog/open-file calls zenity, which opens a native file picker on
+// whatever desktop session the process is attached to and blocks until a human
+// answers. The route was registered unconditionally, and nginx proxies every
+// path, so on the hosted deployment a stranger could open a window on the
+// server's desktop — and each call held a server goroutine for as long as the
+// dialog stood open.
+//
+// It only means anything in the desktop build, so in server mode it must not
+// exist at all.
+
+func newTestServer(t *testing.T, desktop bool) *Server {
+	t.Helper()
+
+	srv, err := New(config.Config{
+		Port:        0,
+		DataDir:     t.TempDir(),
+		Version:     "test",
+		DesktopMode: desktop,
+	})
+	if err != nil {
+		t.Fatalf("New(DesktopMode=%v): %v", desktop, err)
+	}
+	return srv
+}
+
+// hasRoute reports whether the router has a route with the given path template.
+//
+// The route table is inspected rather than a request issued, deliberately: if the
+// gate regressed, sending a request would call zenity and block on a real file
+// picker until a human closed it, so the test would hang instead of failing.
+func hasRoute(t *testing.T, srv *Server, template string) bool {
+	t.Helper()
+
+	found := false
+	err := srv.router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		if tmpl, err := route.GetPathTemplate(); err == nil && tmpl == template {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the router: %v", err)
+	}
+	return found
+}
+
+func TestFileDialogRouteAbsentInServerMode(t *testing.T) {
+	srv := newTestServer(t, false)
+
+	if hasRoute(t, srv, "/api/dialog/open-file") {
+		t.Error("the file dialog route is registered in server mode; " +
+			"a remote caller could open a window on the host's desktop")
+	}
+}
+
+// And the path really is unrouted, so it falls through rather than answering.
+func TestFileDialogPathIsNotHandledInServerMode(t *testing.T) {
+	srv := newTestServer(t, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/dialog/open-file", nil)
+	rec := httptest.NewRecorder()
+	srv.router.ServeHTTP(rec, req)
+
+	// The SPA fallback answers anything unrouted with HTML, so a JSON body here
+	// would mean the dialog handler ran.
+	if ct := rec.Header().Get("Content-Type"); strings.Contains(ct, "application/json") {
+		t.Errorf("something answered with JSON: %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFileDialogRouteRegisteredInDesktopMode(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	if !hasRoute(t, srv, "/api/dialog/open-file") {
+		t.Error("the file dialog route is missing in desktop mode")
+	}
+}
+
+// The zero value of Config must give the server build. A caller that forgets to
+// set DesktopMode should not silently get the desktop routes.
+func TestZeroConfigIsServerMode(t *testing.T) {
+	var cfg config.Config
+	if cfg.DesktopMode {
+		t.Error("the zero value of Config enables desktop mode; it must default to the server build")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,7 +136,12 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/datapack/download", s.handleDatapackDownload).Methods("GET")
 	s.router.HandleFunc("/api/executables/info", s.handleExecutablesInfo).Methods("GET")
 	s.router.HandleFunc("/api/executables/download/{platform}", s.handleExecutableDownload).Methods("GET")
-	s.router.HandleFunc("/api/dialog/open-file", s.handleFileDialog).Methods("POST")
+	// Desktop-only. In server mode the path is simply absent, so it 404s
+	// through the SPA fallback rather than existing and refusing — there is
+	// nothing for a remote caller to probe. See config.Config.DesktopMode.
+	if s.cfg.DesktopMode {
+		s.router.HandleFunc("/api/dialog/open-file", s.handleFileDialog).Methods("POST")
+	}
 
 	// Tile routes - served directly for performance
 	if s.tileStore != nil {
@@ -260,8 +265,9 @@ func (s *Server) startAuxTileServers(mainPort int) {
 
 func (s *Server) Start() error {
 	s.httpServer = &http.Server{
-		Addr:        fmt.Sprintf(":%d", s.cfg.Port),
-		Handler:     s.router,
+		Addr: fmt.Sprintf(":%d", s.cfg.Port),
+		// Every request goes through the body limit; see bodylimit.go.
+		Handler:     limitRequestBody(s.router),
 		ReadTimeout: 15 * time.Second,
 		// WriteTimeout is intentionally unset (0 = disabled) — long-running operations
 		// such as datapack extraction can take several minutes on large archives.
@@ -488,7 +494,7 @@ func (s *Server) rebuildRoutes() {
 	s.router = mux.NewRouter()
 	s.setupRoutes()
 	if s.httpServer != nil {
-		s.httpServer.Handler = s.router
+		s.httpServer.Handler = limitRequestBody(s.router)
 	}
 }
 

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -4,8 +4,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -231,8 +234,14 @@ func (s *Store) Update(id string, updates *Site) (*Site, error) {
 				return nil, fmt.Errorf("failed to save thumbnail: %w", err)
 			}
 			site.Thumbnail = &imagePath
-		} else {
+		} else if *updates.Thumbnail == "" {
+			// An explicit clear.
 			site.Thumbnail = updates.Thumbnail
+		} else if validThumbnailPath(*updates.Thumbnail) {
+			// A path this store wrote earlier, sent back unchanged.
+			site.Thumbnail = updates.Thumbnail
+		} else {
+			return nil, fmt.Errorf("invalid thumbnail path %q: expected a data URL or a path this store wrote", *updates.Thumbnail)
 		}
 	}
 	if len(updates.Geometry) > 0 {
@@ -277,10 +286,19 @@ func (s *Store) Delete(id string) error {
 		return err
 	}
 
-	// Delete thumbnail if exists
-	if site.Thumbnail != nil && strings.HasPrefix(*site.Thumbnail, "/data/images/") {
-		imagePath := filepath.Join(s.dataDir, strings.TrimPrefix(*site.Thumbnail, "/data/"))
-		os.Remove(imagePath) // Ignore errors
+	// Delete the thumbnail, re-validating rather than trusting what was stored:
+	// a value written before this validation existed is still in the file.
+	if site.Thumbnail != nil && *site.Thumbnail != "" {
+		imagePath, err := s.resolveThumbnailFile(*site.Thumbnail)
+		if err != nil {
+			// Refusing to delete is the safe outcome — the alternative is
+			// removing a file this store never wrote. Leave the orphan and say so.
+			log.Printf("Warning: not deleting thumbnail for site %s: %v", id, err)
+		} else if err := os.Remove(imagePath); err != nil && !os.IsNotExist(err) {
+			// A thumbnail that cannot be removed is not a reason to fail the
+			// delete, but it should not be silent either.
+			log.Printf("Warning: could not delete thumbnail %s: %v", imagePath, err)
+		}
 	}
 
 	// Delete site file
@@ -320,6 +338,63 @@ func (s *Store) saveSite(site *Site) error {
 }
 
 // saveThumbnail saves a base64 image to disk and returns the URL path
+// thumbnailPathPattern is the only shape saveThumbnail ever produces:
+// /data/images/<name>.<ext>, with the name limited to characters that cannot
+// form a traversal or an absolute path.
+//
+// The extensions match what saveThumbnail derives from the data URL's MIME type.
+var thumbnailPathPattern = regexp.MustCompile(`^/data/images/[A-Za-z0-9._-]+\.(png|jpe?g|gif|webp)$`)
+
+// validThumbnailPath reports whether a client-supplied thumbnail reference is
+// one this store could have written.
+//
+// A client may send back a path it was given earlier — that is how an unchanged
+// thumbnail survives an update — so the value cannot simply be rejected. But it
+// was previously stored verbatim and later joined onto the data directory and
+// passed to os.Remove, so any string the client chose became a file the process
+// would delete: two requests, one PUT and one DELETE, removed any file the
+// process could reach. A prefix check alone does not help, because
+// "/data/images/../../etc/passwd" satisfies it.
+func validThumbnailPath(p string) bool {
+	if !thumbnailPathPattern.MatchString(p) {
+		return false
+	}
+	// Belt and braces: the pattern already excludes "/" and "\\" inside the
+	// name, so Clean cannot change a valid path. This catches a future widening
+	// of the pattern that reintroduces the problem.
+	return path.Clean(p) == p
+}
+
+// resolveThumbnailFile maps a validated thumbnail reference to a path inside the
+// data directory, and confirms the result really is inside it.
+//
+// The check is on the cleaned, absolute path rather than the input, so a symlink
+// or a traversal that survived validation still cannot escape.
+func (s *Store) resolveThumbnailFile(thumbnail string) (string, error) {
+	if !validThumbnailPath(thumbnail) {
+		return "", fmt.Errorf("thumbnail path is not one this store writes: %q", thumbnail)
+	}
+
+	imagesDir, err := filepath.Abs(s.imagesDir)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve the images directory: %w", err)
+	}
+
+	candidate, err := filepath.Abs(filepath.Join(s.dataDir, strings.TrimPrefix(thumbnail, "/data/")))
+	if err != nil {
+		return "", fmt.Errorf("could not resolve the thumbnail path: %w", err)
+	}
+
+	// filepath.Rel is used rather than a string prefix so that a sibling
+	// directory sharing a prefix — images-backup next to images — cannot pass.
+	rel, err := filepath.Rel(imagesDir, candidate)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("thumbnail path escapes the images directory: %q", thumbnail)
+	}
+
+	return candidate, nil
+}
+
 func (s *Store) saveThumbnail(siteID, dataURL string) (string, error) {
 	// Parse data URL: data:image/jpeg;base64,/9j/4AAQ...
 	parts := strings.SplitN(dataURL, ",", 2)

--- a/internal/sites/thumbnail_test.go
+++ b/internal/sites/thumbnail_test.go
@@ -1,0 +1,219 @@
+package sites
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Thumbnail references arrive from the client. They used to be stored verbatim
+// and later joined onto the data directory and passed to os.Remove, so any
+// string the caller chose became a file the process would delete: two requests,
+// one PUT and one DELETE, removed anything the process could reach.
+//
+// These tests cover the shapes that made that work, and the legitimate ones that
+// must keep working — a client sends a path back unchanged when a thumbnail is
+// not being replaced.
+
+func TestValidThumbnailPathAcceptsWhatSaveThumbnailWrites(t *testing.T) {
+	// Exactly the forms saveThumbnail produces, one per extension it derives
+	// from the data URL's MIME type.
+	for _, p := range []string{
+		"/data/images/site-abc123.jpg",
+		"/data/images/site-abc123.jpeg",
+		"/data/images/site-abc123.png",
+		"/data/images/site-abc123.gif",
+		"/data/images/site-abc123.webp",
+		"/data/images/site-with-dashes_and_underscores.png",
+		"/data/images/site-3f2504e0-4f89-11d3-9a0c-0305e82c3301.jpg",
+	} {
+		if !validThumbnailPath(p) {
+			t.Errorf("rejected a path this store writes: %q", p)
+		}
+	}
+}
+
+func TestValidThumbnailPathRejectsEscapes(t *testing.T) {
+	cases := map[string]string{
+		"parent traversal":            "/data/images/../../etc/passwd",
+		"traversal inside the name":   "/data/images/..%2f..%2fetc%2fpasswd",
+		"single parent":               "/data/images/../secret.png",
+		"absolute path":               "/etc/passwd",
+		"absolute masquerading":       "/data/images//etc/passwd",
+		"nested directory":            "/data/images/sub/dir.png",
+		"wrong directory":             "/data/sites/site-a.json",
+		"sibling directory prefix":    "/data/images-backup/site-a.png",
+		"no extension":                "/data/images/site-a",
+		"disallowed extension":        "/data/images/site-a.json",
+		"double extension":            "/data/images/site-a.png.json",
+		"empty":                       "",
+		"relative":                    "data/images/site-a.png",
+		"backslash traversal":         `/data/images/..\..\windows\system32`,
+		"null byte":                   "/data/images/site-a.png\x00.json",
+		"trailing slash":              "/data/images/site-a.png/",
+		"just the directory":          "/data/images/",
+		"dot segment":                 "/data/images/./site-a.png",
+		"leading whitespace":          " /data/images/site-a.png",
+		"scheme":                      "file:///data/images/site-a.png",
+		"remote url":                  "https://example.com/data/images/a.png",
+		"data url handled separately": "data:image/png;base64,AAAA",
+	}
+
+	for name, p := range cases {
+		if validThumbnailPath(p) {
+			t.Errorf("%s: accepted %q, which this store never writes", name, p)
+		}
+	}
+}
+
+// resolveThumbnailFile is the second gate: it must not return a path outside the
+// images directory even if a value slipped past validation, because values
+// written before the validation existed are still in the site files on disk.
+func TestResolveThumbnailFileConfinesToImagesDir(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	resolved, err := store.resolveThumbnailFile("/data/images/site-a.png")
+	if err != nil {
+		t.Fatalf("rejected a valid thumbnail: %v", err)
+	}
+
+	imagesDir, err := filepath.Abs(filepath.Join(dir, "images"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(resolved, imagesDir+string(filepath.Separator)) {
+		t.Errorf("resolved to %q, which is not inside %q", resolved, imagesDir)
+	}
+
+	for _, bad := range []string{
+		"/data/images/../../etc/passwd",
+		"/data/sites/site-a.json",
+		"/data/images-backup/site-a.png",
+		"/etc/passwd",
+	} {
+		if got, err := store.resolveThumbnailFile(bad); err == nil {
+			t.Errorf("resolved %q to %q instead of refusing", bad, got)
+		}
+	}
+}
+
+// The end-to-end shape of the original attack: store a traversing thumbnail via
+// Update, then delete the site and see whether the unrelated file survives.
+func TestDeleteCannotRemoveFileOutsideImagesDir(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// A file that has nothing to do with thumbnails.
+	victim := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(victim, []byte("do not delete me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	site, err := store.Create(&Site{Title: "target"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The write gate should refuse this outright.
+	traversal := "/data/images/../victim.txt"
+	if _, err := store.Update(site.ID, &Site{Thumbnail: &traversal}); err == nil {
+		t.Error("Update accepted a traversing thumbnail path")
+	}
+
+	// And even with the value forced into the stored record — as it would be in
+	// a site file written before this validation existed — Delete must not act
+	// on it.
+	stored, err := store.Get(site.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	stored.Thumbnail = &traversal
+	if err := store.saveSite(stored); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if err := store.Delete(site.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := os.Stat(victim); err != nil {
+		t.Errorf("deleting the site removed an unrelated file: %v", err)
+	}
+}
+
+// A legitimate thumbnail must still be cleaned up, or every deleted site leaves
+// an orphan behind.
+func TestDeleteRemovesItsOwnThumbnail(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	site, err := store.Create(&Site{Title: "with thumbnail"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A one-pixel PNG, so saveThumbnail writes a real file.
+	dataURL := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8AAAwAB/AL+3TZ9AAAAAElFTkSuQmCC"
+	updated, err := store.Update(site.ID, &Site{Thumbnail: &dataURL})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Thumbnail == nil {
+		t.Fatal("no thumbnail was stored")
+	}
+
+	onDisk, err := store.resolveThumbnailFile(*updated.Thumbnail)
+	if err != nil {
+		t.Fatalf("saveThumbnail produced a path its own validator rejects: %v", err)
+	}
+	if _, err := os.Stat(onDisk); err != nil {
+		t.Fatalf("thumbnail was not written: %v", err)
+	}
+
+	if err := store.Delete(site.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(onDisk); !os.IsNotExist(err) {
+		t.Errorf("thumbnail survived the site being deleted: %v", err)
+	}
+}
+
+// An unchanged thumbnail round-trips: the client sends back the path it was
+// given, and that must not be treated as an attack.
+func TestUpdateAcceptsItsOwnThumbnailPathUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	site, err := store.Create(&Site{Title: "round trip"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	dataURL := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8AAAwAB/AL+3TZ9AAAAAElFTkSuQmCC"
+	withThumb, err := store.Update(site.ID, &Site{Thumbnail: &dataURL})
+	if err != nil {
+		t.Fatalf("Update with data URL: %v", err)
+	}
+
+	again, err := store.Update(site.ID, &Site{Thumbnail: withThumb.Thumbnail})
+	if err != nil {
+		t.Fatalf("Update with the stored path: %v", err)
+	}
+	if again.Thumbnail == nil || *again.Thumbnail != *withThumb.Thumbnail {
+		t.Errorf("thumbnail changed on a no-op update: %v", again.Thumbnail)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -111,6 +111,8 @@ func main() {
 		DataDir:      resolvedDataDir,
 		ResourcesDir: resolvedResourcesDir,
 		Version:      version,
+		// --headless is the server build; anything else opens the window below.
+		DesktopMode: !*headless,
 	}
 
 	log.Printf("Decision Theatre v%s starting on port %d", version, cfg.Port)


### PR DESCRIPTION
Fixes #29, #28, #32

## Summary

Three P0 holes in the HTTP surface, grouped because they are the same class of
fault — an endpoint trusting what arrived — and because the tests share fixtures.

Each fix has a test that I checked against the **unfixed** code, so none of them
is passing by accident.

## #29 — Thumbnail path traversal allowed arbitrary file deletion

`Store.Update` stored whatever thumbnail string the client sent, verbatim.
`Store.Delete` later joined it onto the data directory and called `os.Remove`. The
only guard was `HasPrefix("/data/images/")`, which `/data/images/../../etc/passwd`
satisfies trivially — and the `os.Remove` error was discarded, so nothing was even
logged.

Two requests, one `PUT` and one `DELETE`, removed any file the process could reach.

**Fixed** by validating on write against the only shape `saveThumbnail` produces,
and re-validating on delete — values written before this validation existed are
still in the site files on disk, so the stored record cannot be trusted either.
Resolution goes through `filepath.Abs` and `filepath.Rel` rather than a string
prefix, so a sibling directory sharing a prefix (`images-backup` next to `images`)
cannot pass. Refusing to delete is the safe outcome: an orphaned thumbnail is
logged, rather than a stranger's file removed.

Against the previous code the test reports:

```
thumbnail_test.go:128: Update accepted a traversing thumbnail path
thumbnail_test.go:148: deleting the site removed an unrelated file:
                       stat .../victim.txt: no such file or directory
```

22 traversal shapes are covered — `..`, absolute, backslash, null byte, nested,
sibling-prefix, scheme, double-extension — alongside the legitimate cases that
must keep working, including a client sending a path back unchanged.

## #28 — A file dialog opened on the host's desktop from an HTTP request

`zenity.SelectFile` opens a native file picker on whatever desktop session the
process is attached to, and blocks until a human answers it. The route was
registered unconditionally, and nginx proxies every path — so on the hosted
deployment a stranger could open a window on the server's desktop, and every call
held a server goroutine for as long as the dialog stood open.

**Fixed** by adding `config.Config.DesktopMode`, set from the mode `main.go` is
already choosing, and registering the route only when it is true. The zero value
is the server build, so a caller who forgets the field gets the safe default. The
zenity call is now bounded by a two-minute timeout tied to the request context, so
a forgotten dialog frees its goroutine even in desktop mode.

> Worth noting: my first version of this test issued a `POST` to the route. With
> the gate removed it **hung** — because it called zenity and waited on a real
> picker — instead of failing. It now walks the route table, and fails in
> milliseconds with `the file dialog route is registered in server mode`.

## #32 — No request body size limits on any JSON handler

Every handler decoded straight from `r.Body`, and nginx allowed bodies up to 2 GB,
so a single POST could make the Go process buffer two gigabytes.

**Fixed** with a middleware wrapping every request — including the datapack
handlers, which are not on the `/api` subrouter, so a subrouter-only middleware
would have missed the most dangerous endpoint. A declared oversize is refused with
**413** before a byte is read; an undeclared one (chunked) is stopped mid-read.

Handlers carrying geometry or an inline image get an explicit larger allowance
(32 MiB) rather than an exemption, and `client_max_body_size` drops from `2g` to
`40m` to match. A test asserts the application limit stays below the nginx one, so
the pair cannot drift apart.

## Verified

- `go test -race ./...` — all five packages pass
- `golangci-lint run` — 0 issues
- `gofmt` clean
- Each fix checked against the unfixed code, as quoted above

## Note on scope

These are three of the ten P0 issues. #27 (unauthenticated datapack install
destroying the data directory) is the remaining one in this area and gets its own
pull request.

One thing surfaced while writing #28's gate and is worth recording here, because
it bears on #29 above. The design brief puts the user's own sites in browser
storage, and the client honours that — `getAppRuntime()` returns `browser` unless
the Go webview injects `__DECISION_THEATRE_WEBVIEW__`, and in browser runtime
every site create, read, update and delete goes to the `dt-sites` localStorage
key with no fallthrough to the API. The server calls a browser session does make
all pass `runtime: 'browser'` with the site in the request body: compute in,
result out, nothing written to disk.

But `internal/api/handler.go:121-125` registers the five persistence routes
unconditionally, so the hosted deployment carries an unauthenticated
write-to-disk API that no browser client ever calls. It exists only for the
desktop build. That is the same fault as #28, and it is the reachable path behind
#29: storing a traversing thumbnail needed `PUT /api/sites/{id}`, and acting on it
needed `DELETE`. The validation in this PR is the right defence in depth and
stands on its own, but the routes should also be gated — filed separately, and
#27 falls out of the same change rather than needing an authentication design.