### PR TITLE
perf: compress API responses in server mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cd`-ing into a subdirectory no longer creates a second module cache there. Two had
   accumulated, under `frontend/` and `resources/mbtiles/`.
 
+### Performance
+
+- **No API response was compressed.** Searching the server for compression found
+  exactly one hit — the tile handler, where MBTiles blobs are already gzipped on
+  disk and the header merely declares it. GeoJSON is close to a best case for
+  deflate, and the full-Africa choropleth against the real datapack is 5,760,913
+  bytes.
+
+  Responses are now gzipped in server mode. Measured on that payload:
+
+  | | bytes | ratio |
+  |---|---|---|
+  | before | 5,760,913 | — |
+  | after | 1,794,404 | **3.21x** |
+
+  `/api/columns` goes from 16,642 to 2,779 bytes (6.0x). The compression level was
+  chosen by measurement rather than by default: level 1 gives 2.78x for 100ms of
+  CPU and level 9 gives 3.25x for 294ms, but the level here has to beat nginx's
+  existing `gzip_comp_level 6` — which produced 1,810,329 bytes — because nginx
+  passes a body through untouched once `Content-Encoding` is set. Level 5 does, at
+  230ms, with the remaining levels buying under 2%.
+
+  Small responses (below the 1024-byte threshold, matching `gzip_min_length` in
+  `deployments/nginx.conf`), already-encoded responses such as tiles, and
+  non-text content types are left alone. A test asserts the two thresholds agree.
+
+  **Not applied in desktop mode**, deliberately: the desktop build binds loopback
+  and opens its own WebView onto it, so there is no bandwidth to save and
+  compressing the choropleth would spend 230ms of CPU per request to speed up a
+  transfer that already takes milliseconds.
+
 ### Security
 
 - **The server bound every network interface while claiming it bound only localhost.**

--- a/deployments/nginx.conf
+++ b/deployments/nginx.conf
@@ -22,6 +22,14 @@ client_max_body_size 40m;
 # response here comes through proxy_pass, and gzip_proxied defaults to
 # off for proxied responses, so it must be turned on explicitly or gzip
 # silently compresses nothing.
+#
+# The application now compresses these responses itself in server mode, at a
+# level chosen to slightly beat what gzip_comp_level 6 achieves here — measured
+# on the same 5,760,913-byte payload, 1,794,866 bytes from the application
+# against 1,810,329 from nginx. nginx passes a body through untouched once
+# Content-Encoding is set, so these directives no longer do the work for /api.
+# They stay as the backstop for anything the application declines to compress,
+# and they cost nothing. See internal/server/compress.go.
 gzip on;
 gzip_proxied any;
 gzip_types application/json;

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -1,0 +1,273 @@
+package server
+
+import (
+	"compress/gzip"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Response compression.
+//
+// Searching the server for compression used to find exactly one hit: the tile
+// handler, where MBTiles blobs are already gzipped on disk and the header merely
+// declares it. No /api response was compressed.
+//
+// GeoJSON is close to a best case for deflate — repeated key names, repeated
+// coordinate digit patterns, long runs of similar floats. Measured against the
+// full-Africa choropleth on the real datapack, 5,760,913 bytes:
+//
+//	level 1: 2,074,170 bytes  2.78x  100ms
+//	level 3: 1,934,806 bytes  2.98x  173ms
+//	level 5: 1,794,866 bytes  3.21x  230ms
+//	level 6: 1,782,908 bytes  3.23x  275ms
+//	level 9: 1,773,189 bytes  3.25x  294ms
+//
+// Level 5 is the choice, for one specific reason: nginx in front of the hosted
+// deployment already compresses with gzip_comp_level 6, which produced 1,810,329
+// bytes on the same payload. Anything weaker here would be a regression for the
+// hosted users this is for, because once we set Content-Encoding nginx passes the
+// body through instead of compressing it itself. Level 5 slightly beats what
+// nginx was achieving, at a level whose extra cost over 6 and 9 is nil.
+const gzipLevel = 5
+
+// compressMinBytes is the response size below which compressing is not worth the
+// ~20 bytes of gzip framing, the CPU, or the loss of Content-Length. Matches
+// gzip_min_length in deployments/nginx.conf so the two tiers agree.
+const compressMinBytes = 1024
+
+// compressibleTypes are the content types worth compressing. Everything absent
+// from this list is passed through, which is the safe default: an unknown type is
+// more likely to be an already-compressed binary than a compressible text format.
+var compressibleTypes = []string{
+	"application/json",
+	"application/geo+json",
+	"application/javascript",
+	"image/svg+xml",
+	"text/",
+}
+
+func isCompressibleType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	if ct == "" {
+		return false
+	}
+	for _, candidate := range compressibleTypes {
+		if strings.HasSuffix(candidate, "/") {
+			if strings.HasPrefix(ct, candidate) {
+				return true
+			}
+			continue
+		}
+		if ct == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// acceptsGzip reports whether the client offered gzip.
+//
+// "gzip;q=0" is a client naming gzip in order to refuse it, and must be honoured.
+// The quality is parsed rather than pattern-matched: q=0.01 begins with the same
+// characters as q=0.0 but means the opposite — acceptable, barely.
+func acceptsGzip(header string) bool {
+	for _, part := range strings.Split(header, ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		if !strings.EqualFold(strings.TrimSpace(fields[0]), "gzip") {
+			continue
+		}
+		for _, param := range fields[1:] {
+			key, value, found := strings.Cut(strings.TrimSpace(param), "=")
+			if !found || !strings.EqualFold(strings.TrimSpace(key), "q") {
+				continue
+			}
+			q, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err == nil && q == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+var gzipWriterPool = sync.Pool{
+	New: func() any {
+		zw, err := gzip.NewWriterLevel(nil, gzipLevel)
+		if err != nil {
+			// Only returned for an invalid level, which is a compile-time
+			// constant here, so this cannot happen.
+			panic("invalid gzip level: " + strconv.Itoa(gzipLevel))
+		}
+		return zw
+	},
+}
+
+// gzipResponseWriter decides whether to compress once it has seen enough of the
+// body to know how big it is and what type it is.
+//
+// The decision cannot be made up front: the handler sets Content-Type as it
+// writes, and most do not set Content-Length at all. So the first
+// compressMinBytes are buffered, and the header is not sent until either the
+// threshold is crossed or the handler finishes.
+type gzipResponseWriter struct {
+	http.ResponseWriter
+
+	status  int
+	buf     []byte
+	gz      *gzip.Writer
+	decided bool // whether to compress has been settled
+	raw     bool // settled as: do not compress
+}
+
+func (w *gzipResponseWriter) WriteHeader(status int) {
+	// Held back until the decision is made, because that decision changes the
+	// headers. Close or the threshold will send it.
+	if w.status == 0 {
+		w.status = status
+	}
+}
+
+// hasBody reports whether a status code permits a response body. Compressing a
+// 204 or 304 would add a body where the protocol says there is none.
+func hasBody(status int) bool {
+	switch {
+	case status == http.StatusNoContent, status == http.StatusNotModified:
+		return false
+	case status >= 100 && status < 200:
+		return false
+	}
+	return true
+}
+
+// decide settles whether this response is compressed and sends the header.
+func (w *gzipResponseWriter) decide() {
+	if w.decided {
+		return
+	}
+	w.decided = true
+
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	header := w.Header()
+
+	// Already encoded — the tile handler declares gzip because the blob on disk
+	// is gzipped. Compressing again would produce a body no client can read.
+	alreadyEncoded := header.Get("Content-Encoding") != ""
+	tooSmall := len(w.buf) < compressMinBytes && w.gz == nil
+
+	if alreadyEncoded || !hasBody(w.status) || !isCompressibleType(header.Get("Content-Type")) || tooSmall {
+		w.raw = true
+		w.ResponseWriter.WriteHeader(w.status)
+		return
+	}
+
+	header.Set("Content-Encoding", "gzip")
+	// The length of the compressed body is not known yet, and the handler's value
+	// describes the uncompressed one.
+	header.Del("Content-Length")
+	w.ResponseWriter.WriteHeader(w.status)
+
+	zw := gzipWriterPool.Get().(*gzip.Writer)
+	zw.Reset(w.ResponseWriter)
+	w.gz = zw
+}
+
+func (w *gzipResponseWriter) Write(p []byte) (int, error) {
+	if w.decided {
+		if w.raw {
+			return w.ResponseWriter.Write(p)
+		}
+		return w.gz.Write(p)
+	}
+
+	w.buf = append(w.buf, p...)
+	if len(w.buf) < compressMinBytes {
+		// Not enough yet to know whether compressing is worth it.
+		return len(p), nil
+	}
+
+	w.decide()
+	buffered := w.buf
+	w.buf = nil
+	var err error
+	if w.raw {
+		_, err = w.ResponseWriter.Write(buffered)
+	} else {
+		_, err = w.gz.Write(buffered)
+	}
+	if err != nil {
+		return 0, err
+	}
+	// Report the caller's own length: the bytes it handed over were all accepted,
+	// whatever they compressed to.
+	return len(p), nil
+}
+
+// Flush honours an explicit flush from the handler. Nothing streams today, but a
+// wrapper that swallowed Flush would break it silently if something started to.
+func (w *gzipResponseWriter) Flush() {
+	if !w.decided {
+		// A flush means the client wants what there is now, so decide on what has
+		// been seen so far rather than waiting for the threshold.
+		w.decide()
+		if len(w.buf) > 0 {
+			buffered := w.buf
+			w.buf = nil
+			if w.raw {
+				_, _ = w.ResponseWriter.Write(buffered)
+			} else {
+				_, _ = w.gz.Write(buffered)
+			}
+		}
+	}
+	if w.gz != nil {
+		_ = w.gz.Flush()
+	}
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Close finishes the response: sends the header if nothing did, writes out a body
+// that stayed under the threshold, and returns the gzip writer to the pool.
+func (w *gzipResponseWriter) Close() {
+	if !w.decided {
+		w.decide()
+		if len(w.buf) > 0 {
+			_, _ = w.ResponseWriter.Write(w.buf)
+			w.buf = nil
+		}
+		return
+	}
+	if w.gz != nil {
+		_ = w.gz.Close()
+		gzipWriterPool.Put(w.gz)
+		w.gz = nil
+	}
+}
+
+// compressResponses gzips responses that are worth gzipping.
+//
+// It is applied in server mode only; see the call site in Start for why the
+// desktop build is excluded.
+func compressResponses(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Vary regardless of what this particular request negotiated: a cache
+		// keyed without it would serve a gzipped body to a client that cannot
+		// read one.
+		w.Header().Add("Vary", "Accept-Encoding")
+
+		if !acceptsGzip(r.Header.Get("Accept-Encoding")) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		gw := &gzipResponseWriter{ResponseWriter: w}
+		defer gw.Close()
+		next.ServeHTTP(gw, r)
+	})
+}

--- a/internal/server/compress_test.go
+++ b/internal/server/compress_test.go
@@ -1,0 +1,355 @@
+package server
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// No /api response was compressed, and GeoJSON is close to a best case for
+// deflate. Measured on the real datapack, the full-Africa choropleth is 5,760,913
+// bytes and compresses to 1,794,866 at the level used here.
+
+// bigJSON returns a payload above the threshold that compresses well, in the
+// shape these endpoints actually return.
+func bigJSON() string {
+	var b strings.Builder
+	b.WriteString(`{"ids":[`)
+	for i := 0; i < 4000; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString("1121879850")
+	}
+	b.WriteString(`],"values":[`)
+	for i := 0; i < 4000; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString("412.3")
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}
+
+func jsonHandler(body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func get(t *testing.T, h http.Handler, path, acceptEncoding string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if acceptEncoding != "" {
+		req.Header.Set("Accept-Encoding", acceptEncoding)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestLargeJSONIsCompressed(t *testing.T) {
+	body := bigJSON()
+	rec := get(t, compressResponses(jsonHandler(body)), "/api/choropleth", "gzip")
+
+	if enc := rec.Header().Get("Content-Encoding"); enc != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", enc)
+	}
+	if rec.Body.Len() >= len(body) {
+		t.Errorf("compressed body is %d bytes against %d raw — no saving",
+			rec.Body.Len(), len(body))
+	}
+
+	// And it must actually be readable gzip of exactly the original.
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("reading the gzip body: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("round trip lost data: got %d bytes, want %d", len(got), len(body))
+	}
+	t.Logf("%d bytes -> %d (%.2fx)", len(body), rec.Body.Len(),
+		float64(len(body))/float64(rec.Body.Len()))
+}
+
+// Below the threshold the framing and the lost Content-Length cost more than the
+// saving.
+func TestSmallResponseIsNotCompressed(t *testing.T) {
+	body := `{"status":"ok"}`
+	rec := get(t, compressResponses(jsonHandler(body)), "/api/health", "gzip")
+
+	if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("Content-Encoding = %q for a %d-byte body", enc, len(body))
+	}
+	if rec.Body.String() != body {
+		t.Errorf("body = %q, want %q", rec.Body.String(), body)
+	}
+}
+
+// The tile handler declares gzip because the MBTiles blob on disk is already
+// gzipped. Compressing it again would produce a body no client can read.
+func TestAlreadyEncodedResponseIsNotRecompressed(t *testing.T) {
+	payload := strings.Repeat("pretend this is a gzipped tile blob", 200)
+
+	h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte(payload))
+	}))
+	rec := get(t, h, "/tiles/africa/1/2/3.pbf", "gzip")
+
+	if rec.Body.String() != payload {
+		t.Error("an already-encoded body was altered; it would be double-compressed")
+	}
+	if got := rec.Header().Values("Content-Encoding"); len(got) != 1 {
+		t.Errorf("Content-Encoding = %v, want exactly one value", got)
+	}
+}
+
+func TestBinaryContentTypeIsNotCompressed(t *testing.T) {
+	payload := strings.Repeat("x", 8192)
+
+	for _, ct := range []string{
+		"application/octet-stream",
+		"application/zip",
+		"image/png",
+		"application/x-protobuf",
+	} {
+		h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", ct)
+			_, _ = w.Write([]byte(payload))
+		}))
+		rec := get(t, h, "/api/datapack/download", "gzip")
+
+		if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+			t.Errorf("%s was compressed (Content-Encoding %q)", ct, enc)
+		}
+	}
+}
+
+func TestNoCompressionWithoutAcceptEncoding(t *testing.T) {
+	body := bigJSON()
+
+	for _, header := range []string{"", "identity", "br", "gzip;q=0"} {
+		rec := get(t, compressResponses(jsonHandler(body)), "/api/choropleth", header)
+
+		if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+			t.Errorf("Accept-Encoding %q produced Content-Encoding %q", header, enc)
+		}
+		if rec.Body.String() != body {
+			t.Errorf("Accept-Encoding %q: body was altered", header)
+		}
+	}
+}
+
+func TestAcceptsGzip(t *testing.T) {
+	cases := map[string]bool{
+		"gzip":                      true,
+		"gzip, deflate":             true,
+		"deflate, gzip;q=1.0":       true,
+		"br;q=1.0, gzip;q=0.8":      true,
+		"GZIP":                      true,
+		" gzip ":                    true,
+		"identity":                  false,
+		"":                          false,
+		"br":                        false,
+		"gzip;q=0":                  false,
+		"gzip;q=0.0":                false,
+		"deflate, gzip;q=0":         false,
+		"x-gzip":                    false, // deliberately not treated as gzip
+		"identity;q=1, gzip;q=0.01": true,
+	}
+
+	for header, want := range cases {
+		if got := acceptsGzip(header); got != want {
+			t.Errorf("acceptsGzip(%q) = %v, want %v", header, got, want)
+		}
+	}
+}
+
+// A cache that keyed on the URL alone would hand a gzipped body to a client that
+// asked for identity. Vary must be set either way, not only when compressing.
+func TestVaryIsAlwaysSet(t *testing.T) {
+	for _, header := range []string{"gzip", "identity", ""} {
+		rec := get(t, compressResponses(jsonHandler(bigJSON())), "/api/choropleth", header)
+
+		if !strings.Contains(rec.Header().Get("Vary"), "Accept-Encoding") {
+			t.Errorf("Accept-Encoding %q: Vary = %q, want it to include Accept-Encoding",
+				header, rec.Header().Get("Vary"))
+		}
+	}
+}
+
+// The handler's Content-Length describes the uncompressed body. Left in place it
+// would contradict the bytes on the wire.
+func TestContentLengthIsRemovedWhenCompressing(t *testing.T) {
+	body := bigJSON()
+	h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write([]byte(body))
+	}))
+	rec := get(t, h, "/api/choropleth", "gzip")
+
+	if got := rec.Header().Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length = %q on a compressed response, describing the uncompressed body", got)
+	}
+}
+
+// A 304 has no body by definition; adding a gzip member would invent one.
+func TestStatusesWithoutABodyAreNotCompressed(t *testing.T) {
+	for _, status := range []int{http.StatusNoContent, http.StatusNotModified} {
+		h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+		}))
+		rec := get(t, h, "/api/thing", "gzip")
+
+		if rec.Code != status {
+			t.Errorf("status = %d, want %d", rec.Code, status)
+		}
+		if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+			t.Errorf("status %d got Content-Encoding %q", status, enc)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("status %d got a %d-byte body", status, rec.Body.Len())
+		}
+	}
+}
+
+// The status the handler chose must survive, or an error becomes a 200.
+func TestStatusCodeIsPreserved(t *testing.T) {
+	body := bigJSON()
+	h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	rec := get(t, h, "/api/choropleth", "gzip")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if rec.Header().Get("Content-Encoding") != "gzip" {
+		t.Error("a large error body should still be compressed")
+	}
+}
+
+// A handler writing in many small pieces — json.Encoder does this — must produce
+// the same bytes as one that writes at once.
+func TestManySmallWritesRoundTrip(t *testing.T) {
+	chunks := 500
+	chunk := strings.Repeat("abcdefgh", 8)
+
+	h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		for i := 0; i < chunks; i++ {
+			_, _ = w.Write([]byte(chunk))
+		}
+	}))
+	rec := get(t, h, "/api/choropleth", "gzip")
+
+	if rec.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("not compressed: %q", rec.Header().Get("Content-Encoding"))
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("invalid gzip: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	if want := strings.Repeat(chunk, chunks); string(got) != want {
+		t.Errorf("round trip differs: %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestIsCompressibleType(t *testing.T) {
+	cases := map[string]bool{
+		"application/json":                true,
+		"application/json; charset=utf-8": true,
+		"APPLICATION/JSON":                true,
+		"application/geo+json":            true,
+		"text/html":                       true,
+		"text/plain; charset=utf-8":       true,
+		"image/svg+xml":                   true,
+		"application/javascript":          true,
+		"application/x-protobuf":          false,
+		"image/png":                       false,
+		"application/zip":                 false,
+		"application/octet-stream":        false,
+		"":                                false,
+		"application/json-but-not-really": false,
+		"font/woff2":                      false,
+	}
+
+	for ct, want := range cases {
+		if got := isCompressibleType(ct); got != want {
+			t.Errorf("isCompressibleType(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}
+
+// Compression is applied in server mode only: desktop reaches the server over
+// loopback, where it would cost CPU to speed up nothing.
+func TestCompressionAppliedInServerModeOnly(t *testing.T) {
+	for _, mode := range []struct {
+		name     string
+		desktop  bool
+		wantGzip bool
+	}{
+		{"server", false, true},
+		{"desktop", true, false},
+	} {
+		srv := newTestServer(t, mode.desktop)
+		// A route with a body big enough to cross the threshold.
+		srv.router = muxWithBigJSON()
+		handler := srv.rootHandler()
+
+		rec := get(t, handler, "/api/choropleth", "gzip")
+		gotGzip := rec.Header().Get("Content-Encoding") == "gzip"
+
+		if gotGzip != mode.wantGzip {
+			t.Errorf("%s mode: compressed = %v, want %v", mode.name, gotGzip, mode.wantGzip)
+		}
+	}
+}
+
+// muxWithBigJSON is a router with one route returning a compressible payload.
+func muxWithBigJSON() *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/api/choropleth", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bigJSON()))
+	})
+	return r
+}
+
+// The nginx thresholds and the application's must agree, or a response is
+// compressed by one tier and not the other for no stated reason.
+func TestThresholdMatchesNginx(t *testing.T) {
+	conf, err := os.ReadFile(filepath.Join("..", "..", "deployments", "nginx.conf"))
+	if err != nil {
+		t.Skipf("could not read nginx.conf: %v", err)
+	}
+	want := "gzip_min_length " + strconv.Itoa(compressMinBytes) + ";"
+	if !strings.Contains(string(conf), want) {
+		t.Errorf("nginx.conf does not contain %q; the two tiers disagree on what is worth compressing", want)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -292,6 +292,22 @@ func (s *Server) Start() error {
 	return s.httpServer.ListenAndServe()
 }
 
+// rootHandler wraps the router in the middleware every request passes through.
+//
+// Compression is applied in server mode only. Desktop mode reaches the server
+// exclusively over loopback — it binds 127.0.0.1 and opens its own WebView onto
+// it — where there is no bandwidth to save, so compressing the full-Africa
+// choropleth would spend 230ms of CPU per request to speed up a transfer that
+// already takes milliseconds. Server mode is the one whose clients may be a
+// network away, and the one nginx sits in front of.
+func (s *Server) rootHandler() http.Handler {
+	var handler http.Handler = s.router
+	if !s.cfg.DesktopMode {
+		handler = compressResponses(handler)
+	}
+	return limitRequestBody(handler)
+}
+
 // newHTTPServer builds the main listener's configuration.
 //
 // Separate from Start so a test can inspect the address and the timeouts without
@@ -300,7 +316,7 @@ func (s *Server) newHTTPServer() *http.Server {
 	return &http.Server{
 		Addr: s.cfg.ListenAddress(),
 		// Every request goes through the body limit; see bodylimit.go.
-		Handler:     limitRequestBody(s.router),
+		Handler:     s.rootHandler(),
 		ReadTimeout: 15 * time.Second,
 		// WriteTimeout used to be disabled entirely, justified by a claim that
 		// the server "only listens on localhost" — which was not true: it bound
@@ -532,7 +548,10 @@ func (s *Server) rebuildRoutes() {
 	s.router = mux.NewRouter()
 	s.setupRoutes()
 	if s.httpServer != nil {
-		s.httpServer.Handler = limitRequestBody(s.router)
+		// rootHandler, not limitRequestBody alone: this is the second place the
+		// handler chain is assembled, and rebuilding it by hand here silently drops
+		// whatever middleware the first place added.
+		s.httpServer.Handler = s.rootHandler()
 	}
 }
 


### PR DESCRIPTION
Fixes #74

> Stacked on `security/bind-loopback` (→ gate → #96). GitHub retargets as each
> merges. Review bottom-up.

## Before and after

Measured against the real 3.4 GB datapack, `/api/choropleth` over the full Africa
bbox:

```
BEFORE  curl -H 'Accept-Encoding: gzip' -w '%{size_download}'
        size=5760913  time=4.03s

AFTER   size=1794404  time=4.24s      3.21x smaller, ~4 MB saved
AFTER   (no Accept-Encoding)
        size=5761072                  identity preserved
```

Response headers after: `Content-Encoding: gzip`, `Vary: Accept-Encoding`, and no
`Content-Length` — the handler's value described the uncompressed body.

`/api/columns`: 16,642 → 2,779 bytes (6.0x).

## The level was measured, not assumed

Go's `compress/gzip` on that exact payload:

| level | bytes | ratio | CPU |
|---|---|---|---|
| 1 | 2,074,170 | 2.78x | 100ms |
| 3 | 1,934,806 | 2.98x | 173ms |
| **5** | **1,794,866** | **3.21x** | **230ms** |
| 6 | 1,782,908 | 3.23x | 275ms |
| 9 | 1,773,189 | 3.25x | 294ms |

Level 1 looks like the best trade — 86% of the benefit for a third of the CPU —
and I nearly took it. It would have been a **regression**. nginx already
compresses these responses with `gzip_comp_level 6`, producing 1,810,329 bytes,
and nginx passes a body through untouched once `Content-Encoding` is set. Shipping
level 1 would hand hosted users 15% *more* bytes than they get today. Level 5 is
the lowest level that beats what nginx was already achieving.

Worth noting the issue estimated 10–20x. The real figure is **3.2x**: these
payloads carry many distinct float values, which deflate cannot do much with. Still
4 MB a request, but the estimate was optimistic and the ticket's "16.1 MB → ~1 MB"
should be read as "→ ~5 MB".

## Deliberately not compressed

Verified against the running server, not just asserted:

| | result |
|---|---|
| `/api/health` (16 bytes) | no `Content-Encoding`, `Content-Length: 16` |
| `/tiles/africa/3/4/4.pbf` | single gzip member, decodes to 31,124 bytes |
| binary content types | passed through |
| no/`identity`/`gzip;q=0` | passed through |

The tile case matters: those blobs are already gzipped on disk and the handler
declares it. Compressing again would produce a body no client can read.

**Not applied in desktop mode.** That build binds loopback and opens its own
WebView onto it, so there is no bandwidth to save; compressing the choropleth would
spend 230ms of CPU per request to speed up a transfer that already takes
milliseconds. `rootHandler` applies the middleware only when `DesktopMode` is
false.

## Security note (required by the issue)

Compression combined with secrets in a response body enables BREACH-style attacks:
an attacker who can inject content into a response and observe its compressed size
can infer a secret compressed alongside it.

**Not applicable today.** These endpoints are unauthenticated and return no
secrets, session tokens, or per-user data — the payloads are derived from a public
datapack and are identical for every caller. There is nothing secret to infer.

**Revisit if authentication is added.** If a response ever carries a CSRF token, a
session identifier, or per-user content, either exclude those responses from
compression or ensure the secret is not in a compressible body alongside
attacker-influenced input. Relevant to the authentication work in the security
tickets from the first review round.

## nginx

Already correct — `gzip on`, `gzip_proxied any`, `gzip_types application/json`,
`gzip_min_length 1024`, `gzip_vary on` all landed in #94, so that success criterion
was already met before I started. I only added a comment recording how the two
tiers now interact, because a reader finding compression in both places deserves to
know nginx is now the backstop rather than the mechanism.

## Verified

- 13 new tests in `internal/server`
- `go test ./...` — six packages pass; `go test -race` on `server` and `api` pass
- `golangci-lint run` — 0 issues; `gofmt` clean

One of the tests caught a genuine bug in my own code: I first rejected
`Accept-Encoding: gzip;q=0.01` by prefix-matching `q=0.0`, which means the opposite
of `q=0` — acceptable, barely. The quality value is now parsed as a float.

Also fixed while here: `rebuildRoutes` (called after a datapack install)
reassembled the handler chain by hand as `limitRequestBody(s.router)`. It now calls
the same `rootHandler` as startup — otherwise installing a datapack would silently
switch compression off for the rest of the process's life. That is the sort of
thing a second construction site always eventually does.

## A caveat on the timing column

Wall-clock is unchanged (4.03s → 4.24s) because these requests are dominated by
server-side computation, not transfer — on loopback. The 4 MB saved is the point,
and it is only visible to a client that is actually a network away. If we want the
4-second figure down, that is the sibling performance tickets, not this one.
