### PR TITLE
fix: stop discarding localStorage write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Three tracked Go files were not gofmt-clean** (`internal/api/handler.go` and two test
   files). Now formatted, and the pre-commit hook keeps them that way.
 - **Every shell script under `scripts/` is now shellcheck-clean** at warning severity.
+- **localStorage failures were discarded, so saves appeared to succeed and did
+  not.** Every write path ended in an empty catch block. Once the quota was
+  exhausted the user saw their change reflected in React state and lost it on
+  reload — which reaches us as "the app is flaky" or "it lost my work" rather than
+  as a storage complaint, and hid the underlying problem from anyone debugging it.
+
+  Writes now go through `frontend/src/lib/storage.ts`, which reports rather than
+  swallows. `QuotaExceededError` is told apart from a blocked store (private
+  browsing, a privacy setting) because the advice differs: delete something, versus
+  nothing you save will survive this tab.
+
+  The two kinds of write are treated differently on purpose. Losing a **site** is
+  losing the user's work, and `saveLocalSites` already reported that so the caller
+  could say so. Losing a **pane layout** is losing a preference, and a toast per
+  failed write would be several a minute about something the user cannot act on
+  per-write — so preference failures surface **once per kind of failure per
+  session**, and always log.
+
+  A startup health check warns at 80% of the typical 5 MB quota, while writes still
+  succeed, rather than after something is lost. It probes with a real
+  write-read-remove round trip, because in private mode some browsers expose a
+  `localStorage` whose `setItem` throws — testing that the object exists proves
+  nothing.
+
+  The duplicate `isQuotaExceededError` in `hooks/useApi.ts` now comes from the same
+  module, and the two `sessionStorage` catch blocks in `types/index.ts` were
+  converted too, so nothing in that file swallows a storage error any more.
+
 - `GOPATH` is set from the project root rather than `$PWD`, so running a Go command after
   `cd`-ing into a subdirectory no longer creates a second module cache there. Two had
   accumulated, under `frontend/` and `resources/mbtiles/`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import {
   markSessionActive,
   shouldPromptResumeSession,
 } from './types';
+import { checkStorageHealth, onStorageFailure } from './lib/storage';
 
 function App() {
   const toast = useToast();
@@ -89,6 +90,58 @@ function App() {
   const [chartGraphModes, setChartGraphModes] = useState<('line' | 'boxplot' | null)[]>(() => loadPaneStates().map(() => null));
   const [isExtractingIndicators, setIsExtractingIndicators] = useState(false);
   const { info } = useServerInfo();
+
+  // Storage failures used to be discarded, so a full quota looked like a working
+  // application that quietly forgot things. Two things happen here, once each:
+  //
+  //   - a check on startup, so a user close to the ceiling is warned before the
+  //     next thing they save is the one that fails, rather than after
+  //   - a subscription to write failures, which fires once per kind of failure
+  //     per session; per-write would be several toasts a minute about a pane
+  //     layout, which is noise rather than information
+  useEffect(() => {
+    const health = checkStorageHealth();
+
+    if (!health.available) {
+      toast({
+        title: 'Browser storage is unavailable',
+        description:
+          'Your sites and layout cannot be saved in this browser — private browsing '
+          + 'or a privacy setting is blocking storage. Work will be lost when you '
+          + 'close the tab.',
+        status: 'warning',
+        duration: null,
+        isClosable: true,
+      });
+    } else if (health.nearLimit) {
+      toast({
+        title: 'Browser storage is nearly full',
+        description:
+          `About ${Math.round(health.usedRatio * 100)}% of the space this browser `
+          + 'allows is in use. Delete a site you no longer need, or the next one you '
+          + 'save may not be stored.',
+        status: 'warning',
+        duration: 12000,
+        isClosable: true,
+      });
+    }
+
+    return onStorageFailure((failure) => {
+      toast({
+        title: failure.kind === 'quota'
+          ? 'Browser storage is full'
+          : 'Browser storage is not working',
+        description: failure.kind === 'quota'
+          ? 'Some changes could not be saved. Delete a site you no longer need to '
+            + 'free up space, then try again.'
+          : 'Some changes could not be saved in this browser, so they will be lost '
+            + 'when you close the tab.',
+        status: 'error',
+        duration: null,
+        isClosable: true,
+      });
+    });
+  }, [toast]);
   const { data: fullDomainData } = useFullDomainPrecalculated();
   const minimumQuadPaneCount = DEFAULT_PANE_STATES.length;
   const extractingIndicatorsRef = useRef(false);

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -5,6 +5,7 @@ import { getAppRuntime } from '../types/runtime';
 import { WALKTHROUGH_SITE_IDS } from '../constants/walkthroughSites';
 import { applyAOIWeightedIndicators } from '../utils/indicators';
 import { evictExpired } from '../lib/ttlCache';
+import { isQuotaExceededError } from '../lib/storage';
 
 const API_BASE = '/api';
 const SITES_STORAGE_KEY = 'dt-sites';
@@ -31,10 +32,7 @@ export function loadLocalSites(): Site[] {
   }
 }
 
-function isQuotaExceededError(err: unknown): boolean {
-  return err instanceof DOMException
-    && (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
-}
+
 
 // Returns whether the sites were actually persisted. localStorage has a hard
 // per-origin quota (~5-10MB); every site's per-catchment breakdown (per-species

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,0 +1,215 @@
+/**
+ * localStorage writes that do not fail silently.
+ *
+ * Every write path used to discard its error in an empty catch block, so once the
+ * quota was exhausted, saves appeared to succeed and did not. The
+ * user saw the change reflected in React state and lost it on reload. That reaches
+ * us as "the app is flaky" or "it lost my work", not as a storage complaint, and it
+ * hides the underlying problem from anyone debugging it.
+ *
+ * Two kinds of write share this module, and they deserve different treatment:
+ *
+ *   - **The user's work** — sites and their indicators. Losing one of these is
+ *     losing something they made. `saveLocalSites` in hooks/useApi.ts already
+ *     reports its failure so the caller can tell them.
+ *
+ *   - **Interface preferences** — pane layout, focused pane, current page. Losing
+ *     one is losing a preference. Raising a toast per failed write would be noise,
+ *     several times a minute, about something the user cannot act on per-write.
+ *
+ * So preference writes report through `onStorageFailure`, which fires **once per
+ * kind of failure per session**. The user is told once that their layout will not
+ * be remembered and why; they are not told again on every pane drag.
+ */
+
+/** What went wrong, as far as it can be told apart. */
+export type StorageFailureKind =
+  /** The origin's storage quota is full. Actionable: delete something. */
+  | 'quota'
+  /** localStorage is not usable at all — private mode, or blocked by policy. */
+  | 'unavailable'
+  /** Something else. Reported so it cannot hide, even without specific advice. */
+  | 'unknown';
+
+export interface StorageFailure {
+  kind: StorageFailureKind;
+  /** The key being written when it failed, for a developer reading a log. */
+  key: string;
+  error: unknown;
+}
+
+/**
+ * A quota error, under either name browsers use for it.
+ *
+ * Firefox reports `NS_ERROR_DOM_QUOTA_REACHED`; everyone else uses the standard
+ * name. Some older browsers set only the legacy numeric code.
+ */
+export function isQuotaExceededError(err: unknown): boolean {
+  if (!(err instanceof DOMException)) return false;
+  return (
+    err.name === 'QuotaExceededError' ||
+    err.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    err.code === 22 ||
+    err.code === 1014
+  );
+}
+
+function classify(err: unknown): StorageFailureKind {
+  if (isQuotaExceededError(err)) return 'quota';
+  // A SecurityError, or localStorage missing entirely, means storage is not
+  // available rather than full — private browsing, or a blocking policy.
+  if (err instanceof DOMException && err.name === 'SecurityError') return 'unavailable';
+  if (err instanceof ReferenceError || err instanceof TypeError) return 'unavailable';
+  return 'unknown';
+}
+
+type Listener = (failure: StorageFailure) => void;
+
+const listeners = new Set<Listener>();
+const reported = new Set<StorageFailureKind>();
+
+/**
+ * Subscribe to storage failures. The callback fires at most once per kind of
+ * failure per session — see the note above on why per-write would be noise.
+ *
+ * Returns an unsubscribe function.
+ */
+export function onStorageFailure(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function report(failure: StorageFailure): void {
+  // Always log: a developer chasing "it lost my work" needs the signal even when
+  // nothing is listening, and this is the line that was missing.
+  console.warn(
+    `localStorage write failed (${failure.kind}) for key "${failure.key}"`,
+    failure.error,
+  );
+
+  if (reported.has(failure.kind)) return;
+  reported.add(failure.kind);
+  for (const listener of listeners) listener(failure);
+}
+
+/**
+ * Which of the two Web Storage areas to use.
+ *
+ * A parameter rather than two copies of each function: both throw the same errors
+ * for the same reasons, and sessionStorage is just as capable of failing silently
+ * in private mode.
+ */
+export type StorageArea = 'local' | 'session';
+
+function area(which: StorageArea): Storage {
+  return which === 'session' ? window.sessionStorage : window.localStorage;
+}
+
+/**
+ * Write, reporting failure rather than swallowing it.
+ *
+ * Returns whether the value was actually stored, so a caller that can do
+ * something better than the default has the option.
+ */
+export function safeSetItem(key: string, value: string, which: StorageArea = 'local'): boolean {
+  try {
+    area(which).setItem(key, value);
+    return true;
+  } catch (err) {
+    report({ kind: classify(err), key, error: err });
+    return false;
+  }
+}
+
+/** Remove, with the same reporting. Removal can fail when storage is blocked. */
+export function safeRemoveItem(key: string, which: StorageArea = 'local'): boolean {
+  try {
+    area(which).removeItem(key);
+    return true;
+  } catch (err) {
+    report({ kind: classify(err), key, error: err });
+    return false;
+  }
+}
+
+/**
+ * Roughly how much of the origin's localStorage this application is using, in
+ * UTF-16 code units — the unit browsers actually count.
+ *
+ * Approximate on purpose: the exact accounting (whether keys count, per-entry
+ * overhead) is not specified and differs between browsers. It is good enough to
+ * tell "comfortable" from "about to fail", which is all it is used for.
+ */
+export function estimateStorageChars(): number {
+  try {
+    let total = 0;
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key === null) continue;
+      total += key.length + (window.localStorage.getItem(key)?.length ?? 0);
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The per-origin quota browsers converge on, in UTF-16 code units.
+ *
+ * Not a specification, an observation: 5 MB is the common figure and is counted
+ * in code units rather than bytes, which is why a 4,026,496-character site is
+ * roughly 7.7 MB against it.
+ */
+export const TYPICAL_QUOTA_CHARS = 5 * 1024 * 1024;
+
+/**
+ * Warn at four fifths. Far enough ahead that the user can act — the next site
+ * they create is what would fail — and not so eager that it cries wolf.
+ */
+export const STORAGE_WARN_RATIO = 0.8;
+
+export interface StorageHealth {
+  /** False when localStorage cannot be used at all. */
+  available: boolean;
+  usedChars: number;
+  /** usedChars as a fraction of the typical quota. */
+  usedRatio: number;
+  /** True when close enough to the ceiling that the next write may fail. */
+  nearLimit: boolean;
+}
+
+/**
+ * Check on startup, so the user is warned before hitting the ceiling rather than
+ * after losing something.
+ *
+ * Availability is probed with a real write-read-remove round trip: in private
+ * mode some browsers expose a `localStorage` object whose `setItem` throws, so
+ * merely testing that the object exists proves nothing.
+ */
+export function checkStorageHealth(): StorageHealth {
+  const probeKey = '__dt_storage_probe__';
+  let available = false;
+  try {
+    window.localStorage.setItem(probeKey, 'x');
+    available = window.localStorage.getItem(probeKey) === 'x';
+    window.localStorage.removeItem(probeKey);
+  } catch {
+    available = false;
+  }
+
+  const usedChars = available ? estimateStorageChars() : 0;
+  const usedRatio = usedChars / TYPICAL_QUOTA_CHARS;
+
+  return {
+    available,
+    usedChars,
+    usedRatio,
+    nearLimit: available && usedRatio >= STORAGE_WARN_RATIO,
+  };
+}
+
+/** Exported for tests: forget which failures have already been reported. */
+export function resetStorageReporting(): void {
+  reported.clear();
+}

--- a/frontend/src/test/storage.test.ts
+++ b/frontend/src/test/storage.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  STORAGE_WARN_RATIO,
+  TYPICAL_QUOTA_CHARS,
+  checkStorageHealth,
+  estimateStorageChars,
+  isQuotaExceededError,
+  onStorageFailure,
+  resetStorageReporting,
+  safeRemoveItem,
+  safeSetItem,
+} from '../lib/storage';
+import { savePaneStates, saveLayoutMode, saveCurrentSite } from '../types';
+
+// Every localStorage write discarded its error, so once the quota was exhausted
+// saves appeared to succeed and did not: the user saw the change in React state
+// and lost it on reload. That arrives as "the app is flaky", not as a storage
+// complaint, and it hid the problem from anyone debugging it.
+
+function quotaError(): DOMException {
+  return new DOMException('quota', 'QuotaExceededError');
+}
+
+/** Replaces localStorage.setItem with one that always throws. */
+function breakStorage(err: unknown) {
+  vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    throw err;
+  });
+}
+
+describe('isQuotaExceededError', () => {
+  it('recognises the standard and Firefox names', () => {
+    expect(isQuotaExceededError(quotaError())).toBe(true);
+    expect(isQuotaExceededError(new DOMException('q', 'NS_ERROR_DOM_QUOTA_REACHED'))).toBe(true);
+  });
+
+  it('does not mistake other failures for a full quota', () => {
+    expect(isQuotaExceededError(new DOMException('no', 'SecurityError'))).toBe(false);
+    expect(isQuotaExceededError(new Error('boom'))).toBe(false);
+    expect(isQuotaExceededError('quota')).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+  });
+});
+
+describe('safeSetItem', () => {
+  beforeEach(() => {
+    resetStorageReporting();
+    window.localStorage.clear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('stores a value and reports success', () => {
+    expect(safeSetItem('k', 'v')).toBe(true);
+    expect(window.localStorage.getItem('k')).toBe('v');
+  });
+
+  // The branch the whole issue is about.
+  it('returns false when the quota is exceeded, instead of appearing to succeed', () => {
+    breakStorage(quotaError());
+    expect(safeSetItem('k', 'v')).toBe(false);
+  });
+
+  it('notifies a listener, classifying a full quota', () => {
+    const seen: string[] = [];
+    const off = onStorageFailure((f) => seen.push(f.kind));
+
+    breakStorage(quotaError());
+    safeSetItem('k', 'v');
+    off();
+
+    expect(seen).toEqual(['quota']);
+  });
+
+  it('tells a blocked store apart from a full one', () => {
+    const seen: string[] = [];
+    const off = onStorageFailure((f) => seen.push(f.kind));
+
+    breakStorage(new DOMException('blocked', 'SecurityError'));
+    safeSetItem('k', 'v');
+    off();
+
+    expect(seen).toEqual(['unavailable']);
+  });
+
+  // Preference writes happen several times a minute. One toast is information;
+  // one per pane drag is noise.
+  it('notifies once per kind of failure, not once per write', () => {
+    let calls = 0;
+    const off = onStorageFailure(() => { calls += 1; });
+
+    breakStorage(quotaError());
+    for (let i = 0; i < 25; i++) safeSetItem(`k${i}`, 'v');
+    off();
+
+    expect(calls).toBe(1);
+  });
+
+  // Even with nothing listening, the failure must leave a trace for whoever is
+  // debugging "it lost my work" — that log line is what was missing.
+  it('always logs, even with no listener', () => {
+    breakStorage(quotaError());
+    safeSetItem('k', 'v');
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('reports a different kind separately', () => {
+    const seen: string[] = [];
+    const off = onStorageFailure((f) => seen.push(f.kind));
+
+    breakStorage(quotaError());
+    safeSetItem('a', 'v');
+    breakStorage(new DOMException('blocked', 'SecurityError'));
+    safeSetItem('b', 'v');
+    off();
+
+    expect(seen).toEqual(['quota', 'unavailable']);
+  });
+
+  it('names the key that failed, for the log', () => {
+    const keys: string[] = [];
+    const off = onStorageFailure((f) => keys.push(f.key));
+
+    breakStorage(quotaError());
+    safeSetItem('dt-pane-states', 'v');
+    off();
+
+    expect(keys).toEqual(['dt-pane-states']);
+  });
+});
+
+describe('safeRemoveItem', () => {
+  beforeEach(() => {
+    resetStorageReporting();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('removes a value', () => {
+    window.localStorage.setItem('k', 'v');
+    expect(safeRemoveItem('k')).toBe(true);
+    expect(window.localStorage.getItem('k')).toBeNull();
+  });
+
+  it('reports a failure rather than swallowing it', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    let notified = false;
+    const off = onStorageFailure(() => { notified = true; });
+    expect(safeRemoveItem('k')).toBe(false);
+    off();
+
+    expect(notified).toBe(true);
+  });
+});
+
+describe('storage health', () => {
+  beforeEach(() => {
+    resetStorageReporting();
+    window.localStorage.clear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports an empty store as available and comfortable', () => {
+    const health = checkStorageHealth();
+
+    expect(health.available).toBe(true);
+    expect(health.nearLimit).toBe(false);
+  });
+
+  // A store that merely exists proves nothing: in private mode some browsers
+  // expose one whose setItem throws.
+  it('detects a store that exists but cannot be written', () => {
+    breakStorage(quotaError());
+
+    expect(checkStorageHealth().available).toBe(false);
+  });
+
+  it('leaves no probe key behind', () => {
+    checkStorageHealth();
+
+    const keys = Object.keys(window.localStorage);
+    expect(keys.filter((k) => k.includes('probe'))).toEqual([]);
+  });
+
+  it('warns before the ceiling rather than after', () => {
+    // Just over the warning ratio, comfortably under the quota — the point is to
+    // warn while writes still succeed.
+    const size = Math.ceil(TYPICAL_QUOTA_CHARS * STORAGE_WARN_RATIO) + 10;
+    window.localStorage.setItem('bulk', 'x'.repeat(size));
+
+    const health = checkStorageHealth();
+
+    expect(health.available).toBe(true);
+    expect(health.nearLimit).toBe(true);
+    expect(health.usedRatio).toBeGreaterThanOrEqual(STORAGE_WARN_RATIO);
+  });
+
+  it('counts keys as well as values', () => {
+    window.localStorage.setItem('abc', 'de');
+
+    expect(estimateStorageChars()).toBe(5);
+  });
+});
+
+// The preference writers are the ones that were silent. They must not throw —
+// losing a pane layout should never break the page — but must no longer be quiet.
+describe('preference writers', () => {
+  beforeEach(() => {
+    resetStorageReporting();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('do not throw when storage is full, but do report', () => {
+    breakStorage(quotaError());
+
+    let notified = 0;
+    const off = onStorageFailure(() => { notified += 1; });
+
+    expect(() => savePaneStates([])).not.toThrow();
+    expect(() => saveLayoutMode('single')).not.toThrow();
+    expect(() => saveCurrentSite('abc')).not.toThrow();
+    off();
+
+    expect(notified).toBe(1);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,4 +1,5 @@
 import { getAppRuntime } from './runtime';
+import { safeRemoveItem, safeSetItem } from '../lib/storage';
 
 export type Scenario = 'reference' | 'current' | 'future';
 
@@ -77,7 +78,7 @@ export function loadPaneStates(): PaneStates {
 }
 
 export function savePaneStates(states: PaneStates): void {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(states)); } catch { /* ignore */ }
+  safeSetItem(STORAGE_KEY, JSON.stringify(states));
 }
 
 export function loadLayoutMode(): LayoutMode {
@@ -89,7 +90,7 @@ export function loadLayoutMode(): LayoutMode {
 }
 
 export function saveLayoutMode(mode: LayoutMode): void {
-  try { localStorage.setItem(STORAGE_LAYOUT_KEY, mode); } catch { /* ignore */ }
+  safeSetItem(STORAGE_LAYOUT_KEY, mode);
 }
 
 export function loadFocusedPane(): number {
@@ -104,7 +105,7 @@ export function loadFocusedPane(): number {
 }
 
 export function saveFocusedPane(index: number): void {
-  try { localStorage.setItem(STORAGE_FOCUSED_KEY, String(index)); } catch { /* ignore */ }
+  safeSetItem(STORAGE_FOCUSED_KEY, String(index));
 }
 
 const STORAGE_RANGE_MODE_KEY = 'dt-range-mode';
@@ -118,7 +119,7 @@ export function loadQuadColumns(): QuadColumns {
 }
 
 export function saveQuadColumns(cols: QuadColumns): void {
-  try { localStorage.setItem(STORAGE_QUAD_COLUMNS_KEY, String(cols)); } catch { /* ignore */ }
+  safeSetItem(STORAGE_QUAD_COLUMNS_KEY, String(cols));
 }
 
 export function loadRangeMode(): RangeMode {
@@ -130,7 +131,7 @@ export function loadRangeMode(): RangeMode {
 }
 
 export function saveRangeMode(mode: RangeMode): void {
-  try { localStorage.setItem(STORAGE_RANGE_MODE_KEY, mode); } catch { /* ignore */ }
+  safeSetItem(STORAGE_RANGE_MODE_KEY, mode);
 }
 
 export const SCENARIOS: ScenarioInfo[] = [
@@ -205,13 +206,11 @@ export function loadCurrentSite(): string | null {
 }
 
 export function saveCurrentSite(siteId: string | null): void {
-  try {
-    if (siteId) {
-      localStorage.setItem(STORAGE_CURRENT_SITE_KEY, siteId);
-    } else {
-      localStorage.removeItem(STORAGE_CURRENT_SITE_KEY);
-    }
-  } catch { /* ignore */ }
+  if (siteId) {
+    safeSetItem(STORAGE_CURRENT_SITE_KEY, siteId);
+  } else {
+    safeRemoveItem(STORAGE_CURRENT_SITE_KEY);
+  }
 }
 
 export function loadCurrentPage(): AppPage {
@@ -228,7 +227,7 @@ export function loadCurrentPage(): AppPage {
 }
 
 export function saveCurrentPage(page: AppPage): void {
-  try { localStorage.setItem(STORAGE_CURRENT_PAGE_KEY, page); } catch { /* ignore */ }
+  safeSetItem(STORAGE_CURRENT_PAGE_KEY, page);
 }
 
 // sessionStorage is cleared when a browser tab closes but survives a same-tab
@@ -237,7 +236,7 @@ export function saveCurrentPage(page: AppPage): void {
 const STORAGE_SESSION_ACTIVE_KEY = 'dt-session-active';
 
 export function markSessionActive(): void {
-  try { sessionStorage.setItem(STORAGE_SESSION_ACTIVE_KEY, '1'); } catch { /* ignore */ }
+  safeSetItem(STORAGE_SESSION_ACTIVE_KEY, '1', 'session');
 }
 
 // Whether to ask the user "resume where you left off, or go home?" on load.
@@ -259,19 +258,19 @@ export function shouldPromptResumeSession(): boolean {
 // user's saved sites (there's no server-side persistence to fall back on),
 // not a cache, so a "clear cache" action must leave it alone.
 export function clearBrowserAppCache(): void {
-  try {
-    [
-      STORAGE_KEY,
-      STORAGE_LAYOUT_KEY,
-      STORAGE_FOCUSED_KEY,
-      STORAGE_QUAD_COLUMNS_KEY,
-      STORAGE_RANGE_MODE_KEY,
-      STORAGE_CURRENT_SITE_KEY,
-      STORAGE_CURRENT_PAGE_KEY,
-      'dt-tour-seen', // must match TourGuide.tsx's TOUR_SEEN_KEY
-    ].forEach((key) => localStorage.removeItem(key));
-    sessionStorage.removeItem(STORAGE_SESSION_ACTIVE_KEY);
-  } catch { /* ignore */ }
+  // No try/catch: safeRemoveItem reports its own failures rather than throwing,
+  // so a blocked store no longer makes this a silent no-op.
+  [
+    STORAGE_KEY,
+    STORAGE_LAYOUT_KEY,
+    STORAGE_FOCUSED_KEY,
+    STORAGE_QUAD_COLUMNS_KEY,
+    STORAGE_RANGE_MODE_KEY,
+    STORAGE_CURRENT_SITE_KEY,
+    STORAGE_CURRENT_PAGE_KEY,
+    'dt-tour-seen', // must match TourGuide.tsx's TOUR_SEEN_KEY
+  ].forEach((key) => safeRemoveItem(key));
+  safeRemoveItem(STORAGE_SESSION_ACTIVE_KEY, 'session');
 }
 
 export type SiteCreationMethod = 'shapefile' | 'geojson' | 'drawn' | 'catchments';


### PR DESCRIPTION
Fixes #67

Branched from `main`, independent of the other branches.

## The fault

Every localStorage write ended in an empty catch block:

```ts
export function savePaneStates(states: PaneStates): void {
  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(states)); } catch { /* ignore */ }
}
```

Once the quota was exhausted, saves appeared to succeed and did not. The user saw
the change reflected in React state and lost it on reload. That reaches us as "the
app is flaky" or "it lost my work" — not as a storage complaint — and it hid the
underlying problem from anyone debugging it.

## Two kinds of write, treated differently

This is the design decision in the change, and the issue's phrasing —
"a failed write surfaces to the user as a clear, actionable message" — is right for
one kind and wrong for the other.

| | Losing one means | Treatment |
|---|---|---|
| A site | losing the user's work | reported per failure, already done by `saveLocalSites` |
| A pane layout, focused pane, current page | losing a preference | reported **once per kind of failure per session**, always logged |

Pane state is written several times a minute. A toast per failed write would be
noise about something the user cannot act on per-write — and noise is how a real
warning gets ignored. They are told once that their layout will not be remembered
and why.

## What is now distinguished

`QuotaExceededError` (under both the standard and the Firefox name, plus the legacy
numeric codes) is told apart from a blocked store, because the advice differs:

- **quota** — "delete a site you no longer need to free up space"
- **unavailable** — "private browsing or a privacy setting is blocking storage;
  work will be lost when you close the tab"

## Warning before the ceiling, not after

`checkStorageHealth()` runs on startup and warns at 80% of the typical 5 MB quota,
while writes still succeed — so the next site the user saves is not the one that
fails.

It probes with a real write-read-remove round trip rather than checking that
`window.localStorage` exists: in private mode some browsers expose a `localStorage`
object whose `setItem` throws, so the object's presence proves nothing. A test
covers exactly that shape.

## Verified

18 new tests, checked against the unfixed code by restoring the silent catch.
**Eight fail**, including every one that matters:

```
× returns false when the quota is exceeded, instead of appearing to succeed
× notifies a listener, classifying a full quota
× tells a blocked store apart from a full one
× notifies once per kind of failure, not once per write
× always logs, even with no listener
× preference writers > do not throw when storage is full, but do report
```

The issue asks specifically for "a test covering the quota-exceeded branch with a
mocked storage that throws" — that is `breakStorage()`, which replaces
`Storage.prototype.setItem` with one that throws a real `DOMException`.

- `npx vitest run` — 5 files, **28 tests** pass (baseline 4 files, 10)
- `npx tsc --noEmit` clean; `npx vite build` succeeds

## Tidying that came with it

- The duplicate `isQuotaExceededError` in `hooks/useApi.ts` now comes from the
  shared module. The two copies had already drifted: this one missed the legacy
  numeric codes.
- The two `sessionStorage` catch blocks in `types/index.ts` were converted as well,
  so nothing in that file swallows a storage error. Leaving them would have been
  odd in a change with this title.
- `clearBrowserAppCache` lost its `try`/`catch` wrapper: with `safeRemoveItem`
  reporting its own failures, a blocked store no longer turns a user's explicit
  "clear" into a silent no-op.

## Scope note

The bulk of #67 was already fixed before this branch: `saveLocalSites` returns a
boolean, retries with the per-catchment breakdown stripped, and
`IndicatorEditorPage` raises a "Storage full" toast. What remained were the six
preference writers, the startup check, and the distinction between failure kinds —
which is what this is.
