### PR TITLE
fix: derive the build version from the declaration, not the newest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,14 @@ jobs:
             exit 1
           fi
 
+
+      # version.sh reported `git describe` alone, which names the newest *tag*.
+      # With flake.nix declaring 0.4.0 and the newest tag v0.2.2, every local
+      # build called itself 0.2.2-... while `nix build` called the same source
+      # 0.4.0. A second of shell, and invisible until two binaries are compared.
+      - name: Shell script tests
+        run: ./scripts/tests/version-test.sh
+
   # ==========================================
   # Go lint
   # ==========================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A local build and a nix build of the same commit reported different release
+  numbers.** `scripts/version.sh` — which the Makefile and every packaging script
+  use, so that they cannot disagree — reported `git describe` alone, and
+  `git describe` names the newest *tag*. `flake.nix` declares **0.4.0** and the
+  newest tag is **v0.2.2**, so `make build` produced a binary calling itself
+  `0.2.2-115-g1311b8a` while `nix build`, which takes its version from
+  `flake.nix`, called the identical source `0.4.0`.
+
+  The declared version now leads and git's position follows it —
+  `0.4.0-115-g1311b8a`, `0.4.0-115-g1311b8a-dirty`, or plain `0.4.0` on a clean
+  checkout of the matching tag or outside a git checkout entirely. `flake.nix`
+  remains the one place a release number is written; `version.sh --declared`
+  reports it without the suffix, and `scripts/doctor.sh` now asks for it rather
+  than growing a second grep of `flake.nix`.
+
+  `dt doctor` also reports when the declared version has no tag — the condition
+  that caused this, and one that is otherwise invisible until two binaries are
+  compared. `scripts/tests/version-test.sh` covers the behaviour in throwaway
+  repositories; 8 of its 11 cases fail against the previous script.
+
 - **Switching sites coloured the map from the previous site.** `applyColors` was
   memoised on `[colorScaleMode, colorScaleType]` while its body read the `siteId`
   prop in ten places — the choropleth fetch for both panes, the browser-runtime

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GOLINT := golangci-lint
 
 .PHONY: all app build build-backend build-frontend clean
 .PHONY: run serve dev dev-backend dev-frontend dev-all
-.PHONY: test test-frontend test-all
+.PHONY: test test-frontend test-all test-scripts
 .PHONY: fmt lint check deps
 .PHONY: doctor doctor-deep sync-flake check-flake verify-flake hooks vendor-fonts
 .PHONY: protect-branch
@@ -131,7 +131,13 @@ test:
 test-frontend:
 	cd $(FRONTEND_DIR) && npx vitest run
 
-test-all: test test-frontend
+## test-scripts: Tests for the shell scripts. Currently version.sh, which had
+## every build path reporting a release number that came from the newest tag
+## rather than the declared one.
+test-scripts:
+	@./scripts/tests/version-test.sh
+
+test-all: test test-frontend test-scripts
 
 # ============================
 # Code quality

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -147,7 +147,9 @@ ui_blank
 # -----------------------------------------------------------------------------
 ui_group "VERSIONS"
 
-flake_version="$(grep -oE '^ *version = "[^"]+";' flake.nix | head -1 | sed -E 's/.*"(.*)".*/\1/')"
+# scripts/version.sh owns how the declaration is stored; asking it rather than
+# grepping flake.nix again keeps one reader of that file.
+flake_version="$("$SCRIPT_DIR/version.sh" --declared 2>/dev/null || true)"
 pkg_version="$(jq -r '.version // empty' frontend/package.json 2>/dev/null || true)"
 lock_version="$(jq -r '.version // empty' frontend/package-lock.json 2>/dev/null || true)"
 git_version="$("$SCRIPT_DIR/version.sh" 2>/dev/null || echo "unknown")"
@@ -171,7 +173,16 @@ for pair in "frontend/package.json:$pkg_version" "frontend/package-lock.json:$lo
     fi
 done
 
-ui_note "git describe" "$git_version"
+ui_note "build version" "$git_version"
+
+# The declared version having no tag is why a local build and a nix build used
+# to disagree, and it is invisible until someone compares two binaries.
+if [ -n "$flake_version" ] && git rev-parse -q --verify "refs/tags/v$flake_version" > /dev/null 2>&1; then
+    ui_ok "tag v$flake_version" "exists"
+elif [ -n "$flake_version" ]; then
+    ui_warn "tag v$flake_version" "does not exist yet" \
+        "the declared version has not been released; builds report it with a git suffix"
+fi
 
 # The CHANGELOG should have a section for the version being declared.
 if [ -f CHANGELOG.md ]; then

--- a/scripts/shell-help.sh
+++ b/scripts/shell-help.sh
@@ -54,7 +54,8 @@ COMMANDS=(
 
     "TEST|dt test|Go tests with race detector and coverage"
     "TEST|dt test-frontend|Frontend tests (vitest)"
-    "TEST|dt test-all|Both suites"
+    "TEST|dt test-scripts|Tests for the shell scripts"
+    "TEST|dt test-all|All three suites"
     "TEST|nix flake check|Every check, in a sandbox"
 
     "DIAGNOSE|dt run --diag|Report what the desktop window resolved its layout to"

--- a/scripts/tests/version-test.sh
+++ b/scripts/tests/version-test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# =============================================================================
+# version-test.sh — scripts/version.sh must always lead with the declared
+# version, whatever git says.
+#
+# The bug this guards against: version.sh reported `git describe` alone, which
+# names the nearest *tag*. flake.nix declared 0.4.0, the newest tag was v0.2.2,
+# and so `make build` produced a binary calling itself 0.2.2-115-g1311b8a while
+# `nix build` called the identical source 0.4.0.
+#
+# Each case builds a throwaway repository under a temp directory and runs the
+# real script against it, so nothing here depends on the state of this checkout.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL="$SCRIPT_DIR/../version.sh"
+
+passed=0
+failed=0
+
+fail() {
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' "$1" "$2" "$3"
+    failed=$((failed + 1))
+}
+
+ok() {
+    printf '  ok    %s\n' "$1"
+    passed=$((passed + 1))
+}
+
+# A fresh repository with the declared version and whatever history is asked for.
+make_repo() {
+    local dir="$1" declared="$2"
+    mkdir -p "$dir/scripts"
+    cp "$REAL" "$dir/scripts/version.sh"
+    printf '{\n  outputs = { ... }: {\n    version = "%s";\n  };\n}\n' "$declared" > "$dir/flake.nix"
+    git -C "$dir" init -q
+    git -C "$dir" config user.email t@example.com
+    git -C "$dir" config user.name Test
+    git -C "$dir" add -A
+    git -C "$dir" commit -qm "first"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- the declaration is what a clean tagged checkout reports -----------------
+d="$TMP/tagged"
+make_repo "$d" "0.4.0"
+git -C "$d" tag v0.4.0
+got="$("$d/scripts/version.sh")"
+[ "$got" = "0.4.0" ] && ok "clean checkout of the matching tag" \
+    || fail "clean checkout of the matching tag" "0.4.0" "$got"
+
+# --- the declaration wins over an older tag ---------------------------------
+# This is the actual bug: the tag says 0.2.2, the declaration says 0.4.0.
+d="$TMP/behind"
+make_repo "$d" "0.4.0"
+git -C "$d" tag v0.2.2
+git -C "$d" commit -q --allow-empty -m second
+git -C "$d" commit -q --allow-empty -m third
+got="$("$d/scripts/version.sh")"
+case "$got" in
+    0.4.0-2-g*) ok "declaration leads, git position follows ($got)" ;;
+    *) fail "declaration leads when the newest tag is older" "0.4.0-2-g<sha>" "$got" ;;
+esac
+case "$got" in
+    *0.2.2*) fail "the stale tag must not appear" "no 0.2.2" "$got" ;;
+    *) ok "the stale tag does not appear in the version" ;;
+esac
+
+# --- uncommitted changes are visible ----------------------------------------
+d="$TMP/dirty"
+make_repo "$d" "0.4.0"
+git -C "$d" tag v0.4.0
+echo "change" >> "$d/flake.nix.note"
+git -C "$d" add -A
+echo "more" >> "$d/flake.nix.note"
+got="$("$d/scripts/version.sh")"
+case "$got" in
+    *-dirty) ok "a dirty tree is marked ($got)" ;;
+    *) fail "a dirty tree is marked" "*-dirty" "$got" ;;
+esac
+case "$got" in
+    0.4.0*) ok "a dirty tree still leads with the declaration" ;;
+    *) fail "a dirty tree still leads with the declaration" "0.4.0*" "$got" ;;
+esac
+
+# --- no tags at all ---------------------------------------------------------
+d="$TMP/untagged"
+make_repo "$d" "0.4.0"
+got="$("$d/scripts/version.sh")"
+case "$got" in
+    0.4.0-g*) ok "an untagged repository is identifiable ($got)" ;;
+    *) fail "an untagged repository is identifiable" "0.4.0-g<sha>" "$got" ;;
+esac
+
+# --- not a git checkout at all (a source tarball) ---------------------------
+d="$TMP/notgit"
+make_repo "$d" "0.4.0"
+rm -rf "$d/.git"
+got="$("$d/scripts/version.sh")"
+[ "$got" = "0.4.0" ] && ok "a source tarball reports the declaration" \
+    || fail "a source tarball reports the declaration" "0.4.0" "$got"
+
+# --- --declared ------------------------------------------------------------
+d="$TMP/declared"
+make_repo "$d" "1.2.3"
+git -C "$d" commit -q --allow-empty -m second
+got="$("$d/scripts/version.sh" --declared)"
+[ "$got" = "1.2.3" ] && ok "--declared omits the git suffix" \
+    || fail "--declared omits the git suffix" "1.2.3" "$got"
+
+# --- a leading v in the declaration is stripped ------------------------------
+d="$TMP/vprefix"
+make_repo "$d" "v0.4.0"
+got="$("$d/scripts/version.sh" --declared)"
+[ "$got" = "0.4.0" ] && ok "a declared leading v is stripped" \
+    || fail "a declared leading v is stripped" "0.4.0" "$got"
+
+# --- failure modes are loud -------------------------------------------------
+d="$TMP/noversion"
+make_repo "$d" "0.4.0"
+printf '{ outputs = { ... }: { }; }\n' > "$d/flake.nix"
+if "$d/scripts/version.sh" > /dev/null 2>&1; then
+    fail "a flake with no version attribute fails" "non-zero exit" "exit 0"
+else
+    ok "a flake with no version attribute fails loudly"
+fi
+
+d="$TMP/badarg"
+make_repo "$d" "0.4.0"
+"$d/scripts/version.sh" --nonsense > /dev/null 2>&1
+[ "$?" = "2" ] && ok "an unknown argument exits 2" \
+    || fail "an unknown argument exits 2" "2" "$?"
+
+printf '\n  %d passed, %d failed\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,14 +7,92 @@ set -euo pipefail
 # Called by the Makefile and by every build/packaging script, so a binary
 # reports the same version no matter which of them produced it.
 #
-# The leading "v" that `git describe` inherits from the tag is stripped here:
-# main.go prints "Decision Theatre v%s", and the deb/rpm/msi manifests prefix
-# their own "v" too, so carrying it in the string produced "vv0.2.1-...".
-# Nix builds take their version from flake.nix, which is already bare.
+# The declared version lives in flake.nix and nowhere else. This script reads it
+# and appends git's position relative to the nearest tag, so a development build
+# is identifiable without inventing a second place to state the release number:
+#
+#   0.4.0                  a clean checkout of the tag matching the declaration
+#   0.4.0-115-g1311b8a     115 commits past the nearest tag
+#   0.4.0-115-g1311b8a-dirty   ... with uncommitted changes
+#   0.4.0                  not a git checkout at all (a source tarball)
+#
+# It used to report `git describe` alone, which named the nearest *tag*. With
+# the declaration at 0.4.0 and the newest tag v0.2.2, every local build called
+# itself 0.2.2-115-g1311b8a while `nix build` — which takes its version from
+# flake.nix — called the same source 0.4.0. Two builds of one commit disagreed
+# about which release they were.
+#
+#   version.sh              the full build version, as above
+#   version.sh --declared   just the declared version, with no git suffix
+#
+# --declared exists so that nothing else has to know how flake.nix stores it;
+# scripts/doctor.sh and deployments/Dockerfile ask for it rather than each
+# growing their own grep.
+#
+# The leading "v" that a tag carries is stripped: main.go prints
+# "Decision Theatre v%s", and the deb/rpm/msi manifests prefix their own "v"
+# too, so carrying it in the string produced "vv0.2.1-...".
 # =============================================================================
 
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 
-version="$(git describe --tags --always --dirty 2>/dev/null || echo "dev")"
+# The declaration. flake.nix is the one place the release number is written.
+declared="$(sed -nE 's/^ *version = "([^"]+)";.*/\1/p' flake.nix | head -1)"
 
-printf '%s\n' "${version#v}"
+if [ -z "$declared" ]; then
+    echo "version.sh: no version attribute found in flake.nix" >&2
+    exit 1
+fi
+
+if [ "${1:-}" = "--declared" ]; then
+    printf '%s\n' "${declared#v}"
+    exit 0
+fi
+
+if [ $# -gt 0 ]; then
+    echo "version.sh: unknown argument '$1' (expected --declared or nothing)" >&2
+    exit 2
+fi
+
+declared="${declared#v}"
+
+# Outside a git checkout — a source tarball, or a build context without .git —
+# the declaration is all there is, and it is the right answer.
+described="$(git describe --tags --always --dirty 2>/dev/null || true)"
+if [ -z "$described" ]; then
+    printf '%s\n' "$declared"
+    exit 0
+fi
+
+# Replace whatever tag git named with the declared version, keeping the
+# position suffix. `git describe` produces one of:
+#
+#   v0.2.2                     exactly at a tag
+#   v0.2.2-115-g1311b8a        115 commits past it
+#   1311b8a                    no tags reachable (--always fell back to a sha)
+#   ...-dirty                  any of the above, with uncommitted changes
+suffix=""
+case "$described" in
+    *-*-g*)
+        # Everything from the commit count onwards.
+        suffix="-$(printf '%s' "$described" | sed -E 's/^.*-([0-9]+-g[0-9a-f]+(-dirty)?)$/\1/')"
+        ;;
+    *-dirty)
+        base="${described%-dirty}"
+        # A bare sha with no tag behind it still deserves to be identifiable.
+        case "$base" in
+            *[!0-9.v]*) [ "$base" != "${base#v}" ] || suffix="-g$base" ;;
+        esac
+        suffix="${suffix}-dirty"
+        ;;
+    *)
+        # A bare sha rather than a tag: no dots, and not the tag we expect.
+        case "$described" in
+            v*) ;;
+            *.*) ;;
+            *) suffix="-g$described" ;;
+        esac
+        ;;
+esac
+
+printf '%s%s\n' "$declared" "$suffix"


### PR DESCRIPTION
## Two builds of one commit disagreed about which release they were

`scripts/version.sh` exists so that the Makefile and every packaging script
cannot disagree about what a binary is. It reported `git describe` alone — and
`git describe` names the newest **tag**.

`flake.nix` declares **0.4.0**. The newest tag is **v0.2.2**. So:

| built with | reported |
|---|---|
| `make build` | `0.2.2-115-g1311b8a` |
| `nix build` (takes its version from `flake.nix`) | `0.4.0` |
| `docker compose` (never passes `VERSION`) | `dev` |

Three answers for one commit, and nothing anywhere said so. For a support
conversation that starts "which version are you running", that is the wrong
number to be unsure about.

## The declaration leads, git's position follows

```
0.4.0                      clean checkout of the matching tag
0.4.0-115-g1311b8a         115 commits past the nearest tag
0.4.0-115-g1311b8a-dirty   ... with uncommitted changes
0.4.0                      not a git checkout at all (a source tarball)
```

`flake.nix` stays the one place a release number is written — this adds no
second file to keep in step. `version.sh --declared` reports it without the
suffix, and `scripts/doctor.sh` now asks for that rather than growing its own
grep of `flake.nix`, so there is one reader of that declaration instead of two.

## `dt doctor` reports the condition that caused it

```
  · build version               0.4.0-114-gc113daf-dirty
  ! tag v0.4.0                  does not exist yet
                                the declared version has not been released;
                                builds report it with a git suffix
```

A warning, not an error: an unreleased declaration is a normal state between
releases. What was not normal was being unable to tell.

## Tests

`scripts/tests/version-test.sh` builds throwaway repositories and runs the real
script against them — a tagged checkout, a checkout behind an older tag, a dirty
tree, an untagged repository, a source tarball with no `.git`, `--declared`, a
declaration carrying a leading `v`, a flake with no version attribute, and an
unknown argument.

**8 of its 11 cases fail against the previous script.** It runs in
`dt test-scripts`, in `dt test-all`, and as a step in the existing `file-checks`
CI job — a second of shell, in a job that already exists, rather than a new one.

## Verified

The built binary reports `Decision Theatre v0.4.0-114-gc113daf-dirty` where it
previously reported `0.2.2-...`.

## Not in this PR

`docker compose` still never passes `VERSION`, so an image built the compose way
reports `dev`. Fixing that means touching `deployments/`, which
`fix/container-webkit-alignment` and `feat/nix-container-image` are both already
changing — it belongs with one of those or after them, not here.


## Against #49

`Refs #49`, not `Fixes` — two of its five criteria are untouched.

| | Criterion |
|---|---|
| ☑ | One authoritative version location is chosen and documented — `flake.nix`, stated in the `version.sh` header |
| ◐ | All other locations derive from it, or a release script verifies they agree and fails if not — `version.sh` and `doctor.sh` now derive from it; `frontend/package.json` and `package-lock.json` still declare independently and `dt doctor` reports the disagreement rather than failing a release |
| ◐ | The `v` prefix is stripped consistently — stripped here, in both the declaration and the tag; the MSI and nfpm interpolations were not audited |
| ☐ | A real generated GUID replaces the placeholder `UpgradeCode` — not touched |
| ☐ | `nix build && ./result/bin/decision-theatre --version` reports the real version — likely already true, since the nix build takes its version from `flake.nix`, but I could not run a nix build in my environment to confirm it |

The half-open boxes are why this does not close the issue.
