### PR TITLE
fix: gate site persistence and datapack install behind desktop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cd`-ing into a subdirectory no longer creates a second module cache there. Two had
   accumulated, under `frontend/` and `resources/mbtiles/`.
 
+### Security
+
+- **The hosted deployment exposed an unauthenticated write-to-disk API that nothing
+  called.** A user's own sites belong in their browser, and the client honours that: in
+  browser runtime every site create, read, update and delete goes to the `dt-sites`
+  localStorage key, with no fallthrough to the API. The server registered the site CRUD
+  for everyone anyway, and nginx proxies every path.
+
+  Nine site routes plus `POST /api/datapack/install` are now registered **only** in the
+  desktop build, gated on `config.Config.DesktopMode`. Seven of the nine reach
+  `sites.Store` Create/Update/Delete; two are reads that disclosed every site on the
+  host; `datapack/install` replaced the contents of the data directory with whatever it
+  found at a caller-supplied path. In server mode they are absent from the route table
+  entirely, so no handler code is reachable.
+
+  This was the door behind two other reported faults — arbitrary file deletion via a
+  thumbnail path, and the datapack install — which is why it is recorded here rather than
+  under *Fixed*. The routes a browser session genuinely calls (`/indicators`,
+  `/catchments`, `/whiskers`, `/dissolve-catchments`, `/boundary/*`) are unchanged and
+  stay public: they take `runtime: "browser"` with the site in the request body and
+  return before touching the store.
+
+  The gate depends on `--headless`, which is a launch flag rather than code, so a test
+  asserts that `deployments/Dockerfile` and `deployments/docker-compose.yaml` still pass
+  it. `docs/developer-guide/client-server-boundary.md` now states the persistence split
+  alongside the computation split it already covered — the gap that let this drift.
+
+- **A thumbnail path from the client could delete any file the process could reach.**
+  `Store.Update` stored the string verbatim and `Store.Delete` later joined it onto the
+  data directory and called `os.Remove`, guarded only by a `/data/images/` prefix check
+  that `/data/images/../../etc/passwd` satisfies. The `os.Remove` error was discarded, so
+  nothing was logged either. Paths are now validated against the only shape the store
+  writes, on write and again on delete, and resolved through `filepath.Rel` rather than a
+  string prefix.
+
+- **A file dialog could be opened on the host's desktop by an HTTP request.**
+  `POST /api/dialog/open-file` called `zenity.SelectFile`, which opens a native picker on
+  whatever session the process is attached to and blocks until a human answers, holding a
+  goroutine meanwhile. It is now desktop-only, and bounded by a two-minute timeout tied to
+  the request context.
+
+- **No request body size limits on any JSON handler**, with nginx passing bodies up to
+  2 GB, so one POST could make the process buffer two gigabytes. Every request is now
+  capped — 1 MiB by default, 32 MiB for the handlers carrying geometry or an inline image
+  — and `client_max_body_size` drops to `40m` to match, with a test asserting the
+  application limit stays below the proxy's.
+
+- **A TLS private key was committed** because `certs/` was commented out in
+  `deployments/.gitignore`. The pattern is active again, alongside `*.key`, `*.pem`,
+  `*.crt`, `*.p12` and `*.pfx`, and secret scanning runs in pre-commit and CI.
+
 ## [0.4.0] — 2026-08-16
 
 ### Added

--- a/docs/developer-guide/client-server-boundary.md
+++ b/docs/developer-guide/client-server-boundary.md
@@ -115,6 +115,59 @@ Client storage therefore buys no offline capability. Using it as the primary sto
 derived data is the category error underneath the reported symptoms. Persist user
 intent; refetch everything else.
 
+## Where a site is stored
+
+The rule above is about *computation*. Persistence has its own rule, and it is not the
+same one: **a user's own sites live in their browser, and are never uploaded.**
+
+The runtime decides, via `getAppRuntime()` in `frontend/src/types/runtime.ts`. It
+returns `browser` unless the Go webview has injected
+`window.__DECISION_THEATRE_WEBVIEW__`.
+
+| Operation | Browser runtime | Webview runtime |
+|---|---|---|
+| Create | `saveLocalSites` → `dt-sites` | `POST /api/sites` |
+| Read | `loadLocalSites()` | `GET /api/sites[/{id}]` |
+| Update | rewrite `dt-sites` | `PUT`/`PATCH /api/sites/{id}` |
+| Delete | filter `dt-sites` | `DELETE /api/sites/{id}` |
+
+Both halves matter. The desktop build has a filesystem and no quota, so it uses the
+store in `data/sites/`. The hosted deployment has neither the right nor the need to
+hold anyone's work.
+
+### Consequences for the API surface
+
+Because no browser session ever calls them, the site CRUD routes are registered **only
+in the desktop build** — see `registerDesktopSiteRoutes` in `internal/api/handler.go`,
+gated on `config.Config.DesktopMode`. `POST /api/datapack/install` and
+`POST /api/dialog/open-file` are gated the same way, for the same reason: both act on
+the host's own filesystem.
+
+Registering them unconditionally, as we did until this was noticed, put an
+unauthenticated write-to-disk API on a deployment that nginx proxies wholesale. It was
+the reachable path behind an arbitrary-file-deletion bug (#29) and a
+replace-the-data-directory bug (#27).
+
+The routes a browser session *does* call are a different case and stay public:
+`/indicators`, `/catchments`, `/whiskers`, `/dissolve-catchments` and `/boundary/*`.
+These accept `runtime: "browser"` with the site in the request body and return before
+touching the store — compute in, result out, nothing persisted. Three of them
+(`/indicators/reset`, `/boundary/union`, `/boundary/difference`) have no such guard,
+which is exactly why they are gated instead: the client does that work locally in
+browser runtime and only calls the API from the webview.
+
+!!! warning "The gate depends on a launch flag"
+    `DesktopMode` is `!*headless` in `main.go`. A hosted deployment that stops passing
+    `--headless` re-opens every route above without a line of Go changing, which is why
+    `deployments/Dockerfile` and `deployments/docker-compose.yaml` are asserted to
+    contain it by a test in `internal/api`.
+
+### When adding a route that writes
+
+Ask who calls it. If the answer is "the desktop build", gate it. If the answer is "a
+browser session", it must not write to disk at all — take the site in the request body
+and return the result.
+
 ## Worked example: the two creation paths
 
 ### Selection → outline (correct today)
@@ -191,3 +244,5 @@ Before adding a fetch, a store write or a geometry call, ask:
 - [ ] Am I persisting something the server can regenerate? → don't
 - [ ] Is this geometry the user is editing right now? → client is correct
 - [ ] Does it scale with the size of the study area? → it does not belong in the browser
+- [ ] Does it write to disk? → then no browser session may call it; gate it on
+      `DesktopMode` ([above](#consequences-for-the-api-surface))

--- a/internal/api/desktopsiteroutes_test.go
+++ b/internal/api/desktopsiteroutes_test.go
@@ -1,0 +1,289 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+	"github.com/kartoza/decision-theatre/internal/sites"
+)
+
+// A user's own sites belong in their browser. The client honours that — in
+// browser runtime every site create, read, update and delete goes to the
+// dt-sites localStorage key with no fallthrough to the API — but the server
+// registered the site CRUD for everyone regardless, putting an unauthenticated
+// write-to-disk API on a deployment that nginx proxies wholesale.
+//
+// These tests pin both halves: the desktop-only routes must be absent in server
+// mode, and the routes a browser session genuinely calls must not be.
+
+// routerFor builds a router in the requested mode. The stores are nil: route
+// registration does not touch them, and a handler that did would be a fault
+// worth failing on.
+func routerFor(t *testing.T, desktop bool) *mux.Router {
+	t.Helper()
+
+	dir := t.TempDir()
+	siteStore, err := sites.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	h := NewHandler(nil, nil, siteStore, config.Config{
+		Port:        0,
+		DataDir:     dir,
+		Version:     "test",
+		DesktopMode: desktop,
+	})
+	r := mux.NewRouter()
+	h.RegisterRoutes(r)
+	return r
+}
+
+// registeredRoutes returns "METHOD /path" for every route in the table.
+//
+// The table is inspected rather than requests issued, deliberately: several of
+// these handlers write to disk or block, so a regression must fail as a missing
+// route rather than by running the thing under test.
+func registeredRoutes(t *testing.T, r *mux.Router) map[string]bool {
+	t.Helper()
+
+	out := map[string]bool{}
+	err := r.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		tmpl, err := route.GetPathTemplate()
+		if err != nil {
+			return nil // a route without a path template cannot be one of ours
+		}
+		methods, err := route.GetMethods()
+		if err != nil || len(methods) == 0 {
+			out["ANY "+tmpl] = true
+			return nil
+		}
+		for _, m := range methods {
+			out[m+" "+tmpl] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the router: %v", err)
+	}
+	return out
+}
+
+// desktopOnly is every route that exists solely for the desktop build.
+var desktopOnly = []string{
+	"POST /sites",
+	"PUT /sites/{id}",
+	"PATCH /sites/{id}",
+	"DELETE /sites/{id}",
+	"POST /sites/{id}/indicators/reset",
+	"POST /sites/{id}/boundary/union/{catchmentId}",
+	"POST /sites/{id}/boundary/difference/{catchmentId}",
+	"GET /sites",
+	"GET /sites/{id}",
+}
+
+// sharedRoutes is every site route a browser-runtime session really calls. They
+// take runtime:"browser" with the site in the request body and return before
+// touching the store, so they must stay available to everyone. Gating one of
+// these by mistake would break the hosted application outright.
+var sharedRoutes = []string{
+	"GET /sites/{id}/indicators",
+	"POST /sites/{id}/indicators",
+	"PATCH /sites/{id}/indicators",
+	"GET /sites/{id}/catchments",
+	"POST /sites/{id}/catchments",
+	"GET /sites/{id}/whiskers",
+	"POST /sites/{id}/whiskers",
+	"POST /sites/dissolve-catchments",
+}
+
+func TestDesktopOnlySiteRoutesAbsentInServerMode(t *testing.T) {
+	got := registeredRoutes(t, routerFor(t, false))
+
+	for _, route := range desktopOnly {
+		if got[route] {
+			t.Errorf("%s is registered in server mode; "+
+				"no browser client calls it and it reaches the site store", route)
+		}
+	}
+}
+
+func TestDesktopOnlySiteRoutesPresentInDesktopMode(t *testing.T) {
+	got := registeredRoutes(t, routerFor(t, true))
+
+	for _, route := range desktopOnly {
+		if !got[route] {
+			t.Errorf("%s is missing in desktop mode; the desktop build needs it", route)
+		}
+	}
+}
+
+// The point of the change is the gate, not a smaller API. Everything a browser
+// session calls must survive in both modes.
+func TestSharedSiteRoutesPresentInBothModes(t *testing.T) {
+	for _, mode := range []struct {
+		name    string
+		desktop bool
+	}{{"server", false}, {"desktop", true}} {
+		got := registeredRoutes(t, routerFor(t, mode.desktop))
+
+		for _, route := range sharedRoutes {
+			if !got[route] {
+				t.Errorf("%s mode: %s is missing; browser-runtime sessions call it",
+					mode.name, route)
+			}
+		}
+	}
+}
+
+// Gating must not remove anything else. Whatever the two modes differ by, that
+// difference is exactly the desktop-only list — so a route quietly added to the
+// gated block, or dropped from the shared one, shows up here.
+func TestServerAndDesktopModeDifferByExactlyTheDesktopOnlyRoutes(t *testing.T) {
+	server := registeredRoutes(t, routerFor(t, false))
+	desktop := registeredRoutes(t, routerFor(t, true))
+
+	expected := map[string]bool{}
+	for _, route := range desktopOnly {
+		expected[route] = true
+	}
+
+	var unexpected, missing []string
+	for route := range desktop {
+		if !server[route] && !expected[route] {
+			unexpected = append(unexpected, route)
+		}
+	}
+	for route := range expected {
+		if !desktop[route] {
+			missing = append(missing, route)
+		}
+	}
+	// A route present in server mode but not desktop mode would be stranger
+	// still: the desktop build is meant to be a superset.
+	var serverOnly []string
+	for route := range server {
+		if !desktop[route] {
+			serverOnly = append(serverOnly, route)
+		}
+	}
+
+	sort.Strings(unexpected)
+	sort.Strings(missing)
+	sort.Strings(serverOnly)
+
+	if len(unexpected) > 0 {
+		t.Errorf("desktop mode adds routes that are not on the desktop-only list: %s\n"+
+			"if these are desktop-only, add them to the list and say why; "+
+			"if a browser session calls them, they must not be gated",
+			strings.Join(unexpected, ", "))
+	}
+	if len(missing) > 0 {
+		t.Errorf("on the desktop-only list but not registered in desktop mode: %s",
+			strings.Join(missing, ", "))
+	}
+	if len(serverOnly) > 0 {
+		t.Errorf("registered in server mode but not desktop mode: %s",
+			strings.Join(serverOnly, ", "))
+	}
+}
+
+// The gate is only worth anything if a request actually fails to reach the
+// store. This is the end-to-end shape of the exposure: create a site file on
+// disk, then try to delete it over HTTP the way a stranger would.
+func TestServerModeRequestCannotDeleteASiteFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	siteStore, err := sites.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	site, err := siteStore.Create(&sites.Site{Title: "someone else's work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	h := NewHandler(nil, nil, siteStore, config.Config{
+		Port: 0, DataDir: dir, Version: "test", DesktopMode: false,
+	})
+	r := mux.NewRouter()
+	h.RegisterRoutes(r)
+
+	req := httptest.NewRequest(http.MethodDelete, "/sites/"+site.ID, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("DELETE /sites/%s answered 200 in server mode", site.ID)
+	}
+
+	// The file is what matters, not the status code.
+	if _, err := siteStore.Get(site.ID); err != nil {
+		t.Errorf("the site was deleted by an unauthenticated request: %v", err)
+	}
+	if _, err := filepath.Glob(filepath.Join(dir, "sites", "*.json")); err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+}
+
+// The gate is only as good as the flag that drives it, and the flag comes from
+// the deployment config rather than from code: DesktopMode is !*headless, so a
+// hosted deployment that stops passing --headless silently re-opens every route
+// above without a line of Go changing.
+//
+// Both files are checked because either one alone can launch the container.
+func TestDeploymentConfigRunsInServerMode(t *testing.T) {
+	for _, f := range []string{
+		filepath.Join("..", "..", "deployments", "Dockerfile"),
+		filepath.Join("..", "..", "deployments", "docker-compose.yaml"),
+	} {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Errorf("could not read %s: %v", f, err)
+			continue
+		}
+		if !strings.Contains(string(data), "--headless") {
+			t.Errorf("%s does not pass --headless, so the container would run in "+
+				"desktop mode and expose the site CRUD to the internet", f)
+		}
+	}
+}
+
+// And the same request in desktop mode does reach the store — otherwise the
+// test above would pass with the routes broken for everybody.
+func TestDesktopModeRequestCanDeleteASite(t *testing.T) {
+	dir := t.TempDir()
+	siteStore, err := sites.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	site, err := siteStore.Create(&sites.Site{Title: "my own work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	h := NewHandler(nil, nil, siteStore, config.Config{
+		Port: 0, DataDir: dir, Version: "test", DesktopMode: true,
+	})
+	r := mux.NewRouter()
+	h.RegisterRoutes(r)
+
+	req := httptest.NewRequest(http.MethodDelete, "/sites/"+site.ID, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE in desktop mode answered %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := siteStore.Get(site.ID); err == nil {
+		t.Error("the site survived a delete in desktop mode")
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -117,12 +117,8 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 	// Choropleth endpoint - returns GeoJSON filtered by bbox
 	r.HandleFunc("/choropleth", h.handleChoropleth).Methods("GET")
 
-	// Site management
-	r.HandleFunc("/sites", h.handleListSites).Methods("GET")
-	r.HandleFunc("/sites", h.handleCreateSite).Methods("POST")
-	r.HandleFunc("/sites/{id}", h.handleGetSite).Methods("GET")
-	r.HandleFunc("/sites/{id}", h.handleUpdateSite).Methods("PUT", "PATCH")
-	r.HandleFunc("/sites/{id}", h.handleDeleteSite).Methods("DELETE")
+	// Site management is desktop-only; see registerDesktopSiteRoutes.
+	h.registerDesktopSiteRoutes(r)
 
 	// Catchment selection for site creation
 	r.HandleFunc("/sites/dissolve-catchments", h.handleDissolveCatchments).Methods("POST")
@@ -134,13 +130,62 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/sites/{id}/indicators", h.handleGetSiteIndicators).Methods("GET")
 	r.HandleFunc("/sites/{id}/indicators", h.handleExtractIndicators).Methods("POST")
 	r.HandleFunc("/sites/{id}/indicators", h.handleUpdateIndicators).Methods("PATCH")
-	r.HandleFunc("/sites/{id}/indicators/reset", h.handleResetIdealIndicators).Methods("POST")
 	r.HandleFunc("/sites/{id}/catchments", h.handleSiteCatchments).Methods("GET", "POST")
 	r.HandleFunc("/sites/{id}/whiskers", h.handleSiteWhiskers).Methods("GET", "POST")
+}
 
-	// Site boundary editing (union/difference with catchments)
-	r.HandleFunc("/sites/{id}/boundary/union/{catchmentId}", h.handleBoundaryUnion).Methods("POST")
-	r.HandleFunc("/sites/{id}/boundary/difference/{catchmentId}", h.handleBoundaryDifference).Methods("POST")
+// registerDesktopSiteRoutes registers the site routes that exist solely for the
+// desktop build.
+//
+// A user's own sites belong in their browser, not on our disk. The client
+// honours that: getAppRuntime() returns "browser" unless the Go webview injects
+// __DECISION_THEATRE_WEBVIEW__, and in browser runtime every create, read,
+// update and delete goes to the dt-sites localStorage key with no fallthrough to
+// the API. The routes below therefore have no browser-runtime caller at all.
+//
+// Registering them anyway put an unauthenticated write-to-disk API on the hosted
+// deployment — nginx proxies every path — with nothing on the other end that
+// wanted it. Six of the eight reach sites.Store.Update/Create/Delete; the two
+// reads disclose every site on the host.
+//
+// The shared routes are a different case and stay registered for everyone. A
+// browser session really does call /indicators, /catchments, /whiskers,
+// /dissolve-catchments and /boundary — but it passes runtime:"browser" with the
+// site in the request body, and those handlers return before touching the store.
+// Compute in, result out, nothing persisted.
+// In server mode these are absent from the route table entirely rather than
+// answering 403, so no handler code is reachable — the same approach taken for
+// the file dialog route. An unrouted /api path falls through to the SPA handler,
+// so a caller gets HTML rather than a JSON error; that is worth tidying, but it
+// is the pre-existing behaviour for every unrouted path and not this change.
+func (h *Handler) registerDesktopSiteRoutes(r *mux.Router) {
+	if !h.cfg.DesktopMode {
+		return
+	}
+
+	for _, route := range []struct {
+		path    string
+		methods []string
+		handler http.HandlerFunc
+	}{
+		// Persistence: the CRUD the desktop build uses in place of localStorage.
+		{"/sites", []string{"POST"}, h.handleCreateSite},
+		{"/sites/{id}", []string{"PUT", "PATCH"}, h.handleUpdateSite},
+		{"/sites/{id}", []string{"DELETE"}, h.handleDeleteSite},
+
+		// Writes reached through a narrower door. These lack a runtime:"browser"
+		// guard precisely because the client never sends one — it does the same
+		// work locally and only calls the API in webview runtime.
+		{"/sites/{id}/indicators/reset", []string{"POST"}, h.handleResetIdealIndicators},
+		{"/sites/{id}/boundary/union/{catchmentId}", []string{"POST"}, h.handleBoundaryUnion},
+		{"/sites/{id}/boundary/difference/{catchmentId}", []string{"POST"}, h.handleBoundaryDifference},
+
+		// Reads with no browser-runtime caller.
+		{"/sites", []string{"GET"}, h.handleListSites},
+		{"/sites/{id}", []string{"GET"}, h.handleGetSite},
+	} {
+		r.HandleFunc(route.path, route.handler).Methods(route.methods...)
+	}
 }
 
 // handleMetadataColors returns a map of attribute column names to hex colors.

--- a/internal/api/site_shapefile_test.go
+++ b/internal/api/site_shapefile_test.go
@@ -250,8 +250,13 @@ func openIntegrationStores(t *testing.T) *geodata.GpkgStore {
 }
 
 // buildRouter assembles a Handler + mux.Router using the provided stores.
+//
+// DesktopMode is set because these tests create and update sites through the
+// store, which is the desktop build's job — in the browser runtime the same work
+// happens in localStorage and those routes are not registered at all. See
+// registerDesktopSiteRoutes.
 func buildRouter(gpkg *geodata.GpkgStore, siteStore *sites.Store, dataDir string) *mux.Router {
-	cfg := config.Config{Port: 0, DataDir: dataDir, Version: "test"}
+	cfg := config.Config{Port: 0, DataDir: dataDir, Version: "test", DesktopMode: true}
 	h := NewHandler(nil, gpkg, siteStore, cfg)
 	r := mux.NewRouter()
 	h.RegisterRoutes(r)

--- a/internal/server/desktoproutes_test.go
+++ b/internal/server/desktoproutes_test.go
@@ -88,6 +88,47 @@ func TestFileDialogRouteRegisteredInDesktopMode(t *testing.T) {
 	}
 }
 
+// /api/datapack/install takes a path on the host's filesystem and replaces the
+// contents of the data directory with whatever it finds there. The path can only
+// come from the file dialog, which is desktop-only, so there was no way to use
+// this legitimately on a hosted deployment — and no authentication stopping
+// anyone using it otherwise.
+func TestDatapackInstallRouteAbsentInServerMode(t *testing.T) {
+	srv := newTestServer(t, false)
+
+	if hasRoute(t, srv, "/api/datapack/install") {
+		t.Error("the datapack install route is registered in server mode; " +
+			"an unauthenticated caller could replace the data directory")
+	}
+}
+
+func TestDatapackInstallRouteRegisteredInDesktopMode(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	if !hasRoute(t, srv, "/api/datapack/install") {
+		t.Error("the datapack install route is missing in desktop mode; " +
+			"the setup guide needs it")
+	}
+}
+
+// Serving the pack and the installers is what the hosted deployment is for, so
+// gating must not catch them. These read; they do not write.
+func TestPublicDatapackRoutesSurviveInServerMode(t *testing.T) {
+	srv := newTestServer(t, false)
+
+	for _, path := range []string{
+		"/api/datapack/status",
+		"/api/datapack/download-info",
+		"/api/datapack/download",
+		"/api/executables/info",
+		"/api/executables/download/{platform}",
+	} {
+		if !hasRoute(t, srv, path) {
+			t.Errorf("%s is missing in server mode; the hosted deployment serves it", path)
+		}
+	}
+}
+
 // The zero value of Config must give the server build. A caller that forgets to
 // set DesktopMode should not silently get the desktop routes.
 func TestZeroConfigIsServerMode(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,18 +129,26 @@ func (s *Server) setupRoutes() {
 	apiHandler := api.NewHandler(s.tileStore, s.gpkgStore, s.siteStore, s.cfg)
 	apiHandler.RegisterRoutes(apiRouter)
 
-	// Data pack management routes
+	// Data pack management routes. Serving the pack and the installers is the
+	// hosted deployment's job, so those stay public.
 	s.router.HandleFunc("/api/datapack/status", s.handleDatapackStatus).Methods("GET")
-	s.router.HandleFunc("/api/datapack/install", s.handleDatapackInstall).Methods("POST")
 	s.router.HandleFunc("/api/datapack/download-info", s.handleDatapackDownloadInfo).Methods("GET")
 	s.router.HandleFunc("/api/datapack/download", s.handleDatapackDownload).Methods("GET")
 	s.router.HandleFunc("/api/executables/info", s.handleExecutablesInfo).Methods("GET")
 	s.router.HandleFunc("/api/executables/download/{platform}", s.handleExecutableDownload).Methods("GET")
-	// Desktop-only. In server mode the path is simply absent, so it 404s
+
+	// Desktop-only. In server mode these paths are simply absent, so they 404
 	// through the SPA fallback rather than existing and refusing — there is
 	// nothing for a remote caller to probe. See config.Config.DesktopMode.
 	if s.cfg.DesktopMode {
 		s.router.HandleFunc("/api/dialog/open-file", s.handleFileDialog).Methods("POST")
+
+		// Install takes a path on this machine's filesystem and replaces the
+		// contents of the data directory with whatever it finds there. The path
+		// can only come from the file dialog above, which is itself desktop-only,
+		// so on a hosted deployment there was no way to use this route
+		// legitimately and no authentication stopping anyone using it otherwise.
+		s.router.HandleFunc("/api/datapack/install", s.handleDatapackInstall).Methods("POST")
 	}
 
 	// Tile routes - served directly for performance


### PR DESCRIPTION
Fixes #27

> **Stacked on #96.** The base is `security/harden-http-surface`, because this
> builds on the `config.Config.DesktopMode` flag added there. GitHub retargets to
> `main` automatically when #96 merges. Review that one first.

## The finding

Tim asked a question that turned out to be the important one: *"we should not be
uploading things to the server — the original design brief called for users' sites
to be in local browser storage — have we deviated from that?"*

The client has not. `getAppRuntime()` returns `browser` unless the Go webview
injects `__DECISION_THEATRE_WEBVIEW__`, and in browser runtime every persistence
path is localStorage-only with **no fallthrough to the API**:

| Operation | Browser runtime | Webview runtime |
|---|---|---|
| `createSite` | `saveLocalSites` → `dt-sites` | `POST /api/sites` |
| `getSite` / list | `loadLocalSites()` | `GET /api/sites[/{id}]` |
| `updateSite` / `patchSite` | rewrite `dt-sites` | `PUT`/`PATCH /api/sites/{id}` |
| `deleteSite` | filter `dt-sites` | `DELETE /api/sites/{id}` |

The server deviated. `internal/api/handler.go` registered the site CRUD
unconditionally, and nginx proxies every path, so the hosted deployment carried an
unauthenticated write-to-disk API that **no client will ever call**.

## What is gated

Nine site routes plus `POST /api/datapack/install`, on the existing
`config.Config.DesktopMode`:

| Route | Why desktop-only |
|---|---|
| `POST /sites` | `siteStore.Create` — localStorage's job in the browser |
| `PUT`/`PATCH /sites/{id}` | `siteStore.Update` |
| `DELETE /sites/{id}` | `siteStore.Delete` |
| `POST /sites/{id}/indicators/reset` | `siteStore.Update`, no browser caller |
| `POST /sites/{id}/boundary/union/{catchmentId}` | `siteStore.Update`, no browser caller |
| `POST /sites/{id}/boundary/difference/{catchmentId}` | `siteStore.Update`, no browser caller |
| `GET /sites` | discloses every site on the host |
| `GET /sites/{id}` | discloses any site on the host |
| `POST /api/datapack/install` | replaces the data directory from a host path (#27) |

The last three writes deserve a note, because they were the ones I nearly missed:
they have **no `runtime: "browser"` guard** server-side, and at first that looks
like the bug. It isn't — the client never sends one, because
`IndicatorEditorPage.tsx` and `MapView.tsx` do that work locally in browser runtime
and only call the API from the webview. They are unguarded *because* they are
desktop-only, which is precisely why gating is the right fix rather than adding a
guard.

I found them only after the first grep missed them: they bypass `useApi.ts` and use
raw `/api/...` paths, so `grep "API_BASE}/sites"` came back clean and I nearly
concluded there were five routes to gate rather than nine.

## What is deliberately not gated

The routes a browser session really does call, which must keep working for the
hosted application: `/indicators` (GET, POST, PATCH), `/catchments`, `/whiskers`,
`/dissolve-catchments`. Each takes `runtime: "browser"` with the site in the request
body and returns before touching the store — compute in, result out, nothing
persisted. `handleDissolveCatchments` never writes at all.

Also public: `datapack/status`, `datapack/download`, `datapack/download-info` and
`executables/*`. Serving the pack and the installers is what the hosted deployment
is *for*.

`TestSharedSiteRoutesPresentInBothModes` pins all of this. Gating one of them by
mistake would break the hosted application outright, which is a worse outcome than
the bug being fixed.

## Verified

Each test was checked against the unfixed code. With the gate neutered:

```
--- FAIL: TestDesktopOnlySiteRoutesAbsentInServerMode
    POST /sites is registered in server mode; no browser client calls it …
    … (all nine)
--- FAIL: TestServerModeRequestCannotDeleteASiteFromDisk
    DELETE /sites/a25966bc… answered 200 in server mode
    the site was deleted by an unauthenticated request: no such file or directory
```

That second failure is the whole issue in one line.

- `go test ./...` and `go test -race ./internal/...` — all five packages pass
- `golangci-lint run` — 0 issues
- `gofmt` clean

Six new tests in `internal/api`, four in `internal/server`. Two are not about this
change directly and are worth calling out:

- **`TestServerAndDesktopModeDifferByExactlyTheDesktopOnlyRoutes`** — the two modes
  must differ by exactly the documented list. A route quietly added to the gated
  block, or dropped from the shared one, fails here rather than in production.
- **`TestDeploymentConfigRunsInServerMode`** — `DesktopMode` is `!*headless`, so the
  gate rests on a launch flag, not on code. A deployment that stops passing
  `--headless` would re-open every route above without a line of Go changing. Both
  `deployments/Dockerfile` and `deployments/docker-compose.yaml` are asserted to
  contain it, because either can launch the container.

`buildRouter` in `site_shapefile_test.go` now sets `DesktopMode: true` — those
integration tests create and update sites through the store, which is the desktop
build's job. Without it they would have started 404ing, which is how I know the gate
bites.

## Docs

`docs/developer-guide/client-server-boundary.md` stated the *computation* boundary
and never the *persistence* one. That gap is arguably how this drifted in the first
place, so it now carries a **Where a site is stored** section with the table above,
the consequences for the API surface, the launch-flag caveat, and a checklist item:
*does it write to disk? → then no browser session may call it.*

## Deploying this

`data/sites/` on the hosted host may hold whatever was written through these routes
while they were open — by users on an earlier build, or by anyone who found them.
Nothing there is precious: the server's data directory is reproducible from the
datapack, so **wipe `data/sites/` and `data/images/` on the next deploy** rather than
auditing what is in them. Anything a stranger could have written includes the
pre-validation thumbnail paths that #96 has to defend against on read.

## One thing I did not do

**An unrouted `/api/*` path falls through to the SPA handler**, so a caller gets HTML
rather than a JSON 404. That makes the gate slightly harder to diagnose, and it is
worth tidying, but it is the pre-existing behaviour for every unrouted path and not
this change's business.

## A follow-up this suggests

In server mode the site store is now effectively unreachable — every handler that
touches it is either gated or returns on `runtime: "browser"` first — yet
`sites.NewStore(cfg.DataDir)` still runs at startup and creates `data/sites/` and
`data/images/`. Not constructing it at all in server mode would remove the writable
surface rather than merely closing the routes to it. I have left it alone here
because it means auditing every `h.siteStore` dereference for nil, which is a
different change with a different risk profile.
