### PR TITLE
feat(ci): add --no-strict to protect-branch.sh for batch merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/protect-branch.sh --no-strict`**, for batch merges. Strict protection
+  requires a branch to be up to date with `main` before it can merge, so with several
+  green pull requests waiting, merging the first makes every other one stale: five
+  ready pull requests become five sequential update-and-wait-for-CI cycles.
+
+  `--no-strict` drops only the up-to-dateness requirement. Every check is still
+  required and must still have passed — the only thing given up is the demand that it
+  passed against the newest `main`. That is a real if small risk, since two changes can
+  each be green alone and broken together, so it is meant for a deliberate batch with
+  `main` checked afterwards, never as a standing setting. Running the script with no
+  arguments restores strictness, which is what the batch caller relies on.
+
+  `--help` no longer reads a hardcoded line range, which the new paragraph would have
+  silently truncated.
+
 - **The flake can no longer fall out of step with the Go and npm manifests.** `flake.nix`
   pins two fixed-output hashes — `vendorHash` from `go.mod`/`go.sum`, `npmDepsHash` from
   `frontend/package-lock.json`. A fixed-output derivation is only revalidated when its

--- a/scripts/protect-branch.sh
+++ b/scripts/protect-branch.sh
@@ -36,6 +36,24 @@ set -euo pipefail
 #   ./scripts/protect-branch.sh                   apply it
 #   ./scripts/protect-branch.sh --require-review 1
 #   ./scripts/protect-branch.sh --branch develop
+#   ./scripts/protect-branch.sh --no-strict      apply without up-to-dateness
+#   ./scripts/protect-branch.sh --strict         the default, stated explicitly
+#
+# WHY --no-strict EXISTS
+#
+# Strict means a branch must be up to date with main before it can merge. With
+# several green pull requests waiting, merging the first makes every other one
+# out of date, so each merge needs a round of "update branch" and a full CI run
+# before the next can go. Five ready pull requests become five sequential CI
+# cycles.
+#
+# --no-strict turns off only that up-to-dateness requirement, for the length of
+# a batch merge. Every check is still required and still has to have passed; the
+# only thing dropped is the demand that it passed against the newest main. That
+# is a real, small risk — two changes can each be green alone and broken
+# together — so it belongs to a deliberate batch with main checked afterwards,
+# never as a standing setting. Restore it with --strict, or by running this
+# script with no arguments at all.
 #
 # Needs an authenticated `gh` with admin rights on the repository.
 # =============================================================================
@@ -51,11 +69,16 @@ cd "$PROJECT_ROOT"
 BRANCH="main"
 REVIEWS=0
 MODE="apply"
+# The safe value is the default: a run with no arguments restores strictness,
+# which is what the batch-merge caller relies on to put it back.
+STRICT="true"
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --show) MODE="show" ;;
         --dry-run) MODE="dry-run" ;;
+        --no-strict) STRICT="false" ;;
+        --strict) STRICT="true" ;;
         --branch)
             BRANCH="${2:?--branch needs a name}"
             shift
@@ -65,7 +88,11 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h | --help)
-            sed -n '4,44p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            # Derived from the rules rather than a hardcoded range: this was
+            # '4,44p', and the paragraph added above would have silently cut the
+            # end off --help. The same lesson as scripts/run-app.sh.
+            awk '/^# ={10,}$/ { rules++; next } rules == 1' "${BASH_SOURCE[0]}" |
+                sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -157,7 +184,12 @@ ui_group "WILL REQUIRE"
 for c in "${CHECKS[@]}"; do
     ui_ok "$c" "must pass"
 done
-ui_note "strict" "the branch must be up to date with $BRANCH before merging"
+if [ "$STRICT" = "true" ]; then
+    ui_note "strict" "the branch must be up to date with $BRANCH before merging"
+else
+    ui_warn "strict" "OFF — checks are still required, up-to-dateness is not" \
+        "for a batch merge only; re-run without --no-strict to restore it"
+fi
 ui_note "admins" "included — the setting is meaningless otherwise"
 ui_note "approvals" "$REVIEWS"
 
@@ -168,8 +200,9 @@ PAYLOAD="$(python3 -c '
 import json, sys
 contexts = json.loads(sys.argv[1])
 reviews = int(sys.argv[2])
+strict = sys.argv[3] == "true"
 print(json.dumps({
-    "required_status_checks": {"strict": True, "contexts": contexts},
+    "required_status_checks": {"strict": strict, "contexts": contexts},
     "enforce_admins": True,
     "required_pull_request_reviews": {
         "required_approving_review_count": reviews,
@@ -180,7 +213,7 @@ print(json.dumps({
     "restrictions": None,
     "allow_force_pushes": False,
     "allow_deletions": False,
-}))' "$CONTEXTS_JSON" "$REVIEWS")"
+}))' "$CONTEXTS_JSON" "$REVIEWS" "$STRICT")"
 
 if [ "$MODE" = "dry-run" ]; then
     ui_blank


### PR DESCRIPTION
## Five ready pull requests, five sequential CI cycles

Strict branch protection requires a branch to be up to date with `main` before it
can merge. That is the right default — a pull request that went green against an
older `main` can still break the new one.

It has a cost that shows up as soon as more than one thing is ready. Merging the
first pull request makes every other one stale, so each subsequent merge needs an
"update branch" and a full CI run before it can go. This is not hypothetical: it is
what happened in the last two runs of my helper script.

```
#113  MERGEABLE/CLEAN   -> merged
#111  the merge commit cannot be cleanly created
#112  the head branch is not up to date with the base branch
#109  the head branch is not up to date with the base branch
```

## What `--no-strict` gives up, precisely

Only the up-to-dateness requirement. **Every check is still required and still has
to have passed.** What is dropped is the demand that it passed against the newest
`main`.

That is a real risk, and a small one: two changes can each be green alone and broken
together. So it belongs to a deliberate batch, with `main` checked afterwards — the
caller already prints the command for that — and never as a standing setting.

Running the script with no arguments restores strictness. That is deliberate: the
batch caller restores it by re-running plain, including from a trap, so an
interrupted batch does not leave protection weakened.

## Why this is a pull request and not already there

**It existed, as an uncommitted edit in a working tree, and a `git reset --hard`
took it** — which is what an uncommitted edit deserves. I told Tim to run that
reset, so this one is mine.

The consequence was quiet rather than loud: the caller ran
`protect-branch.sh --no-strict`, the script exited 2 with `Unknown option`, and the
caller had that on `>/dev/null 2>&1` and reported only *"could not relax strict;
merging one at a time instead"*. It looked like a permissions problem for two runs.
The caller now prints the reason.

## Also fixed here

`--help` read a hardcoded line range, `sed -n '4,44p'`. The paragraph this PR adds
to the header would have silently cut the end off it — the same fault
`scripts/run-app.sh` already carries a comment about, having been bitten once. It
now derives the range from the `====` rules, so the header can grow.

## Verified

| | |
|---|---|
| `--dry-run` payload, default | `"strict": true` |
| `--dry-run --strict` | `"strict": true` |
| `--dry-run --no-strict` | `"strict": false` |
| `--no-strict --strict` together | ends strict — last wins, so a restore cannot be defeated by argument order |
| unknown flag | still exits 2 |
| `--help` | prints through to its final line |

The `--no-strict` run also reports itself as a warning rather than a note, with the
reason and how to undo it, so it cannot be left on silently.
