### PR TITLE
change label to use detailed column name

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,9 +15,9 @@ import IndicatorEditorPage from './components/IndicatorEditorPage';
 import DownloadPage from './components/DownloadPage';
 import FeedbackLink from './components/FeedbackLink';
 import ResumeSessionModal from './components/ResumeSessionModal';
-import { patchSite, patchSiteIndicators, useServerInfo, getSite, useFullDomainPrecalculated, primeSiteCatchmentsFromEmbedded, loadLocalSites, saveLocalSites } from './hooks/useApi';
+import { patchSite, patchSiteIndicators, useServerInfo, getSite, useFullDomainPrecalculated, primeSiteCatchmentsFromEmbedded, loadLocalSites, saveLocalSites, useAttributeDetails, useAttributeVariableTypes, useAttributeUserInputs } from './hooks/useApi';
 import { getAppRuntime } from './types/runtime';
-import { showTargetWarningsPopup } from './utils/warnings';
+import { showTargetWarningsPopup, showLowDataAvailabilityWarning, computeIndicatorAvailabilityFraction } from './utils/warnings';
 import type { Scenario, LayoutMode, QuadColumns, PaneStates, ComparisonState, AppPage, Site, IdentifyResult, MapExtent, MapStatistics, ColorScaleMode, ColorScaleType, RangeMode, ViewMode } from './types';
 import {
   DEFAULT_PANE_STATES,
@@ -42,6 +42,14 @@ import { checkStorageHealth, onStorageFailure } from './lib/storage';
 
 function App() {
   const toast = useToast();
+  const { details: attributeDetails, loading: attributeDetailsLoading } = useAttributeDetails();
+  const { variableTypes, loading: variableTypesLoading } = useAttributeVariableTypes();
+  const { userInputs, loading: userInputsLoading } = useAttributeUserInputs();
+  const catalogLoadingRef = useRef(true);
+  catalogLoadingRef.current = attributeDetailsLoading || variableTypesLoading || userInputsLoading;
+  const catalogRef = useRef({ attributeDetails, variableTypes, userInputs });
+  catalogRef.current = { attributeDetails, variableTypes, userInputs };
+  const dataAvailabilityWarnedSiteRef = useRef<string | null>(null);
   const { isOpen: isDocsOpen, onToggle: onToggleDocs, onClose: onCloseDocs } = useDisclosure({ defaultIsOpen: false });
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(loadLayoutMode);
   const [quadColumns, setQuadColumns] = useState<QuadColumns>(loadQuadColumns);
@@ -252,6 +260,17 @@ function App() {
     setIsExtractingIndicators(false);
   }, []);
 
+  // Warn once per site, right when its indicators first finish extracting (which
+  // happens immediately after site creation), rather than waiting for the user to
+  // visit the indicator editor page.
+  const maybeWarnLowDataAvailability = useCallback((site: Site) => {
+    if (!site.indicators || dataAvailabilityWarnedSiteRef.current === site.id || catalogLoadingRef.current) return;
+    dataAvailabilityWarnedSiteRef.current = site.id;
+    const { attributeDetails, variableTypes, userInputs } = catalogRef.current;
+    const fraction = computeIndicatorAvailabilityFraction(site.indicators, attributeDetails, variableTypes, userInputs);
+    showLowDataAvailabilityWarning(fraction, toast);
+  }, [toast]);
+
   const startBackgroundIndicatorExtraction = useCallback((site: Site | null, options?: { force?: boolean }) => {
     const force = options?.force ?? false;
     if (!site || (!force && site.indicators) || !site.catchmentIds?.length) return;
@@ -299,6 +318,7 @@ function App() {
             });
           }
           setCurrentSite((prev) => (prev?.id === siteId ? updatedSite : prev));
+          maybeWarnLowDataAvailability(updatedSite);
         })
         .catch((err) => console.error('Browser indicator extraction failed:', err))
         .finally(stopExtractionPolling);
@@ -326,13 +346,15 @@ function App() {
         const updatedSite = await r.json() as Site;
         if (updatedSite.indicators) {
           stopExtractionPolling();
-          setCurrentSite((prev) => (prev?.id === siteId ? { ...updatedSite, thumbnail } : prev));
+          const siteWithThumbnail = { ...updatedSite, thumbnail };
+          setCurrentSite((prev) => (prev?.id === siteId ? siteWithThumbnail : prev));
+          maybeWarnLowDataAvailability(siteWithThumbnail);
         }
       } catch {
         // network hiccup — retry next tick
       }
     }, 1000);
-  }, [stopExtractionPolling, toast]);
+  }, [stopExtractionPolling, toast, maybeWarnLowDataAvailability]);
 
   // Auto-extract indicators when a site is opened that has catchments but no indicators yet
   useEffect(() => {

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -652,7 +652,7 @@ function ChartView({
     );
     if (!hasData) return null;
 
-    const xLabel = axisLabels[attribute] ?? attribute.replace(/_/g, ' ');
+    const xLabel = resolveAxisLabelForColumn(attribute, xAxisLabels) ?? attribute.replace(/_/g, ' ');
     const chartType = 'line';
 
     return {
@@ -664,7 +664,7 @@ function ChartView({
         typeof idealVal === 'number' && Number.isFinite(idealVal) ? idealVal : null,
       ] as (number | null)[],
     };
-  }, [attribute, axisLabels, rangeMode, mapStatistics, leftScenario, rightScenario, siteIndicators, catchmentData, summaryRangeData, targetHasBeenUpdated]);
+  }, [attribute, xAxisLabels, rangeMode, mapStatistics, leftScenario, rightScenario, siteIndicators, catchmentData, summaryRangeData, targetHasBeenUpdated]);
 
   // Build grouped chart data for all columns where Grouping variable matches the selected group.
   const groupedChartData = useMemo(() => {
@@ -1628,7 +1628,8 @@ function ChartView({
                   xref: 'paper',
                   yref: 'paper',
                   x: 0.5,
-                  y: -0.18,
+                  y: 0,
+                  yshift: -45,
                   showarrow: false,
                   font: { color: '#a0aec0', size: 13 },
                 },

--- a/frontend/src/components/IndicatorEditorPage.tsx
+++ b/frontend/src/components/IndicatorEditorPage.tsx
@@ -51,7 +51,7 @@ import {
 import type { Site, SiteIndicators, AppPage } from '../types';
 import { getAppRuntime } from '../types/runtime';
 import { useAttributeDetails, useAttributeUserInputs, useAttributeVariableTypes, loadLocalSites, saveLocalSites } from '../hooks/useApi';
-import { showTargetWarningsPopup, showLowDataAvailabilityWarning } from '../utils/warnings';
+import { showTargetWarningsPopup } from '../utils/warnings';
 import { colors } from '../styles/colors';
 
 const MotionTr = motion(Tr);
@@ -275,9 +275,9 @@ export default function IndicatorEditorPage({
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
   const lastCatchmentCountRef = useRef<number | null>(null);
   const toast = useToast();
-  const { details: attributeDetails, loading: attributeDetailsLoading } = useAttributeDetails();
-  const { userInputs, loading: userInputsLoading } = useAttributeUserInputs();
-  const { variableTypes, loading: variableTypesLoading } = useAttributeVariableTypes();
+  const { details: attributeDetails } = useAttributeDetails();
+  const { userInputs } = useAttributeUserInputs();
+  const { variableTypes } = useAttributeVariableTypes();
 
   const headerBg = useColorModeValue('gray.900', 'gray.900');
   const tableBg = useColorModeValue('gray.850', 'gray.850');
@@ -867,26 +867,6 @@ export default function IndicatorEditorPage({
 
     return { total: keys.length, improved, degraded, unchanged };
   }, [localIndicators, availableIndicatorKeys]);
-
-  // Warn once per site when few of the app's known indicators actually have
-  // reference-period data for it (mirrors the Above/Below/At Reference tiles
-  // above: their combined count over the total is exactly this fraction).
-  // Fires whether indicators were just extracted or were already cached from
-  // an earlier visit, since either way this is the first time this component
-  // has seen this site's real coverage. Gated on the attribute catalog hooks
-  // having finished loading — until then availableIndicatorKeys only reflects
-  // this site's own keys, understating the true (much larger) catalog total
-  // and producing a falsely reassuring ratio.
-  const dataAvailabilityWarnedSiteRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (attributeDetailsLoading || userInputsLoading || variableTypesLoading) return;
-    if (!summaryStats || summaryStats.total === 0) return;
-    if (dataAvailabilityWarnedSiteRef.current === site.id) return;
-    dataAvailabilityWarnedSiteRef.current = site.id;
-
-    const availableFraction = (summaryStats.improved + summaryStats.degraded + summaryStats.unchanged) / summaryStats.total;
-    showLowDataAvailabilityWarning(availableFraction, toast);
-  }, [summaryStats, site.id, toast, attributeDetailsLoading, userInputsLoading, variableTypesLoading]);
 
   if (isLoading && !localIndicators) {
     return (

--- a/frontend/src/utils/warnings.ts
+++ b/frontend/src/utils/warnings.ts
@@ -36,6 +36,45 @@ export function showTargetWarningsPopup(warnings: string[] | undefined, toast: T
 // value for a site, warn that the site sits mostly outside the dataset's covered area.
 const LOW_DATA_AVAILABILITY_THRESHOLD = 0.2;
 
+interface IndicatorMaps {
+  reference?: Record<string, number>;
+  current?: Record<string, number>;
+  ideal?: Record<string, number>;
+}
+
+// Fraction of the app's known indicators that resolve both a reference and current
+// value for a site. Mirrors IndicatorEditorPage's summary tiles: the denominator is
+// every key the catalog (or the site itself) knows about, the numerator is how many
+// of those a site actually has data for.
+export function computeIndicatorAvailabilityFraction(
+  indicators: IndicatorMaps | null | undefined,
+  attributeDetails: Record<string, string>,
+  variableTypes: Record<string, string>,
+  userInputs: Record<string, boolean>,
+): number | undefined {
+  if (!indicators) return undefined;
+
+  const allKeys = new Set<string>();
+  Object.keys(indicators.reference || {}).forEach((k) => allKeys.add(k));
+  Object.keys(indicators.current || {}).forEach((k) => allKeys.add(k));
+  Object.keys(indicators.ideal || {}).forEach((k) => allKeys.add(k));
+  Object.keys(attributeDetails || {}).forEach((k) => allKeys.add(k));
+  Object.keys(variableTypes || {}).forEach((k) => allKeys.add(k));
+  Object.keys(userInputs || {}).forEach((k) => allKeys.add(k));
+
+  const keys = Array.from(allKeys)
+    .filter((key) => key.trim() !== '' && key.toLowerCase() !== 'catchid' && key.toLowerCase() !== 'catchment_id');
+  if (keys.length === 0) return undefined;
+
+  const available = keys.filter((key) => {
+    const ref = indicators.reference?.[key] ?? null;
+    const cur = indicators.current?.[key] ?? null;
+    return ref !== null && cur !== null;
+  }).length;
+
+  return available / keys.length;
+}
+
 export function showLowDataAvailabilityWarning(dataAvailability: number | undefined, toast: ToastFn): void {
   if (dataAvailability === undefined || dataAvailability >= LOW_DATA_AVAILABILITY_THRESHOLD) {
     return;


### PR DESCRIPTION
Chart x-axis now uses the "Detailed name" metadata column (Ticket #171)
- Single-indicator chart's x-axis label now pulls from the "Detailed name" CSV column (via xAxisLabels), matching what the grouped chart already did, instead of the "axis label" column.
- Fixed a layout bug where that label was invisible in single-pane view (though visible in grid view) — it was positioned as a Plotly annotation at a height-relative offset (y: -0.18 of plot height), so it got clipped once the pane was tall enough. Now uses a fixed pixel offset (yshift: -45) so it renders consistently at any pane size.

Low-data-availability warning now fires right after site creation
- Previously only shown when a user opened a site's indicator editor page. Now fires as soon as background indicator extraction completes (which happens automatically right after site creation), so users see it immediately instead of needing to navigate into the indicator view.