### PR TITLE
fix: keep demo tour state in memory instead of localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Three tracked Go files were not gofmt-clean** (`internal/api/handler.go` and two test
   files). Now formatted, and the pre-commit hook keeps them that way.
 - **Every shell script under `scripts/` is now shellcheck-clean** at warning severity.
+- **Starting a demo tour tried to write a multi-megabyte site to localStorage and blew
+  the quota.** The tour resets the walkthrough's ideal targets to current, then
+  persisted the whole site object into the `dt-sites` key "so it is available for the
+  rest of the session". The Africa walkthrough is 4,026,496 characters — roughly
+  7.7 MB in UTF-16 against a typical 5 MB per-origin quota — so the write could never
+  succeed, and it happened on a completely fresh profile before the user had created
+  anything of their own. The return value was ignored, so it failed silently.
+
+  The reset is presentation state for the current session and never needed to be
+  durable, so it now lives in an in-memory map that cannot fail and is gone on reload
+  — which is the intended lifetime, since the tour resets the targets again next time
+  it runs.
+
+  `getSite` gained a fallback to the session store and then the static walkthrough
+  JSON, because a demo site previously resolved *only* as a side effect of that
+  localStorage write; removing the write without this would have broken the tours.
+  The fallback is limited to known walkthrough ids so that looking up a deleted site
+  does not cost a 404. `DemoTour` also had its own copy of the fetch-and-normalise
+  logic `getSite` already implements, along with a progress step for a fetch that no
+  longer happens; both are gone rather than left as an unreachable branch.
+
 - `GOPATH` is set from the project root rather than `$PWD`, so running a Go command after
   `cd`-ing into a subdirectory no longer creates a second module cache there. Two had
   accumulated, under `frontend/` and `resources/mbtiles/`.

--- a/frontend/src/components/DemoTour.tsx
+++ b/frontend/src/components/DemoTour.tsx
@@ -14,7 +14,7 @@ import {
 import { AnimatePresence, motion, useDragControls } from 'framer-motion';
 import { FiX } from 'react-icons/fi';
 import { colors } from '../styles/colors';
-import { getSite, loadLocalSites, saveLocalSites, normalizeWalkthroughSite } from '../hooks/useApi';
+import { loadDemoSiteForTour } from '../hooks/useApi';
 import type { Site } from '../types';
 
 export interface DemoStep {
@@ -172,37 +172,12 @@ export default function DemoTour({
     setStep(nextStep);
   };
 
-  const loadDemoSite = async (): Promise<Site> => {
-    let site: Site | null = await getSite(siteId);
-
-    if (!site) {
-      setLoadStatus({ message: 'Fetching site data…', pct: 40 });
-      const response = await fetch(`/data/walkthroughs/${siteId}.json`);
-      if (!response.ok) throw new Error('Walkthrough site data not found');
-      site = normalizeWalkthroughSite({ ...await response.json() as Site, source: 'walkthrough' as const });
-    }
-
-    // Reset ideal (target) values to match current each time the tour starts
-    // so that any changes from a previous run do not carry over.
-    if (site.indicators?.current) {
-      site = {
-        ...site,
-        indicators: { ...site.indicators, ideal: { ...site.indicators.current } },
-      };
-    }
-
-    // Persist the reset state so it is available for the rest of the session.
-    const existingSites = loadLocalSites();
-    const siteIndex = existingSites.findIndex((s) => s.id === site!.id);
-    if (siteIndex >= 0) {
-      existingSites[siteIndex] = site;
-      saveLocalSites(existingSites);
-    } else {
-      saveLocalSites([...existingSites, site]);
-    }
-
-    return site;
-  };
+  // Resolving the site, resetting its targets and remembering it for the session
+  // all live in useApi.loadDemoSiteForTour — this component previously carried its
+  // own copy of the fetch-and-normalise logic that getSite already implements, and
+  // then persisted the whole site to localStorage, which for the 4 MB Africa
+  // walkthrough could not fit in the quota.
+  const loadDemoSite = (): Promise<Site> => loadDemoSiteForTour(siteId);
 
   // Automatically load and zoom to the walkthrough site when loadSiteStep is reached.
   useEffect(() => {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -602,6 +602,65 @@ function loadWalkthroughSites(): Promise<Site[]> {
   return _walkthroughSitesPromise;
 }
 
+// Session-scoped site overrides, held in memory only.
+//
+// Starting a demo tour resets the walkthrough's ideal targets to current, so that
+// changes from a previous run do not carry over. That reset used to be persisted
+// into the `dt-sites` localStorage key "so it is available for the rest of the
+// session" — but the Africa walkthrough is 4,026,496 characters, which is roughly
+// 7.7 MB in UTF-16 against a typical 5 MB quota. The write could never succeed,
+// and it happened on a fresh profile before the user had created anything.
+//
+// It never needed to be durable: it is presentation state for the current
+// session. A Map costs nothing, cannot fail, and is gone on reload — which is
+// exactly the intended lifetime, since the tour resets the targets again next
+// time it runs.
+const _sessionSites = new Map<string, Site>();
+
+// setSessionSite records a site for the rest of this page's lifetime without
+// persisting it. Used for read-only demo sites.
+export function setSessionSite(site: Site): void {
+  _sessionSites.set(site.id, site);
+  // A stale getSite result would otherwise mask this until the TTL expires.
+  _siteCache.delete(site.id);
+}
+
+// Exported for tests: nothing in the application clears these deliberately.
+//
+// The getSite cache is evicted for the same ids, or a later lookup would still
+// hand back the override this just dropped.
+export function clearSessionSites(): void {
+  for (const id of _sessionSites.keys()) _siteCache.delete(id);
+  _sessionSites.clear();
+}
+
+// loadDemoSiteForTour resolves a walkthrough site and resets its ideal targets to
+// match current, so that changes from a previous run of the tour do not carry
+// over.
+//
+// This lives here rather than inside DemoTour because the component had its own
+// copy of the fetch-and-normalise logic that getSite already implements, and
+// because the reset plus the session write is the part worth testing on its own.
+// Nothing is persisted: see the note on _sessionSites.
+export async function loadDemoSiteForTour(siteId: string): Promise<Site> {
+  // getSite resolves a walkthrough from the session store or the static file, so
+  // there is no second fetch to make here. DemoTour previously had one, along
+  // with a "Fetching site data…" progress step for it; both are gone rather than
+  // kept as an unreachable branch.
+  const loaded = await getSite(siteId);
+  if (!loaded) throw new Error('Walkthrough site data not found');
+
+  const site: Site = loaded.indicators?.current
+    ? {
+        ...loaded,
+        indicators: { ...loaded.indicators, ideal: { ...loaded.indicators.current } },
+      }
+    : loaded;
+
+  setSessionSite(site);
+  return site;
+}
+
 export async function listSites(): Promise<Site[]> {
   const [realSites, walkthroughSites] = await Promise.all([
     isBrowserRuntime() ? loadLocalSites() : fetchJSON<Site[]>(`${API_BASE}/sites`),
@@ -645,7 +704,22 @@ export async function getSite(id: string): Promise<Site | null> {
   const promise = (async (): Promise<Site | null> => {
     if (isBrowserRuntime()) {
       const sites = loadLocalSites();
-      return sites.find((site) => site.id === id) || null;
+      const stored = sites.find((site) => site.id === id);
+      if (stored) return stored;
+
+      // A session override, then the static walkthrough JSON. Without these a
+      // demo site resolved only because starting its tour had written the whole
+      // thing into localStorage; that write is gone, so look here instead of
+      // returning null and breaking the tour.
+      const session = _sessionSites.get(id);
+      if (session) return session;
+
+      // Only for a known demo id — fetching /data/walkthroughs/{id}.json for a
+      // real site id would just be a 404 on every lookup of a deleted site.
+      if ((WALKTHROUGH_SITE_IDS as readonly string[]).includes(id)) {
+        return loadWalkthroughSite(id);
+      }
+      return null;
     }
     const response = await fetch(`${API_BASE}/sites/${id}`);
     if (response.status === 404) return null;

--- a/frontend/src/test/sessionSites.test.ts
+++ b/frontend/src/test/sessionSites.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getSite,
+  setSessionSite,
+  clearSessionSites,
+  loadLocalSites,
+  loadDemoSiteForTour,
+} from '../hooks/useApi';
+import { AFRICA_SITE_ID, SHAI_HILLS_SITE_ID } from '../constants/walkthroughSites';
+import type { Site } from '../types';
+
+// Starting a demo tour reset the walkthrough's ideal targets to current and then
+// wrote the whole site into the `dt-sites` localStorage key "so it is available
+// for the rest of the session". The Africa walkthrough is 4,026,496 characters —
+// roughly 7.7 MB in UTF-16 against a typical 5 MB quota — so the write could
+// never succeed, and it happened on a fresh profile before the user had created
+// anything of their own.
+//
+// The reset is presentation state for the current session, so it now lives in
+// memory. These tests pin the two halves of that: nothing is written to
+// localStorage, and a demo site is still resolvable afterwards — which matters,
+// because getSite used to find it only because the tour had persisted it.
+
+const SITE_KEY = 'dt-sites';
+
+function walkthroughJSON(): Record<string, unknown> {
+  return {
+    id: AFRICA_SITE_ID,
+    title: 'Africa walkthrough',
+    indicators: {
+      current: { NPP_gm2: 400 },
+      ideal: { NPP_gm2: 999 },
+    },
+  };
+}
+
+describe('session-scoped demo sites', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearSessionSites();
+    delete window.__DECISION_THEATRE_WEBVIEW__; // browser runtime
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes(`/data/walkthroughs/${AFRICA_SITE_ID}.json`)) {
+          return new Response(JSON.stringify(walkthroughJSON()), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearSessionSites();
+    window.localStorage.clear();
+  });
+
+  // The reason the old write existed. If this fails, removing it broke the tour.
+  it('resolves a walkthrough site with nothing in localStorage', async () => {
+    expect(loadLocalSites()).toEqual([]);
+
+    const site = await getSite(AFRICA_SITE_ID);
+
+    expect(site).not.toBeNull();
+    expect(site?.id).toBe(AFRICA_SITE_ID);
+  });
+
+  it('does not write the site to localStorage when resolving it', async () => {
+    await getSite(AFRICA_SITE_ID);
+
+    expect(window.localStorage.getItem(SITE_KEY)).toBeNull();
+    expect(loadLocalSites()).toEqual([]);
+  });
+
+  it('returns the session override in preference to the static file', async () => {
+    const reset = {
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 400 } },
+    } as unknown as Site;
+
+    setSessionSite(reset);
+    const site = await getSite(AFRICA_SITE_ID);
+
+    // The tour's reset — ideal equal to current — rather than the baked 999.
+    expect(site?.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+  });
+
+  it('keeps the override out of localStorage', () => {
+    setSessionSite(walkthroughJSON() as unknown as Site);
+
+    expect(window.localStorage.getItem(SITE_KEY)).toBeNull();
+  });
+
+  // A session store that outlived the session would be a cache with no
+  // invalidation, and the tour resets the targets on every run anyway.
+  it('forgets overrides once cleared, as a reload would', async () => {
+    setSessionSite({
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 1 } },
+    } as unknown as Site);
+    clearSessionSites();
+
+    const site = await getSite(AFRICA_SITE_ID);
+
+    // Back to the file's own values.
+    expect(site?.indicators?.ideal).toEqual({ NPP_gm2: 999 });
+  });
+
+  // A real site the user deleted must not cost a 404 on every lookup.
+  it('does not fetch a walkthrough file for an unknown site id', async () => {
+    const site = await getSite('11111111-2222-3333-4444-555555555555');
+
+    expect(site).toBeNull();
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const walkthroughFetches = calls.filter((c) => String(c[0]).includes('/data/walkthroughs/'));
+    expect(walkthroughFetches).toEqual([]);
+  });
+
+  // A site the user really owns still comes from localStorage, unchanged.
+  it('prefers a stored real site over everything else', async () => {
+    const own = { id: 'own-site', title: 'Mine' } as unknown as Site;
+    window.localStorage.setItem(SITE_KEY, JSON.stringify([own]));
+
+    const site = await getSite('own-site');
+
+    expect(site?.title).toBe('Mine');
+  });
+});
+
+// The tour's own load path — the thing that actually blew the quota. It used to
+// live inline in DemoTour, where it could only be reached by rendering the whole
+// component and driving it to the right step.
+describe('loadDemoSiteForTour', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearSessionSites();
+    delete window.__DECISION_THEATRE_WEBVIEW__;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes(`/data/walkthroughs/${AFRICA_SITE_ID}.json`)) {
+          return new Response(JSON.stringify(walkthroughJSON()), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearSessionSites();
+    window.localStorage.clear();
+  });
+
+  it('writes nothing to localStorage', async () => {
+    await loadDemoSiteForTour(AFRICA_SITE_ID);
+
+    expect(window.localStorage.getItem(SITE_KEY)).toBeNull();
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it('resets ideal targets to current, so a previous run does not carry over', async () => {
+    const site = await loadDemoSiteForTour(AFRICA_SITE_ID);
+
+    // The file bakes ideal at 999; the tour must start from current.
+    expect(site.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+  });
+
+  it('makes the reset visible to the rest of the session', async () => {
+    await loadDemoSiteForTour(AFRICA_SITE_ID);
+
+    const later = await getSite(AFRICA_SITE_ID);
+    expect(later?.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+  });
+
+  it('throws when the walkthrough file is missing, rather than resolving null', async () => {
+    await expect(loadDemoSiteForTour(SHAI_HILLS_SITE_ID)).rejects.toThrow(
+      /Walkthrough site data not found/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #66

Independent of the security stack — branched from `main`, so it can merge in any
order.

## The fault

Starting a demo tour reset the walkthrough's ideal targets to current, then
persisted the whole site into the `dt-sites` localStorage key "so it is available
for the rest of the session".

```
$ wc -c data/walkthroughs/6dede7c6-8eb3-47a8-a678-16c610b551e6.json
4026496
```

localStorage is counted in UTF-16 code units, so that is roughly **7.7 MB against a
typical 5 MB per-origin quota**. The write could never succeed. It happened on a
completely fresh profile, before the user had created anything of their own, and
`saveLocalSites`' return value was ignored — so it failed silently, which is most
of why this reaches us as "the app is flaky" rather than as a storage complaint.

## The fix

The reset is presentation state for the current session. It never needed to be
durable, so it now lives in an in-memory `Map`: it cannot fail, costs nothing, and
is gone on reload — which is exactly the intended lifetime, because the tour resets
the targets again on the next run.

## The part that would have broken it

The obvious change — delete the write — breaks every tour, and this is worth
spelling out because the issue proposed exactly that.

`getSite` in browser runtime read *only* localStorage. A demo site was resolvable
later in the session **solely as a side effect of that write**. Remove the write
and `getSite` returns `null` for the walkthrough id.

So `getSite` now falls back to the session store, then to the static walkthrough
JSON. That fallback is limited to the four known walkthrough ids, or every lookup of
a site the user had deleted would cost a 404 against
`/data/walkthroughs/{id}.json`.

The load-bearing test is *"resolves a walkthrough site with nothing in
localStorage"*. If that ever fails, the tours are broken.

## Two things removed rather than kept

- `DemoTour` had its own copy of the fetch-and-normalise logic `getSite` already
  implements. The tour's load path moved into `useApi.loadDemoSiteForTour`, which
  also made the actual bug unit-testable — it previously sat in a closure reachable
  only by rendering the component and driving it to the right step.
- Once `getSite` resolves walkthroughs, the `"Fetching site data…"` progress step
  covered a fetch that no longer happens. A test caught this by failing, and the
  dead branch is gone rather than papered over. The tour still shows
  "Loading site…" → "Opening on map…" → "Zooming to site…".

## Verified

11 new tests. Checked against the unfixed code by restoring the `saveLocalSites`
write and removing the `getSite` fallback — six fail:

```
× resolves a walkthrough site with nothing in localStorage
× returns the session override in preference to the static file
× forgets overrides once cleared, as a reload would
× loadDemoSiteForTour > writes nothing to localStorage
× loadDemoSiteForTour > resets ideal targets to current
× loadDemoSiteForTour > makes the reset visible to the rest of the session
```

- `npx vitest run` — 5 files, 21 tests pass (baseline was 4 files, 10 tests)
- `npx tsc --noEmit` — clean

I also dropped one test I had written that asserted the file is fetched only once:
it passed or failed depending on test order, because `getSite`'s module-level cache
survives between tests. It was testing incidental caching rather than this bug. That
did surface a real wart, though — `clearSessionSites` left a stale `getSite` cache
entry behind, so it now evicts those ids too.

## Not in scope

- **#67** (silent quota failures) is largely already handled: `saveLocalSites`
  returns a boolean, retries with the per-catchment breakdown stripped, and
  `IndicatorEditorPage` raises a "Storage full" toast. What remains are the six
  `catch { /* ignore */ }` pane- and page-state writes in `types/index.ts` and the
  startup storage-health check. Worth reducing #67 to that.
- **The frontend has no eslint at all.** `npm run lint` is in `package.json` but
  cannot run — there is no eslint config anywhere in the repo, and neither
  pre-commit nor CI invokes it. The CI job named `lint-frontend`, which is a
  required check, runs `npx tsc --noEmit` and nothing else, so the name promises
  more than it delivers. Same on `main`, so not caused here, and the typecheck I ran
  is exactly what that job runs — but no TypeScript in this repo has ever been
  linted. Wants its own issue.
