### PR TITLE
fix: listen on loopback by default instead of every interface

### DIFF
--- a/.dt-env.example
+++ b/.dt-env.example
@@ -22,6 +22,12 @@
 # HTTP port. The app walks forward from here if the port is busy.
 #DT_PORT=8080
 
+# Interface to listen on. Defaults to 127.0.0.1, because the API has no
+# authentication of its own — 0.0.0.0 hands it to everyone who can reach this
+# machine. Set it when you want to open the app in a browser or on a phone on
+# your own network, and only on a network you trust.
+#DT_BIND=0.0.0.0
+
 # Skip the staleness checks entirely and launch the existing bin/decision-theatre.
 #DT_SKIP_BUILD=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The server bound every network interface while claiming it bound only localhost.**
+  `Addr: fmt.Sprintf(":%d", port)` listens on `0.0.0.0`, and the comment three lines
+  below asserted the opposite — then used that false claim to justify disabling
+  `WriteTimeout` entirely. Every endpoint is unauthenticated, so on a desktop install
+  this published the whole API, including the routes that write to disk, to everyone
+  on the user's network. The three auxiliary tile listeners did the same, and set
+  neither a read nor a write timeout.
+
+  The bind address is now `config.Config.BindAddress`, defaulting to `127.0.0.1` for
+  every build, with `--bind` (or `DT_BIND`) to change it. The container deployment
+  passes `--bind 0.0.0.0` explicitly, which is safe there because the `app` service
+  only `expose`s its ports on the Docker network and Nginx is the single way in.
+  Verified with `ss -tlnp`: the default now shows `127.0.0.1` on the main port and all
+  three auxiliary ports.
+
+  All three timeouts are set on every listener. `WriteTimeout` is bounded on its own
+  merits rather than on the old false premise: datapack extraction, the original
+  reason for disabling it, answers 202 immediately and reports progress through
+  `/api/datapack/status`, so no handler blocks on it. The two handlers that genuinely
+  stream a large file lift their own deadline with `http.NewResponseController`
+  instead of leaving every request unbounded.
+
+  Also fixed in passing: the port probe now binds the interface it is about to use,
+  rather than answering a different question, and `--help` for `run-app.sh` derives
+  its line range instead of hardcoding it — adding these knobs to the header had
+  silently truncated the Options section.
+
 - **The hosted deployment exposed an unauthenticated write-to-disk API that nothing
   called.** A user's own sites belong in their browser, and the client honours that: in
   browser runtime every site create, read, update and delete goes to the `dt-sites`

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -75,4 +75,8 @@ RUN mkdir -p /app/data /app/resources
 EXPOSE 8080 8081 8082 8083
 
 ENTRYPOINT ["decision-theatre"]
-CMD ["--headless", "--port", "8080", "--data-dir", "/app/data", "--resources-dir", "/app/resources"]
+# --bind 0.0.0.0 is required and deliberate: the process must accept connections
+# from outside its own network namespace to be reachable at all. The default is
+# loopback because the API is unauthenticated, so here it is nginx in front of
+# this container that controls access.
+CMD ["--headless", "--bind", "0.0.0.0", "--port", "8080", "--data-dir", "/app/data", "--resources-dir", "/app/resources"]

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -7,6 +7,12 @@ services:
     restart: unless-stopped
     command:
       - --headless
+      # Required and deliberate — see the note on CMD in Dockerfile. The
+      # application defaults to loopback because its API is unauthenticated;
+      # inside a container nothing would reach it, and nginx in front of this
+      # service is what controls access.
+      - --bind
+      - 0.0.0.0
       - --port
       - "8080"
       - --data-dir

--- a/docs/developer-guide/server-deployment.md
+++ b/docs/developer-guide/server-deployment.md
@@ -417,10 +417,26 @@ The `docker-compose.yaml` passes the following flags to the binary. These are fi
 
 | Flag | Value | Description |
 |------|-------|-------------|
-| `--headless` | *(present)* | Disables the GUI window. Required for server operation. |
+| `--headless` | *(present)* | Disables the GUI window. Required for server operation, and it is also what selects the server build — see [Client/Server Boundary](client-server-boundary.md#consequences-for-the-api-surface). |
+| `--bind` | `0.0.0.0` | Interface to listen on. Required here; see the warning below. |
 | `--port` | `8080` | HTTP port the app listens on inside the container. |
 | `--data-dir` | `/app/data` | Path to the data directory (bound from `DT_DATA_DIR`). |
 | `--resources-dir` | `/app/resources` | Path to the resources directory (bound from `DT_RESOURCES_DIR`). |
+
+!!! warning "`--bind 0.0.0.0` is safe here and only here"
+    The application defaults to `127.0.0.1`, because every endpoint is
+    unauthenticated and binding all interfaces would publish the whole API to the
+    network. Inside a container that default would make the app unreachable even
+    to Nginx, so the compose file opts in explicitly.
+
+    What makes it acceptable is that the `app` service only `expose`s 8080–8083 on
+    the Docker network and never publishes them to the host; `nginx` is the only
+    service with a `ports:` mapping, so it is the single way in. Adding
+    `ports: - "8080:8080"` to `app` would bypass Nginx and publish an
+    unauthenticated API to your network.
+
+    If you run the binary directly on a host rather than through the compose
+    stack, leave `--bind` at its default and put a proxy in front of it.
 
 ---
 

--- a/internal/config/bindaddress_test.go
+++ b/internal/config/bindaddress_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"strconv"
+	"testing"
+)
+
+// The server bound 0.0.0.0 while a comment three lines below asserted it "only
+// listens on localhost" — and that false claim was used to justify disabling
+// WriteTimeout. Every endpoint is unauthenticated, so on a desktop install this
+// published the whole API, including the routes that write to disk, to everyone
+// on the user's network.
+
+// The zero value has to be the safe one. A caller that never thinks about
+// BindAddress must not end up publishing to the network.
+func TestZeroConfigBindsLoopback(t *testing.T) {
+	var cfg Config
+	cfg.Port = 8080
+
+	if got := cfg.ListenAddress(); got != "127.0.0.1:8080" {
+		t.Errorf("ListenAddress() = %q for a zero-value BindAddress, want 127.0.0.1:8080", got)
+	}
+	if DefaultBindAddress != "127.0.0.1" {
+		t.Errorf("DefaultBindAddress = %q, want 127.0.0.1", DefaultBindAddress)
+	}
+}
+
+// An empty address must never produce a wildcard bind, which is what
+// fmt.Sprintf(":%d", port) did.
+func TestListenAddressIsNeverWildcardByDefault(t *testing.T) {
+	for _, port := range []int{0, 80, 8080, 65535} {
+		cfg := Config{Port: port}
+		if got := cfg.ListenAddress(); got[0] == ':' {
+			t.Errorf("ListenAddress() = %q, which binds every interface", got)
+		}
+	}
+}
+
+func TestListenAddressHonoursAnExplicitAddress(t *testing.T) {
+	cases := map[string]struct {
+		bind string
+		port int
+		want string
+	}{
+		"wildcard, as the container asks for": {"0.0.0.0", 8080, "0.0.0.0:8080"},
+		"one specific interface":              {"192.168.1.10", 8080, "192.168.1.10:8080"},
+		"loopback by name":                    {"localhost", 3000, "localhost:3000"},
+		// JoinHostPort brackets an IPv6 literal; a bare colon-joined form would
+		// be unparseable as an address.
+		"ipv6 loopback":  {"::1", 8080, "[::1]:8080"},
+		"ipv6 wildcard":  {"::", 8080, "[::]:8080"},
+		"explicit local": {"127.0.0.1", 8080, "127.0.0.1:8080"},
+	}
+
+	for name, c := range cases {
+		cfg := Config{BindAddress: c.bind, Port: c.port}
+		if got := cfg.ListenAddress(); got != c.want {
+			t.Errorf("%s: ListenAddress() = %q, want %q", name, got, c.want)
+		}
+	}
+}
+
+// The auxiliary tile listeners bound the wildcard separately, so they need the
+// same treatment as the main port rather than their own rule.
+func TestListenAddressForPortUsesTheSameInterface(t *testing.T) {
+	cfg := Config{Port: 8080}
+	for i := 1; i <= 3; i++ {
+		want := "127.0.0.1:" + strconv.Itoa(8080+i)
+		if got := cfg.ListenAddressForPort(8080 + i); got != want {
+			t.Errorf("ListenAddressForPort(%d) = %q, want %q", 8080+i, got, want)
+		}
+	}
+
+	wide := Config{BindAddress: "0.0.0.0", Port: 8080}
+	if got := wide.ListenAddressForPort(8081); got != "0.0.0.0:8081" {
+		t.Errorf("an explicit wildcard should carry to the aux ports, got %q", got)
+	}
+}
+
+// LocalURL is what this process uses to reach its own server: the webview loads
+// it and the readiness probe polls it. A wildcard is not a usable destination,
+// and a specific interface means localhost is not listening.
+func TestLocalURL(t *testing.T) {
+	cases := map[string]struct {
+		bind string
+		want string
+	}{
+		"default is loopback":     {"", "http://localhost:8080"},
+		"wildcard is not dialled": {"0.0.0.0", "http://localhost:8080"},
+		"ipv6 wildcard":           {"::", "http://localhost:8080"},
+		"ipv6 wildcard bracketed": {"[::]", "http://localhost:8080"},
+		"explicit loopback":       {"127.0.0.1", "http://127.0.0.1:8080"},
+		// Bound to one interface, so that is the only address that answers.
+		"specific interface": {"192.168.1.10", "http://192.168.1.10:8080"},
+	}
+
+	for name, c := range cases {
+		cfg := Config{BindAddress: c.bind, Port: 8080}
+		if got := cfg.LocalURL(); got != c.want {
+			t.Errorf("%s: LocalURL() = %q, want %q", name, got, c.want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,16 +2,38 @@ package config
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 )
 
 const appName = "decision-theatre"
 
+// DefaultBindAddress is the interface the server listens on unless told
+// otherwise.
+//
+// Loopback, deliberately. Every endpoint is unauthenticated, so binding all
+// interfaces puts the whole API — including the routes that write to disk in the
+// desktop build — in reach of everyone on the user's network. A desktop
+// application has no reason to accept a connection from another machine, and a
+// container needs the opposite, so the container asks for it explicitly rather
+// than being served by an unsafe default.
+const DefaultBindAddress = "127.0.0.1"
+
 // Config holds the application configuration
 type Config struct {
-	Port         int
+	Port int
+
+	// BindAddress is the interface to listen on. Empty means
+	// DefaultBindAddress: the zero value must be the safe one, so a caller that
+	// forgets the field does not accidentally publish to the network.
+	//
+	// Use "0.0.0.0" to accept connections from anywhere, which is what the
+	// container deployment does — see deployments/docker-compose.yaml.
+	BindAddress string
+
 	DataDir      string
 	ResourcesDir string
 	Version      string
@@ -30,6 +52,35 @@ type Config struct {
 	// The zero value is the safe one. A caller that forgets to set it gets the
 	// server build, without the desktop-only routes.
 	DesktopMode bool
+}
+
+// ListenAddress returns the host:port to bind, applying the safe default.
+func (c Config) ListenAddress() string {
+	return c.ListenAddressForPort(c.Port)
+}
+
+// ListenAddressForPort is ListenAddress for a port other than the configured
+// one, used by the auxiliary tile listeners.
+func (c Config) ListenAddressForPort(port int) string {
+	host := c.BindAddress
+	if host == "" {
+		host = DefaultBindAddress
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+// LocalURL returns a URL this process can use to reach its own server: the
+// address the webview loads and the readiness probe polls.
+//
+// A wildcard bind is not a usable destination, so it becomes localhost. Any other
+// address is used as given, because a bind to one specific interface means
+// localhost is not listening.
+func (c Config) LocalURL() string {
+	host := c.BindAddress
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(c.Port))
 }
 
 // Settings holds persistent user settings saved to disk

--- a/internal/server/bind_test.go
+++ b/internal/server/bind_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+)
+
+// The server bound every interface — `Addr: fmt.Sprintf(":%d", port)` — while the
+// comment three lines below asserted it "only listens on localhost", and used
+// that false claim to justify disabling WriteTimeout entirely. Every endpoint is
+// unauthenticated, so on a desktop install this published the whole API,
+// including the routes that write to disk, to everyone on the user's network.
+
+func TestMainServerBindsLoopbackByDefault(t *testing.T) {
+	srv := newTestServer(t, true) // desktop build: the case that matters most
+	srv.cfg.Port = 8080
+
+	httpSrv := srv.newHTTPServer()
+
+	if httpSrv.Addr != "127.0.0.1:8080" {
+		t.Errorf("Addr = %q, want 127.0.0.1:8080", httpSrv.Addr)
+	}
+	if strings.HasPrefix(httpSrv.Addr, ":") {
+		t.Errorf("Addr = %q binds every interface", httpSrv.Addr)
+	}
+}
+
+func TestMainServerHonoursAnExplicitBindAddress(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.cfg.Port = 8080
+	srv.cfg.BindAddress = "0.0.0.0"
+
+	if got := srv.newHTTPServer().Addr; got != "0.0.0.0:8080" {
+		t.Errorf("Addr = %q, want 0.0.0.0:8080 — the container asks for this explicitly", got)
+	}
+}
+
+// A disabled write timeout means a stalled client holds a connection and its
+// goroutine forever. The long downloads opt out individually instead; see
+// allowLongDownload.
+func TestMainServerHasAllTimeoutsSet(t *testing.T) {
+	httpSrv := newTestServer(t, true).newHTTPServer()
+
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+	}{
+		{"ReadTimeout", httpSrv.ReadTimeout},
+		{"WriteTimeout", httpSrv.WriteTimeout},
+		{"IdleTimeout", httpSrv.IdleTimeout},
+	} {
+		if c.got <= 0 {
+			t.Errorf("%s is %v; an unbounded timeout lets a stalled client hold a goroutine", c.name, c.got)
+		}
+	}
+}
+
+// The aux listeners set only IdleTimeout, so a client that opened a connection
+// and stalled mid-request held it indefinitely.
+func TestAuxTileServerHasAllTimeoutsSet(t *testing.T) {
+	aux := newAuxTileServer(mux.NewRouter())
+
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+	}{
+		{"ReadTimeout", aux.ReadTimeout},
+		{"WriteTimeout", aux.WriteTimeout},
+		{"IdleTimeout", aux.IdleTimeout},
+	} {
+		if c.got <= 0 {
+			t.Errorf("aux tile server %s is %v, want a bound", c.name, c.got)
+		}
+	}
+}
+
+// End to end: the listener the server would actually open must not answer on a
+// routable address. This binds a real port rather than inspecting a struct field,
+// so a future change that computes the address correctly and then ignores it
+// still fails.
+func TestListenerIsNotReachableOffLoopback(t *testing.T) {
+	routable := routableIPv4(t)
+
+	cfg := config.Config{Port: 0} // port 0: the OS picks a free one
+	ln, err := net.Listen("tcp", cfg.ListenAddress())
+	if err != nil {
+		t.Fatalf("listening on %s: %v", cfg.ListenAddress(), err)
+	}
+	defer ln.Close() //nolint:errcheck
+
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Loopback must work, or the application is broken.
+	local, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 2*time.Second)
+	if err != nil {
+		t.Fatalf("could not reach the server on loopback: %v", err)
+	}
+	local.Close() //nolint:errcheck
+
+	// The same port on this machine's routable address must not.
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(routable, strconv.Itoa(port)), 2*time.Second)
+	if err == nil {
+		conn.Close() //nolint:errcheck
+		t.Errorf("the server accepted a connection on %s:%d; it is reachable from the network",
+			routable, port)
+	}
+}
+
+// routableIPv4 returns a non-loopback IPv4 address of this machine, skipping the
+// test when there is none — a container with only loopback cannot demonstrate
+// anything here.
+func routableIPv4(t *testing.T) string {
+	t.Helper()
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Skipf("could not enumerate interfaces: %v", err)
+	}
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+		if ip4 := ipnet.IP.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	}
+	t.Skip("no non-loopback IPv4 address on this machine")
+	return ""
+}
+
+// The safe default is only safe if the deployment that needs the unsafe one asks
+// for it, rather than the default being widened to suit the container.
+func TestDeploymentConfigBindsExplicitly(t *testing.T) {
+	for _, f := range []string{
+		filepath.Join("..", "..", "deployments", "Dockerfile"),
+		filepath.Join("..", "..", "deployments", "docker-compose.yaml"),
+	} {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Errorf("could not read %s: %v", f, err)
+			continue
+		}
+		if !strings.Contains(string(data), "0.0.0.0") {
+			t.Errorf("%s does not pass --bind 0.0.0.0; the container would listen on "+
+				"loopback only and nginx could not reach it", f)
+		}
+	}
+}

--- a/internal/server/datapack.go
+++ b/internal/server/datapack.go
@@ -344,7 +344,26 @@ func (s *Server) handleDatapackDownload(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", fi.Size()))
+	allowLongDownload(w, filename, fi.Size())
 	http.ServeContent(w, r, filename, fi.ModTime(), f)
+}
+
+// allowLongDownload lifts the server's WriteTimeout for a single response.
+//
+// The datapack is hundreds of megabytes; on a slow connection sending it takes
+// far longer than any timeout that is useful against a stalled client. Rather
+// than disable WriteTimeout for every request — which is what the server did
+// before, and which let one stuck client hold a goroutine indefinitely — the two
+// handlers that stream a large file opt out here.
+//
+// A failure is logged and ignored: the download then runs under the default
+// deadline, which is worse for the user but not incorrect, and there is nothing
+// better to do at this point since the response has already begun.
+func allowLongDownload(w http.ResponseWriter, filename string, size int64) {
+	// The zero time means no deadline.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		log.Printf("Could not lift the write deadline for %s (%d bytes): %v", filename, size, err)
+	}
 }
 
 type executableInfo struct {
@@ -424,6 +443,7 @@ func (s *Server) handleExecutableDownload(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", fi.Size()))
+	allowLongDownload(w, filename, fi.Size())
 	http.ServeContent(w, r, filename, fi.ModTime(), f)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -239,6 +239,21 @@ func (s *Server) handleTileRequest(w http.ResponseWriter, r *http.Request) {
 	w.Write(tileData)
 }
 
+// newAuxTileServer configures one auxiliary tile listener.
+//
+// These previously set IdleTimeout only, so a client that opened a connection and
+// then stalled mid-request held it indefinitely. Tiles are small and read from a
+// local mbtiles file, so nothing here streams for long and WriteTimeout needs no
+// exemption, unlike the main server's downloads.
+func newAuxTileServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:      handler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+}
+
 // startAuxTileServers opens up to 3 extra listeners on the ports immediately
 // following the main port. Each listener runs a minimal router that only
 // handles tile requests, giving the browser additional HTTP/1.1 connection
@@ -251,11 +266,8 @@ func (s *Server) startAuxTileServers(mainPort int) {
 			r.HandleFunc("/tiles/{name}/{z:[0-9]+}/{x:[0-9]+}/{y:[0-9]+}.pbf",
 				s.handleTileRequest).Methods("GET")
 		}
-		srv := &http.Server{
-			Handler:     r,
-			IdleTimeout: 120 * time.Second,
-		}
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		srv := newAuxTileServer(r)
+		ln, err := net.Listen("tcp", s.cfg.ListenAddressForPort(port))
 		if err != nil {
 			log.Printf("Aux tile server: port %d unavailable, skipping: %v", port, err)
 			continue
@@ -272,21 +284,39 @@ func (s *Server) startAuxTileServers(mainPort int) {
 }
 
 func (s *Server) Start() error {
-	s.httpServer = &http.Server{
-		Addr: fmt.Sprintf(":%d", s.cfg.Port),
-		// Every request goes through the body limit; see bodylimit.go.
-		Handler:     limitRequestBody(s.router),
-		ReadTimeout: 15 * time.Second,
-		// WriteTimeout is intentionally unset (0 = disabled) — long-running operations
-		// such as datapack extraction can take several minutes on large archives.
-		// This is safe because the server only listens on localhost.
-		IdleTimeout: 120 * time.Second,
-	}
+	s.httpServer = s.newHTTPServer()
 
 	s.startAuxTileServers(s.cfg.Port)
 
-	log.Printf("Server listening on http://localhost:%d", s.cfg.Port)
+	log.Printf("Server listening on http://%s", s.cfg.ListenAddress())
 	return s.httpServer.ListenAndServe()
+}
+
+// newHTTPServer builds the main listener's configuration.
+//
+// Separate from Start so a test can inspect the address and the timeouts without
+// binding a port or blocking in ListenAndServe.
+func (s *Server) newHTTPServer() *http.Server {
+	return &http.Server{
+		Addr: s.cfg.ListenAddress(),
+		// Every request goes through the body limit; see bodylimit.go.
+		Handler:     limitRequestBody(s.router),
+		ReadTimeout: 15 * time.Second,
+		// WriteTimeout used to be disabled entirely, justified by a claim that
+		// the server "only listens on localhost" — which was not true: it bound
+		// 0.0.0.0. The binding is fixed now, but a disabled write timeout still
+		// means a stalled client holds a connection and its goroutine forever, so
+		// it is bounded here on its own merits.
+		//
+		// Nothing needs minutes. Datapack extraction, the original reason given,
+		// answers 202 immediately and reports progress through
+		// /api/datapack/status, so no handler blocks on it. The two handlers that
+		// genuinely stream a large file — the datapack and executable downloads —
+		// extend their own deadline with http.NewResponseController rather than
+		// forcing every request to be unbounded. See datapack.go.
+		WriteTimeout: 120 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 }
 
 // Stop gracefully shuts down the server.

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func main() {
 	dataDir := flag.String("data-dir", "", "Directory containing data files (mbtiles, geopackage)")
 	resourcesDir := flag.String("resources-dir", "", "Directory containing resource files (mbtiles, styles)")
 	headless := flag.Bool("headless", false, "Run in headless mode (no GUI window)")
+	bindAddress := flag.String("bind", config.DefaultBindAddress,
+		"Interface to listen on. Loopback by default; the API is unauthenticated, "+
+			"so use 0.0.0.0 only where something in front of it controls access.")
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	flag.Parse()
 
@@ -97,7 +100,7 @@ func main() {
 	}
 
 	// Find an available port (try up to 10 ports starting from the requested one)
-	availablePort, err := findAvailablePort(*port, 10)
+	availablePort, err := findAvailablePort(*bindAddress, *port, 10)
 	if err != nil {
 		log.Fatalf("Failed to find available port: %v", err)
 	}
@@ -111,6 +114,7 @@ func main() {
 		DataDir:      resolvedDataDir,
 		ResourcesDir: resolvedResourcesDir,
 		Version:      version,
+		BindAddress:  *bindAddress,
 		// --headless is the server build; anything else opens the window below.
 		DesktopMode: !*headless,
 	}
@@ -135,7 +139,7 @@ func main() {
 	}()
 
 	// Wait for server to be ready
-	serverURL := fmt.Sprintf("http://localhost:%d", cfg.Port)
+	serverURL := cfg.LocalURL()
 	waitForServer(serverURL, 10*time.Second)
 
 	if *headless {
@@ -253,10 +257,13 @@ func waitForServer(url string, timeout time.Duration) {
 
 // findAvailablePort finds an available port, starting from the given port.
 // If the port is in use, it tries subsequent ports up to maxAttempts times.
-func findAvailablePort(startPort int, maxAttempts int) (int, error) {
+// The probe must bind the same interface the server will, or it answers a
+// different question: a port free on loopback can be taken on another interface,
+// and vice versa.
+func findAvailablePort(bindAddress string, startPort int, maxAttempts int) (int, error) {
 	for i := 0; i < maxAttempts; i++ {
 		port := startPort + i
-		addr := fmt.Sprintf(":%d", port)
+		addr := config.Config{BindAddress: bindAddress}.ListenAddressForPort(port)
 		listener, err := net.Listen("tcp", addr)
 		if err == nil {
 			// Opened only to see whether the port is free.

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -18,13 +18,19 @@ set -euo pipefail
 #
 #   desktop  the standalone GTK/WebKit application — the server runs in-process
 #            and an embedded WebView window opens onto it. The default.
-#   server   the same server with no window, for a browser on this or another
-#            machine to connect to at http://<host>:<port>.
+#   server   the same server with no window, for a browser to connect to at
+#            http://127.0.0.1:<port>. Reaching it from another machine needs
+#            DT_BIND — the default is loopback because the API is
+#            unauthenticated.
 #
 # Environment knobs (all optional):
 #   DT_MODE          desktop (default) or server.
 #   DT_BIN           Launch this binary; skips every build step entirely.
 #   DT_PORT          HTTP port (default: the app's own default, 8080).
+#   DT_BIND          Interface to listen on (default: 127.0.0.1). The API is
+#                    unauthenticated, so 0.0.0.0 exposes it to your whole
+#                    network — set it only when something in front controls
+#                    access. Server mode on another machine needs it.
 #   DT_DATA_DIR      Passed as --data-dir. Unset lets the app resolve it from
 #                    saved settings, then ./data, then the per-user directory.
 #   DT_RESOURCES_DIR Passed as --resources-dir.
@@ -51,7 +57,11 @@ set -euo pipefail
 # =============================================================================
 
 usage() {
-    sed -n '4,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Print the comment block between the two ==== rules above. The range is
+    # derived rather than hardcoded: it was '4,45p', and adding four lines to the
+    # header silently truncated --help so the Options section stopped appearing.
+    awk '/^# ={10,}$/ { rules++; next } rules == 1' "${BASH_SOURCE[0]}" |
+        sed 's/^# \{0,1\}//'
 }
 
 # The knobs that .dt-env is allowed to set.
@@ -59,6 +69,7 @@ DT_VARS=(
     DT_MODE
     DT_BIN
     DT_PORT
+    DT_BIND
     DT_DATA_DIR
     DT_RESOURCES_DIR
     DT_HEADLESS
@@ -173,6 +184,7 @@ BIN="$DT_RESOLVED_BIN"
 ARGS=()
 
 [ -n "${DT_PORT:-}" ] && ARGS+=(--port "$DT_PORT")
+[ -n "${DT_BIND:-}" ] && ARGS+=(--bind "$DT_BIND")
 [ -n "${DT_DATA_DIR:-}" ] && ARGS+=(--data-dir "$DT_DATA_DIR")
 [ -n "${DT_RESOURCES_DIR:-}" ] && ARGS+=(--resources-dir "$DT_RESOURCES_DIR")
 [ "$DT_MODE" = "server" ] && ARGS+=(--headless)


### PR DESCRIPTION
Fixes #30

> **Stacked on the gating branch** (`security/gate-desktop-only-routes`), which is
> itself stacked on #96. GitHub retargets each PR as the one below it merges.
> Review bottom-up.

## The fault

```go
Addr: fmt.Sprintf(":%d", s.cfg.Port),   // binds 0.0.0.0
...
// This is safe because the server only listens on localhost.
IdleTimeout: 120 * time.Second,
```

The comment is three lines below the code that contradicts it, and the false claim
was doing work: it justified leaving `WriteTimeout` at zero. Every endpoint is
unauthenticated, so on a desktop install this published the whole API to everyone
on the user's network — including the routes that write to disk, which the branch
below this one has just finished gating to the desktop build. Gating them to
desktop mode and then binding `0.0.0.0` would have moved the problem rather than
fixed it.

The three auxiliary tile listeners bound the wildcard too, and set neither a read
nor a write timeout.

## The fix

`config.Config.BindAddress`, defaulting to `127.0.0.1` for **every** build, with
`--bind` (or `DT_BIND` via `run-app.sh`) to change it. The zero value is the safe
one, so a caller who never thinks about the field cannot accidentally publish.

The container opts in explicitly with `--bind 0.0.0.0`, because inside a container
loopback would make the app unreachable even to Nginx. That is safe *there* and
only there: the `app` service `expose`s 8080–8083 on the Docker network and never
publishes them to the host, and `nginx` holds the only `ports:` mapping — I checked
rather than assumed. The deployment doc now says so, and says plainly that adding
`ports: - "8080:8080"` to `app` would undo it.

### Timeouts

All three are now set on both the main and auxiliary listeners. `WriteTimeout` is
bounded on its own merits rather than on the old premise:

- Datapack extraction, the original reason given for disabling it, answers **202
  immediately** and reports progress through `/api/datapack/status`. No handler
  blocks on it.
- The two handlers that genuinely stream a large file — the datapack and executable
  downloads — lift their own deadline via `http.NewResponseController`
  (`allowLongDownload`), rather than every request in the process being unbounded
  so that two of them can be.

## Verified

Tests checked against the old behaviour by setting `DefaultBindAddress` back to
`0.0.0.0` and reverting the timeouts. All the load-bearing ones fail:

```
--- FAIL: TestZeroConfigBindsLoopback
    ListenAddress() = "0.0.0.0:8080" for a zero-value BindAddress
--- FAIL: TestListenAddressForPortUsesTheSameInterface
    ListenAddressForPort(8081) = "0.0.0.0:8081", want "127.0.0.1:8081"
--- FAIL: TestMainServerHasAllTimeoutsSet
    WriteTimeout is 0s; an unbounded timeout lets a stalled client hold a goroutine
--- FAIL: TestAuxTileServerHasAllTimeoutsSet
    aux tile server ReadTimeout is 0s, want a bound
--- FAIL: TestListenerIsNotReachableOffLoopback
    the server accepted a connection on 192.168.122.1:46775; it is reachable
    from the network
```

That last one binds a real port and dials this machine's routable address, so it
fails if the address is ever computed correctly and then ignored — a struct-field
assertion alone would not catch that. It skips on a host with no non-loopback IPv4.

**And on a running binary, which is what #30 asked for:**

```
$ ss -tlnp | grep 1808
LISTEN 127.0.0.1:18080   ("dt-bind-check")
LISTEN 127.0.0.1:18081   ("dt-bind-check")
LISTEN 127.0.0.1:18082   ("dt-bind-check")
LISTEN 127.0.0.1:18083   ("dt-bind-check")

$ # with --bind 0.0.0.0
LISTEN *:18090  LISTEN *:18091  LISTEN *:18092  LISTEN *:18093
```

The main port and all three aux ports, both ways.

- `go test ./...` and `go test -race ./internal/...` — six packages pass
- `golangci-lint run` — 0 issues
- `gofmt` clean

## Success criteria from #30

- [x] Bind address is a config field defaulting to `127.0.0.1`
- [x] The container sets `0.0.0.0` explicitly and knowingly
- [x] The stale comment is corrected and `WriteTimeout` re-justified on its actual
      merits, with a per-response exemption for the two long downloads
- [x] Aux tile servers get `ReadTimeout` and `WriteTimeout`
- [x] Verified with `ss -tlnp`
- [x] `go test -race ./...` passes

## Behaviour change worth flagging

`dt serve` is no longer reachable from another machine by default. That was a
documented use — `run-app.sh`'s own header advertised "this or another machine" —
so the header now says loopback and points at `DT_BIND`, and `.dt-env.example`
carries the knob with a note about when it is reasonable to set it. This is the one
thing in the PR a user could notice as a regression, and it is the point of the
change rather than a side effect.

## Two incidental fixes

- **The port probe bound the wrong interface.** `findAvailablePort` opened `:port`
  regardless, so it answered "is this port free on any interface?" when the
  question is "is it free on the one I am about to bind?" It now takes the bind
  address.
- **`run-app.sh --help` was truncated.** `usage()` did `sed -n '4,45p'`, and adding
  four lines of `DT_BIND` documentation to the header pushed the Options section
  out of range — `--desktop`, `--server` and `--diag` silently stopped being
  listed. The range is now derived from the `====` rules that delimit the block, so
  it cannot drift again. I caught this only because I ran `--help` afterwards.
