### PR TITLE
Ticket 172

### DIFF
--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -147,6 +147,31 @@ function resolveVariableTypeForColumn(column: string, variableTypes: Record<stri
   return '';
 }
 
+// Separates a "Grouping variable" value from an optional axis-label suffix in an
+// encoded chartAxisLabelFilter value (see encodeGroupingOption in ControlPanel.tsx).
+// Must stay in sync with the identical delimiter/encoder there.
+const GROUP_UNIT_DELIM = '\u0001';
+
+function decodeGroupingFilter(value: string | null | undefined): { group: string; axisLabel: string | null } {
+  if (!value) return { group: '', axisLabel: null };
+  const idx = value.indexOf(GROUP_UNIT_DELIM);
+  if (idx === -1) return { group: value, axisLabel: null };
+  return { group: value.slice(0, idx), axisLabel: value.slice(idx + 1) };
+}
+
+function columnMatchesGroupingFilter(
+  column: string,
+  filterValue: string | null | undefined,
+  groupingVariables: Record<string, string>,
+  axisLabels: Record<string, string>,
+): boolean {
+  if (!filterValue) return true;
+  const { group, axisLabel } = decodeGroupingFilter(filterValue);
+  if (resolveGroupingVariableForColumn(column, groupingVariables) !== group) return false;
+  if (axisLabel !== null && (resolveAxisLabelForColumn(column, axisLabels) ?? '') !== axisLabel) return false;
+  return true;
+}
+
 function normalizeColumnKey(value: string): string {
   const normalized = value
     .trim()
@@ -336,17 +361,19 @@ function ChartView({
 
     return candidates.filter((col) => {
       if (chartGroup && resolveVariableTypeForColumn(col, variableTypes) !== chartGroup) return false;
-      if (chartAxisLabelFilter && resolveGroupingVariableForColumn(col, groupingVariables) !== chartAxisLabelFilter) return false;
+      if (!columnMatchesGroupingFilter(col, chartAxisLabelFilter, groupingVariables, axisLabels)) return false;
       return true;
     });
-  }, [rangeMode, columns, chartGroup, chartAxisLabelFilter, variableTypes, groupingVariables]);
+  }, [rangeMode, columns, chartGroup, chartAxisLabelFilter, variableTypes, groupingVariables, axisLabels]);
 
   const groupedDisplayColumns = useMemo(() => {
     if (filteredChartColumns.length === 0) return filteredChartColumns;
 
+    const filterGroup = decodeGroupingFilter(chartAxisLabelFilter).group;
+
     // Herbivores/Diet includes multiple metric families sharing the same x-axis labels
     // (kgkm2, counts, dmi, ch4). Mixing them corrupts grouped line/boxplot rendering.
-    if (chartGroup === 'Herbivores' && chartAxisLabelFilter === 'Diet') {
+    if (chartGroup === 'Herbivores' && filterGroup === 'Diet') {
       const familyByColumn = new Map<string, string>();
       const familyOrder: string[] = [];
 
@@ -808,7 +835,7 @@ function ChartView({
       p.curLower = p.curLowerCount > 0 && p.curLower !== null ? p.curLower / p.curLowerCount : null;
     }
 
-    const hideNoRefOrCur = chartGroup === 'Herbivores' && chartAxisLabelFilter === 'Species';
+    const hideNoRefOrCur = chartGroup === 'Herbivores' && decodeGroupingFilter(chartAxisLabelFilter).group === 'Species';
     const valid = points.filter((p) => {
       if (hideNoRefOrCur) {
         const refVal = p.ref ?? 0;

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -406,11 +406,19 @@ function ChartView({
   const [groupedRangeData, setGroupedRangeData] = useState<{
     reference: Record<string, number>;
     current: Record<string, number>;
+    referenceLower: Record<string, number>;
+    referenceUpper: Record<string, number>;
+    currentLower: Record<string, number>;
+    currentUpper: Record<string, number>;
   } | null>(null);
   const [groupedRangeLoading, setGroupedRangeLoading] = useState(false);
   const [summaryRangeData, setSummaryRangeData] = useState<{
     reference: Record<string, number>;
     current: Record<string, number>;
+    referenceLower: Record<string, number>;
+    referenceUpper: Record<string, number>;
+    currentLower: Record<string, number>;
+    currentUpper: Record<string, number>;
   } | null>(null);
   const [summaryRangeLoading, setSummaryRangeLoading] = useState(false);
   const [whiskerBounds, setWhiskerBounds] = useState<WhiskerBoundsResponse | null>(null);
@@ -554,7 +562,7 @@ function ChartView({
       throw lastErr ?? new Error('request failed');
     };
 
-    const fetchAggregates = async (scenario: Scenario): Promise<Record<string, number>> => {
+    const fetchAggregates = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
       // Large groups like "functional group" can exceed practical URL/query limits
       // when sent as one comma-separated list; request in chunks and merge.
       const batchSize = 12;
@@ -569,6 +577,7 @@ function ChartView({
           scenario,
           attributes: batch.join(','),
         });
+        if (bound) params.set('bound', bound);
 
         if (rangeMode === 'extent' && mapExtent?.bounds) {
           const [minx, miny, maxx, maxy] = mapExtent.bounds;
@@ -590,13 +599,17 @@ function ChartView({
     Promise.all([
       fetchAggregates('reference'),
       fetchAggregates('current'),
-    ]).then(([reference, current]) => {
+      fetchAggregates('reference', 'lower'),
+      fetchAggregates('reference', 'upper'),
+      fetchAggregates('current', 'lower'),
+      fetchAggregates('current', 'upper'),
+    ]).then(([reference, current, referenceLower, referenceUpper, currentLower, currentUpper]) => {
       if (cancelled) return;
 
       if (Object.keys(reference).length === 0 && Object.keys(current).length === 0) {
         setGroupedRangeData(null);
       } else {
-        setGroupedRangeData({ reference, current });
+        setGroupedRangeData({ reference, current, referenceLower, referenceUpper, currentLower, currentUpper });
       }
       setGroupedRangeLoading(false);
     }).catch(() => {
@@ -627,8 +640,9 @@ function ChartView({
     let cancelled = false;
     setSummaryRangeLoading(true);
 
-    const fetchAggregate = async (scenario: Scenario): Promise<Record<string, number>> => {
+    const fetchAggregate = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
       const params = new URLSearchParams({ scenario, attributes: attribute });
+      if (bound) params.set('bound', bound);
       if (rangeMode === 'extent' && mapExtent?.bounds) {
         const [minx, miny, maxx, maxy] = mapExtent.bounds;
         params.set('minx', String(minx));
@@ -641,10 +655,17 @@ function ChartView({
       return resp.json() as Promise<Record<string, number>>;
     };
 
-    Promise.all([fetchAggregate('reference'), fetchAggregate('current')])
-      .then(([reference, current]) => {
+    Promise.all([
+      fetchAggregate('reference'),
+      fetchAggregate('current'),
+      fetchAggregate('reference', 'lower'),
+      fetchAggregate('reference', 'upper'),
+      fetchAggregate('current', 'lower'),
+      fetchAggregate('current', 'upper'),
+    ])
+      .then(([reference, current, referenceLower, referenceUpper, currentLower, currentUpper]) => {
         if (cancelled) return;
-        setSummaryRangeData({ reference, current });
+        setSummaryRangeData({ reference, current, referenceLower, referenceUpper, currentLower, currentUpper });
         setSummaryRangeLoading(false);
       })
       .catch(() => {
@@ -754,18 +775,30 @@ function ChartView({
         ? resolveMapValueForColumn(siteIndicators?.currentLower, col)
         : undefined;
 
+      // For "site" zone range, prefer siteIndicators then fall back to the
+      // site's own catchment-derived whisker bounds. For "domain"/"extent",
+      // there's no site to scope to, so use the area-weighted bound
+      // aggregates fetched for the current zone range instead.
       const refUpperRaw = typeof siteRefUpperRaw === 'number'
         ? siteRefUpperRaw
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceUpper, col) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceUpper, col) : undefined)
+          : resolveMapValueForColumn(groupedRangeData?.referenceUpper ?? null, col);
       const refLowerRaw = typeof siteRefLowerRaw === 'number'
         ? siteRefLowerRaw
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceLower, col) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceLower, col) : undefined)
+          : resolveMapValueForColumn(groupedRangeData?.referenceLower ?? null, col);
       const curUpperRaw = typeof siteCurUpperRaw === 'number'
         ? siteCurUpperRaw
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentUpper, col) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentUpper, col) : undefined)
+          : resolveMapValueForColumn(groupedRangeData?.currentUpper ?? null, col);
       const curLowerRaw = typeof siteCurLowerRaw === 'number'
         ? siteCurLowerRaw
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentLower, col) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentLower, col) : undefined)
+          : resolveMapValueForColumn(groupedRangeData?.currentLower ?? null, col);
       const normalizedRefUpper = normalizedRef !== null && typeof refUpperRaw === 'number' && Number.isFinite(refUpperRaw) ? refUpperRaw : null;
       const normalizedRefLower = normalizedRef !== null && typeof refLowerRaw === 'number' && Number.isFinite(refLowerRaw) ? refLowerRaw : null;
       const normalizedCurUpper = normalizedCur !== null && typeof curUpperRaw === 'number' && Number.isFinite(curUpperRaw) ? curUpperRaw : null;
@@ -981,6 +1014,9 @@ function ChartView({
 
   const { width, height } = size;
 
+  const isLoading = groupedRangeLoading || summaryRangeLoading
+    || (groupedChartType === 'boxplot' && whiskerLoading);
+
   if (!hasData) {
     return (
       <Box
@@ -997,11 +1033,13 @@ function ChartView({
       >
         {visible
           ? (
-            chartGroup
-              ? (chartAxisLabelFilter
-                ? (groupedRangeLoading ? 'Loading\u2026' : 'No grouped chart data for this selection')
-                : 'Select a grouping variable to show chart data')
-              : (attribute ? 'Loading…' : 'Select a factor to view its chart')
+            isLoading
+              ? <Spinner size="xl" color="orange.400" thickness="3px" speed="0.7s" />
+              : (chartGroup
+                ? (chartAxisLabelFilter
+                  ? 'No grouped chart data for this selection'
+                  : 'Select a grouping variable to show chart data')
+                : (attribute ? 'No chart data for this selection' : 'Select a factor to view its chart'))
           )
           : null}
       </Box>
@@ -1564,23 +1602,35 @@ function ChartView({
       const curVal = values[1];
       const targetVal = values[2];
 
-      const siteRefUpper = resolveMapValueForColumn(siteIndicators?.referenceUpper, attribute!);
-      const siteRefLower = resolveMapValueForColumn(siteIndicators?.referenceLower, attribute!);
-      const siteCurUpper = resolveMapValueForColumn(siteIndicators?.currentUpper, attribute!);
-      const siteCurLower = resolveMapValueForColumn(siteIndicators?.currentLower, attribute!);
+      const siteRefUpper = rangeMode === 'site' ? resolveMapValueForColumn(siteIndicators?.referenceUpper, attribute!) : undefined;
+      const siteRefLower = rangeMode === 'site' ? resolveMapValueForColumn(siteIndicators?.referenceLower, attribute!) : undefined;
+      const siteCurUpper = rangeMode === 'site' ? resolveMapValueForColumn(siteIndicators?.currentUpper, attribute!) : undefined;
+      const siteCurLower = rangeMode === 'site' ? resolveMapValueForColumn(siteIndicators?.currentLower, attribute!) : undefined;
 
+      // For "site" zone range, prefer siteIndicators then fall back to the
+      // site's own catchment-derived whisker bounds. For "domain"/"extent",
+      // there's no site to scope to, so use the area-weighted bound
+      // aggregates fetched for the current zone range instead.
       const refUpperRaw = typeof siteRefUpper === 'number'
         ? siteRefUpper
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceUpper, attribute!) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceUpper, attribute!) : undefined)
+          : resolveMapValueForColumn(summaryRangeData?.referenceUpper ?? null, attribute!);
       const refLowerRaw = typeof siteRefLower === 'number'
         ? siteRefLower
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceLower, attribute!) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.referenceLower, attribute!) : undefined)
+          : resolveMapValueForColumn(summaryRangeData?.referenceLower ?? null, attribute!);
       const curUpperRaw = typeof siteCurUpper === 'number'
         ? siteCurUpper
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentUpper, attribute!) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentUpper, attribute!) : undefined)
+          : resolveMapValueForColumn(summaryRangeData?.currentUpper ?? null, attribute!);
       const curLowerRaw = typeof siteCurLower === 'number'
         ? siteCurLower
-        : (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentLower, attribute!) : undefined);
+        : rangeMode === 'site'
+          ? (whiskerBounds ? resolveMapValueForColumn(whiskerBounds.currentLower, attribute!) : undefined)
+          : resolveMapValueForColumn(summaryRangeData?.currentLower ?? null, attribute!);
 
       const seriesDefs = [
         { name: SERIES_LABELS[0], color: SERIES_COLORS[0], val: refVal,
@@ -1943,9 +1993,6 @@ function ChartView({
       </svg>
     );
   };
-
-  const isLoading = groupedRangeLoading || summaryRangeLoading
-    || (groupedChartType === 'boxplot' && whiskerLoading);
 
   return (
     <Box

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -18,7 +18,7 @@ import {
 import { FiChevronRight, FiInfo, FiMapPin, FiGlobe, FiSquare, FiTarget } from 'react-icons/fi';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { useAttributeCanMap, useAttributeCanGraph, useAttributeChartTypes, useAttributeColors, useColumns, useAttributeDetails, useAttributeGroupingVariables, useAttributeVariableTypes } from '../hooks/useApi';
+import { useAttributeCanMap, useAttributeCanGraph, useAttributeChartTypes, useAttributeColors, useColumns, useAttributeDetails, useAttributeGroupingVariables, useAttributeVariableTypes, useAttributeAxisLabels } from '../hooks/useApi';
 import { PRISM_CSS_GRADIENT, formatNumber } from './MapView';
 import type { Scenario, ComparisonState, MapStatistics, ColorScaleMode, ColorScaleType, ViewMode, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
@@ -101,6 +101,59 @@ function resolveVariableTypeForColumn(column: string, variableTypes: Record<stri
   }
 
   return '';
+}
+
+function resolveAxisLabelForColumn(column: string, axisLabels: Record<string, string>): string {
+  const candidates = [
+    column,
+    column.replace(/_/g, ' '),
+    column.replace(/_/g, '.'),
+    column.replace(/\./g, '_'),
+    column.replace(/\./g, ' '),
+    column.replace(/ /g, '_'),
+    column.replace(/ /g, '.'),
+  ];
+
+  for (const key of candidates) {
+    const label = axisLabels[key];
+    if (label && label.trim().length > 0) return label;
+  }
+
+  const normalizedColumn = normalizeColumnKey(column);
+  for (const [key, label] of Object.entries(axisLabels)) {
+    if (normalizeColumnKey(key) === normalizedColumn && label.trim().length > 0) return label;
+  }
+
+  return '';
+}
+
+// Separates a "Grouping variable" value from an optional axis-label suffix in an
+// encoded chartAxisLabelFilter value (see encodeGroupingOption below). Must stay in
+// sync with the identical delimiter/decoder in ChartView.tsx.
+const GROUP_UNIT_DELIM = '\u0001';
+
+function encodeGroupingOption(group: string, axisLabel: string): string {
+  return `${group}${GROUP_UNIT_DELIM}${axisLabel}`;
+}
+
+function decodeGroupingFilter(value: string | null | undefined): { group: string; axisLabel: string | null } {
+  if (!value) return { group: '', axisLabel: null };
+  const idx = value.indexOf(GROUP_UNIT_DELIM);
+  if (idx === -1) return { group: value, axisLabel: null };
+  return { group: value.slice(0, idx), axisLabel: value.slice(idx + 1) };
+}
+
+function columnMatchesGroupingFilter(
+  column: string,
+  filterValue: string | null | undefined,
+  groupingVariables: Record<string, string>,
+  axisLabels: Record<string, string>,
+): boolean {
+  if (!filterValue) return true;
+  const { group, axisLabel } = decodeGroupingFilter(filterValue);
+  if (resolveGroupingVariableForColumn(column, groupingVariables) !== group) return false;
+  if (axisLabel !== null && resolveAxisLabelForColumn(column, axisLabels) !== axisLabel) return false;
+  return true;
 }
 
 function normalizeColumnKey(value: string): string {
@@ -412,6 +465,7 @@ function ControlPanel({
   const { chartTypes } = useAttributeChartTypes();
   const { groupingVariables } = useAttributeGroupingVariables();
   const { variableTypes } = useAttributeVariableTypes();
+  const { axisLabels } = useAttributeAxisLabels();
   const bgColor = useColorModeValue('gray.50', 'gray.800');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const cardBg = useColorModeValue('white', 'gray.750');
@@ -441,21 +495,42 @@ function ControlPanel({
     if (!chartGroup) return [];
 
     const fromChartableColumns = columns
-      .filter((col) => canGraph[col] && resolveVariableTypeForColumn(col, variableTypes) === chartGroup)
-      .map((col) => resolveGroupingVariableForColumn(col, groupingVariables))
-      .filter((group): group is string => Boolean(group && group.trim().length > 0 && group !== 'catchID'));
+      .filter((col) => canGraph[col] && resolveVariableTypeForColumn(col, variableTypes) === chartGroup);
 
-    const groups = fromChartableColumns.length > 0
+    const sourceColumns = fromChartableColumns.length > 0
       ? fromChartableColumns
-      : Object.entries(groupingVariables)
-          .filter(([col, group]) => {
-            if (!group || group === 'catchID') return false;
-            return resolveVariableTypeForColumn(col, variableTypes) === chartGroup;
-          })
-          .map(([, group]) => group);
+      : Object.keys(groupingVariables)
+          .filter((col) => resolveVariableTypeForColumn(col, variableTypes) === chartGroup);
 
-    return [...new Set(groups)].sort().map((group) => ({ value: group, label: group.replace(/_/g, ' ') }));
-  }, [chartGroup, columns, canGraph, variableTypes, groupingVariables]);
+    // Mixing indicators that plot on different axes into one chart produces a
+    // meaningless combined y-axis (e.g. burned area and fuel load on the same
+    // scale), so split any grouping-variable bucket whose columns span multiple
+    // "axis label" values into one option per axis label.
+    const axisLabelsByGroup = new Map<string, Set<string>>();
+    for (const col of sourceColumns) {
+      const group = resolveGroupingVariableForColumn(col, groupingVariables);
+      if (!group || group === 'catchID') continue;
+      const axisLabel = resolveAxisLabelForColumn(col, axisLabels) || 'unspecified axis label';
+      if (!axisLabelsByGroup.has(group)) axisLabelsByGroup.set(group, new Set());
+      axisLabelsByGroup.get(group)!.add(axisLabel);
+    }
+
+    const options: { value: string; label: string }[] = [];
+    for (const [group, labelSet] of axisLabelsByGroup) {
+      if (labelSet.size <= 1) {
+        options.push({ value: group, label: group.replace(/_/g, ' ') });
+        continue;
+      }
+      for (const axisLabel of labelSet) {
+        options.push({
+          value: encodeGroupingOption(group, axisLabel),
+          label: `${group.replace(/_/g, ' ')} (${axisLabel})`,
+        });
+      }
+    }
+
+    return options.sort((a, b) => a.label.localeCompare(b.label));
+  }, [chartGroup, columns, canGraph, variableTypes, groupingVariables, axisLabels]);
 
   const lineBoxplotToggleAvailable = useMemo(() => {
     if (viewMode !== 'chart' || !chartGroup || !chartAxisLabelFilter) return false;
@@ -487,14 +562,14 @@ function ControlPanel({
     const groupColumns = columns.filter((col) => {
       if (!canGraph[col]) return false;
       if (resolveVariableTypeForColumn(col, variableTypes) !== chartGroup) return false;
-      return resolveGroupingVariableForColumn(col, groupingVariables) === chartAxisLabelFilter;
+      return columnMatchesGroupingFilter(col, chartAxisLabelFilter, groupingVariables, axisLabels);
     });
 
     return groupColumns.some((col) => {
       const chartType = (resolveChartTypeForColumn(col) ?? '').toLowerCase().replace(/\s+/g, '');
       return chartType.includes('line/boxplot');
     });
-  }, [viewMode, chartGroup, chartAxisLabelFilter, columns, canGraph, variableTypes, groupingVariables, chartTypes]);
+  }, [viewMode, chartGroup, chartAxisLabelFilter, columns, canGraph, variableTypes, groupingVariables, chartTypes, axisLabels]);
 
   useEffect(() => {
     if (chartAxisLabelFilter && !groupingVariableOptions.some((option) => option.value === chartAxisLabelFilter)) {
@@ -524,7 +599,7 @@ function ControlPanel({
             return false;
           }
           if (viewMode === 'chart' && chartAxisLabelFilter) {
-            if (resolveGroupingVariableForColumn(col, groupingVariables) !== chartAxisLabelFilter) return false;
+            if (!columnMatchesGroupingFilter(col, chartAxisLabelFilter, groupingVariables, axisLabels)) return false;
           }
           return true;
         })
@@ -534,7 +609,7 @@ function ControlPanel({
       label: attributeDetails[col] || col,
       sublabel: attributeDetails[col] ? col : undefined,
     }));
-  }, [viewMode, canGraph, canMap, chartTypes, columns, chartGroup, chartAxisLabelFilter, groupingVariables, variableTypes, attributeDetails]);
+  }, [viewMode, canGraph, canMap, chartTypes, columns, chartGroup, chartAxisLabelFilter, groupingVariables, variableTypes, attributeDetails, axisLabels]);
 
   const allGraphableFactorOptions = useMemo(
     () => columns

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -433,6 +433,8 @@ func (h *Handler) handleScenarioData(w http.ResponseWriter, r *http.Request) {
 //	scenario: scenario name (required)
 //	attributes: comma-separated list of attribute column names (required)
 //	minx,miny,maxx,maxy: optional bbox for extent aggregation
+//	bound: optional "lower" or "upper" to return the corresponding uncertainty
+//	  bound instead of the mean, for whisker/box-plot ranges outside site scope
 func (h *Handler) handleAggregateData(w http.ResponseWriter, r *http.Request) {
 	if h.gpkgStore == nil {
 		respondError(w, http.StatusNotFound, "no geo data loaded")
@@ -499,9 +501,21 @@ func (h *Handler) handleAggregateData(w http.ResponseWriter, r *http.Request) {
 		bbox = &[4]float64{minx, miny, maxx, maxy}
 	}
 
+	bound := strings.TrimSpace(q.Get("bound"))
+	if bound != "" && bound != "lower" && bound != "upper" {
+		respondError(w, http.StatusBadRequest, "bound must be 'lower' or 'upper'")
+		return
+	}
+
 	aggStart := time.Now()
-	agg, err := h.gpkgStore.GetScenarioAverages(scenario, attributes, bbox)
-	log.Printf("[perf] handleAggregateData scenario=%s attributes=%d hasBbox=%v duration_ms=%d", scenario, len(attributes), bbox != nil, time.Since(aggStart).Milliseconds())
+	var agg map[string]float64
+	var err error
+	if bound == "" {
+		agg, err = h.gpkgStore.GetScenarioAverages(scenario, attributes, bbox)
+	} else {
+		agg, err = h.gpkgStore.GetScenarioBoundAverages(scenario, bound, attributes, bbox)
+	}
+	log.Printf("[perf] handleAggregateData scenario=%s bound=%q attributes=%d hasBbox=%v duration_ms=%d", scenario, bound, len(attributes), bbox != nil, time.Since(aggStart).Milliseconds())
 	if err != nil {
 		respondError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/geodata/gpkg_store.go
+++ b/internal/geodata/gpkg_store.go
@@ -184,6 +184,16 @@ func resolveScenarioTable(scenario string) string {
 	return "scenario_current"
 }
 
+// resolveScenarioBoundTable resolves the table holding the lower/upper
+// uncertainty bound columns for a scenario, mirroring resolveScenarioTable.
+// bound must be "lower" or "upper".
+func resolveScenarioBoundTable(scenario, bound string) (string, error) {
+	if bound != "lower" && bound != "upper" {
+		return "", fmt.Errorf("invalid bound: %s", bound)
+	}
+	return resolveScenarioTable(scenario) + "_" + bound, nil
+}
+
 func normalizeCatchmentID(id string) string {
 	return strings.TrimSuffix(id, ".0")
 }
@@ -291,11 +301,25 @@ func (s *GpkgStore) GetScenarioData(scenario, attribute string) (map[string]floa
 // GetScenarioAverages returns area-weighted means for one scenario across multiple attributes.
 // When bbox is provided, the aggregation is restricted to catchments intersecting that bbox.
 func (s *GpkgStore) GetScenarioAverages(scenario string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
+	return s.getAveragesForTable(resolveScenarioTable(scenario), attributes, bbox)
+}
+
+// GetScenarioBoundAverages returns area-weighted means of the lower/upper
+// uncertainty bound columns for one scenario across multiple attributes.
+// These power whisker/box-plot ranges outside "site" zone range, where the
+// per-catchment whisker computation (ComputeWhiskerBounds) doesn't apply.
+func (s *GpkgStore) GetScenarioBoundAverages(scenario, bound string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
+	tableName, err := resolveScenarioBoundTable(scenario, bound)
+	if err != nil {
+		return nil, err
+	}
+	return s.getAveragesForTable(tableName, attributes, bbox)
+}
+
+func (s *GpkgStore) getAveragesForTable(tableName string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
 	if len(attributes) == 0 {
 		return nil, fmt.Errorf("no attributes provided")
 	}
-
-	tableName := resolveScenarioTable(scenario)
 
 	selectExprs := make([]string, 0, len(attributes))
 	for i, attr := range attributes {


### PR DESCRIPTION
**Fix collapsed whisker box plot outside Site zone range**
The Reference/Current box plot was rendering as a flat line (no spread) whenever Zone Range was set to "Full" or "Extent" — most visibly in Explore mode, which has no site to scope to. Root cause: upper/lower bounds only existed for the "Site" zone range; /api/aggregate only ever returned the mean.

- Backend: /api/aggregate now accepts an optional bound=lower|upper param, sourcing from the existing scenario_*_lower/scenario_*_upper tables with the same area-weighted aggregation as the mean.
- Frontend: chart now fetches and uses these bounds for Full/Extent ranges instead of incorrectly falling back to site-only whisker data.
- While the box plot is loading, the chart now shows a spinner instead of a text placeholder.
- Fix grouping-variable selection ambiguity in Control Panel

Some "Grouping variable" options shared the same name across different axis-label families (e.g. Herbivores/Diet), causing the chart to pull in columns from the wrong family. Grouping-variable values are now disambiguated by encoding the axis label alongside the group name, kept in sync between ControlPanel.tsx and ChartView.tsx.