### PR TITLE
perf(map): hold WebGL contexts only for maps being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **The application held twelve WebGL contexts in grid view and never gave one
+  back.** Each `MapView` built two MapLibre instances — left and right — whether or
+  not the user was comparing anything, and a pane latched "has shown a map" on first
+  display and kept the map mounted behind `opacity: 0` for the rest of the session.
+  Six panes, two contexts each, permanently. Browsers cap simultaneous contexts at
+  around sixteen and silently drop the oldest past that ("Too many active WebGL
+  contexts"), and integrated GPUs run out of memory well before that count.
+
+  The right map is now created on entering compare mode and removed on leaving it,
+  and a pane releases its maps once it has stopped displaying one. MapLibre
+  instances constructed by a six-pane grid, counted under the test harness:
+
+  | grid view, six panes | before | after |
+  |---|---:|---:|
+  | all on a map, compare off | 12 | **6** |
+  | all on a map, compare on | 12 | 12 |
+  | two on a map, four on chart/dial/table | 12 | **4** |
+
+  The compare swiper defaults to on, so the worst case is unchanged; what has gone
+  is paying for maps nothing is displaying.
+
+  Releasing a map is not free, so a pane keeps its map for fifteen seconds after
+  switching away — flipping to a chart and straight back does not reload anything.
+  The sync registry now remembers the last view any map reported, and a new
+  instance opens there rather than at the default world view, so a release and
+  recreate does not move the map under the user.
+
 - **The browser stored three to eight times more than it needed to, and rewrote all
   of it on every save.** A user's sites live in their browser — that is the design
   brief — so this is the system of record, not a cache. Three things made it

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -92,8 +92,17 @@ requires the backend.
 
 ## Map Rendering Architecture
 
-Each `MapView` creates **two** MapLibre GL instances, left and right, to support swipe
-comparison. In grid view the six panes therefore hold up to twelve WebGL contexts.
+Each `MapView` owns a left map and, **only while the compare swiper is on**, a right
+one. The right instance is created on entering compare mode and removed on leaving it,
+and a pane releases its maps entirely once it has stopped displaying one (after a short
+grace period, so flipping to a chart and straight back does not reload the map). A
+recreated map opens at the last view the sync registry saw, so the release is invisible.
+
+The ceiling is therefore *panes currently showing a map* x (compare mode ? 2 : 1), not a
+flat twelve. Grid view with all six panes on a map and the swiper on still reaches
+twelve; browsers cap simultaneous WebGL contexts at around sixteen and silently drop the
+oldest past that, so the swiper default (on, in `App.tsx`) is worth knowing about when
+diagnosing context loss.
 
 - **Base layers** (MapLibre GL JS) — ecoregions, countries, rivers, lakes, catchment
   outlines, populated places, served from MBTiles via `/tiles/`.
@@ -109,12 +118,7 @@ comparison. In grid view the six panes therefore hold up to twelve WebGL context
     per map instance. It is expected to move into the vector tile pipeline. The
     data-driven `fill-color` expression is correct and will be preserved.
 
-    Also expected to change: the right-hand map is currently created eagerly whether or
-    not the user is comparing, and map instances are not released when a pane switches
-    to a non-map view.
-
     Tickets: *Serve the choropleth as vector tiles rather than a GeoJSON source*,
-    *Twelve WebGL contexts are created in grid view and never released*,
     *Clamp devicePixelRatio on low-end devices*.
 
 ## Auxiliary Tile Servers

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1178,11 +1178,16 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         );
 
         const applySide = (
-          map: maplibregl.Map,
+          // Nullable since the compare map is created only in compare mode:
+          // this is the tile path's equivalent of the guards the GeoJSON path
+          // carries. Without it the right side is asked to paint a map that
+          // does not exist.
+          map: maplibregl.Map | null,
           side: 'left' | 'right',
           values: ChoroplethValues | null,
           scenario: Scenario,
         ) => {
+          if (!map) return;
           if (!values || values.ids.length === 0) {
             removeChoroplethLayers(map, side);
             return;

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -6,7 +6,7 @@ import { bbox as turfBbox, featureCollection, union, difference, intersect, area
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { ComparisonState, Scenario, IdentifyResult, MapExtent, MapStatistics, ZoneStats, BoundingBox, DomainRange, ColorScaleMode, ColorScaleType, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
-import { registerMap, unregisterMap } from '../hooks/useMapSync';
+import { registerMap, unregisterMap, getLastMapView } from '../hooks/useMapSync';
 import { getSite, getSiteCatchments, getSiteAOIFractions, useAttributeColors, useAttributeDetails, loadLocalSite, saveLocalSite, clearSiteWhiskerCache } from '../hooks/useApi';
 import { getAppRuntime } from '../types/runtime';
 import { colors } from '../styles/colors';
@@ -925,7 +925,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const { details: attributeDetails } = useAttributeDetails();
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const leftMapRef = useRef<maplibregl.Map | null>(null);
+  // Null whenever compare mode is off — see createRightMap in the map-init
+  // effect. Everything that mirrors work onto the right side has to tolerate
+  // its absence.
   const rightMapRef = useRef<maplibregl.Map | null>(null);
+  // Set by the map-init effect; the compare-mode effect below drives them.
+  const ensureRightMapRef = useRef<(() => maplibregl.Map) | null>(null);
+  const destroyRightMapRef = useRef<(() => void) | null>(null);
   const viewportBoundsRef = useRef<maplibregl.LngLatBoundsLike | null>(null);
   const leftClipContainerRef = useRef<HTMLDivElement | null>(null);
   const compareContainerRef = useRef<HTMLDivElement | null>(null);
@@ -933,7 +939,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const sliderHandleRef = useRef<HTMLDivElement | null>(null);
   const sliderDockedRef = useRef<'left' | 'right' | null>(null);
   const isDragging = useRef(false);
-  const mapsReady = useRef<{ left: boolean; right: boolean }>({ left: false, right: false });
+  // `right` reads as "the right map, if any, has loaded". The right map only
+  // exists in compare mode (see createRightMap below), so when it is absent the
+  // right side is trivially ready and every mapsReady.current.right check in
+  // this file stays correct without a null dance at each one.
+  const mapsReady = useRef<{ left: boolean; right: boolean }>({ left: false, right: true });
   const resizeFrameRef = useRef<number | null>(null);
 
   // Compare swiper state (split-screen on/off)
@@ -1089,7 +1099,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap) return;
+    // rightMap may legitimately be null: it only exists in compare mode. Every
+    // right-side call below either takes a nullable map or is guarded.
+    if (!leftMap) return;
     if (!mapsReady.current.left || !mapsReady.current.right) return;
 
     if (!isChoroplethEnabledRef.current) {
@@ -1307,8 +1319,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         removeChoroplethLayers(leftMap, 'left');
       }
 
-      // Apply to right map - verify the map is ready
-      if (rightDisplay && rightDisplay.features.length > 0) {
+      // Apply to right map - verify it exists (compare mode only) and is ready
+      if (rightMap && rightDisplay && rightDisplay.features.length > 0) {
         if (rightMap.loaded()) {
           applyChoroplethLayer(rightMap, 'right', rightDisplay, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
@@ -1427,7 +1439,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap || !mapsReady.current.left || !mapsReady.current.right) return;
+    if (!leftMap || !mapsReady.current.left || !mapsReady.current.right) return;
 
     removeChoroplethLayers(leftMap, 'left');
     removeChoroplethLayers(rightMap, 'right');
@@ -1516,7 +1528,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const geometry = boundaryGeometryRef.current;
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
-    if (!geometry || !leftMap || !rightMap) return;
+    if (!geometry || !leftMap) return;
 
     const applyToMap = (map: maplibregl.Map) => {
       if (map.isStyleLoaded()) {
@@ -1539,7 +1551,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     };
 
     applyToMap(leftMap);
-    applyToMap(rightMap);
+    if (rightMap) applyToMap(rightMap);
   // useCallback has a missing dependency: 'addBoundaryLayersIfMissing'
   // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing; see the tracking issue
   }, []);
@@ -1774,9 +1786,10 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   /**
    * Remove choropleth layers from a map.
    */
-  function removeChoroplethLayers(map: maplibregl.Map, side: string) {
-    // Safety check: map.style is undefined after map.remove() is called
-    if (!map.style) return;
+  function removeChoroplethLayers(map: maplibregl.Map | null, side: string) {
+    // The right map is absent outside compare mode, and map.style is undefined
+    // after map.remove() — either way there is nothing to strip.
+    if (!map?.style) return;
 
     const layerId = `choropleth-${side}`;
     const edgeBlendLayerId = `${layerId}-edge-blend`;
@@ -1985,7 +1998,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const toggleGoogleBasemap = useCallback(() => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
-    if (!leftMap || !rightMap) return;
+    if (!leftMap) return;
 
     const nextVal = !isGoogleBasemapRef.current;
     isGoogleBasemapRef.current = nextVal;
@@ -2007,10 +2020,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     };
 
     reapplyAfterStyleLoad(leftMap);
-    reapplyAfterStyleLoad(rightMap);
-
     leftMap.setStyle(newStyle);
-    rightMap.setStyle(newStyle);
+    if (rightMap) {
+      reapplyAfterStyleLoad(rightMap);
+      rightMap.setStyle(newStyle);
+    }
 
     // Re-apply boundary and choropleth layers after styles settle
     window.setTimeout(() => {
@@ -2818,12 +2832,20 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // Set initial sizes BEFORE creating maps so they initialize with correct dimensions
     updateMapSizes();
 
+    // A map instance is transient now: this effect re-runs, compare mode adds
+    // and removes the right map, and a pane releases its maps when it stops
+    // showing one. Opening at the last view the sync registry saw keeps that
+    // invisible — a recreated map would otherwise snap back to the world view.
+    // Pitch stays under the 3D toggle's control rather than being restored.
+    const restoredView = getLastMapView();
+
     // Create left map with all interactions enabled
     const leftMap = new maplibregl.Map({
       container: leftContainer,
       style: mapStyle,
-      center: [20, 0],
-      zoom: 3,
+      center: restoredView?.center ?? [20, 0],
+      zoom: restoredView?.zoom ?? 3,
+      bearing: restoredView?.bearing ?? 0,
       pitch: is3DModeRef.current ? 60 : 0,
       attributionControl: false,
       fadeDuration: 0,
@@ -2839,32 +2861,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     });
     leftMap.addControl(new maplibregl.NavigationControl(), 'bottom-left');
 
-    // Create right map with all interactions enabled
-    const rightMap = new maplibregl.Map({
-      container: rightContainer,
-      style: mapStyle,
-      center: [20, 0],
-      zoom: 3,
-      pitch: is3DModeRef.current ? 60 : 0,
-      attributionControl: false,
-      fadeDuration: 0,
-      pixelRatio: mapPixelRatio(),
-      scrollZoom: true,
-      dragPan: true,
-      dragRotate: true,
-      doubleClickZoom: true,
-      boxZoom: true,
-      keyboard: true,
-      touchZoomRotate: true,
-      touchPitch: true,
-    });
-    rightMap.addControl(new maplibregl.NavigationControl(), 'bottom-left');
-
     const applyViewportLimits = () => {
       const bounds = viewportBoundsRef.current;
       if (!bounds) return;
       applyZoomOutClipToBounds(leftMap, bounds);
-      applyZoomOutClipToBounds(rightMap, bounds);
+      const rightMap = rightMapRef.current;
+      if (rightMap) applyZoomOutClipToBounds(rightMap, bounds);
     };
 
     void (async () => {
@@ -2892,14 +2894,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     }
 
     leftMap.on('move', () => {
-      syncMaps(leftMap, rightMap);
+      const rightMap = rightMapRef.current;
+      if (rightMap) syncMaps(leftMap, rightMap);
       updateIdentifyOverlayPosition();
     });
-    rightMap.on('move', () => syncMaps(rightMap, leftMap));
 
     // Identify click handlers - pass side info for correct layer querying
     leftMap.on('click', (e) => handleIdentifyClick(leftMap, e, 'left'));
-    rightMap.on('click', (e) => handleIdentifyClick(rightMap, e, 'right'));
 
     // Fetch new choropleth data when map moves (debounced)
     leftMap.on('moveend', () => {
@@ -2952,21 +2953,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       signalReady();
       resizeAndRefresh(leftMap);
       if (mapsReady.current.right) {
-        resizeAndRefresh(rightMap);
-        applyColorsRef.current();
-        setAreMapsReady(true);
-        reapplyBoundaryLayers();
-        // Deferred retry: ensures boundary is on top after applyColors async
-        // continuation and React boundary effect have both completed.
-        requestAnimationFrame(() => reapplyBoundaryLayers());
-      }
-    });
-    rightMap.on('load', () => {
-      mapsReady.current.right = true;
-      signalReady();
-      resizeAndRefresh(rightMap);
-      if (mapsReady.current.left) {
-        resizeAndRefresh(leftMap);
+        const rightMap = rightMapRef.current;
+        if (rightMap) resizeAndRefresh(rightMap);
         applyColorsRef.current();
         setAreMapsReady(true);
         reapplyBoundaryLayers();
@@ -2982,10 +2970,96 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const readyTimeoutId = setTimeout(signalReady, 15_000);
 
     leftMapRef.current = leftMap;
-    rightMapRef.current = rightMap;
 
     // Register the left map for cross-pane sync
     const syncId = registerMap(leftMap);
+
+    // The compare (right) map is created on demand rather than up front.
+    // Two MapLibre instances per pane meant twelve WebGL contexts in quad
+    // view, against a browser ceiling of about sixteen past which the oldest
+    // context is silently dropped — and integrated GPUs run out of memory
+    // well before that count. Half of them were drawing nothing whenever the
+    // compare swiper was off. See issue #76.
+    function createRightMap(): maplibregl.Map {
+      const existing = rightMapRef.current;
+      if (existing) return existing;
+
+      // Open on the left map's current view so revealing the split shows the
+      // same place the user is already looking at; the move handlers below
+      // only keep the two in step from the next movement onwards.
+      const leftCenter = leftMap.getCenter();
+      const rightMap = new maplibregl.Map({
+        container: rightContainer,
+        // Re-read the basemap choice rather than reusing the style captured at
+        // init: the user may have toggled the satellite basemap since.
+        style: isGoogleBasemapRef.current ? satelliteBasemapStyle() : getStyleForMap(styleUrl),
+        center: [leftCenter.lng, leftCenter.lat],
+        zoom: leftMap.getZoom(),
+        bearing: leftMap.getBearing(),
+        pitch: leftMap.getPitch(),
+        attributionControl: false,
+        fadeDuration: 0,
+        pixelRatio: mapPixelRatio(),
+        scrollZoom: true,
+        dragPan: true,
+        dragRotate: true,
+        doubleClickZoom: true,
+        boxZoom: true,
+        keyboard: true,
+        touchZoomRotate: true,
+        touchPitch: true,
+      });
+      rightMap.addControl(new maplibregl.NavigationControl(), 'bottom-left');
+
+      mapsReady.current.right = false;
+      rightMapRef.current = rightMap;
+
+      rightMap.on('move', () => syncMaps(rightMap, leftMap));
+      rightMap.on('click', (e) => handleIdentifyClick(rightMap, e, 'right'));
+
+      // The site-boundary effect wires a styledata listener per map, but it
+      // only runs on site changes and readiness — a map created after that
+      // would never re-add its boundary after a style swap.
+      rightMap.on('styledata', () => reapplyBoundaryLayers());
+
+      rightMap.on('load', () => {
+        mapsReady.current.right = true;
+        signalReady();
+        resizeAndRefresh(rightMap);
+        if (mapsReady.current.left) {
+          resizeAndRefresh(leftMap);
+          applyColorsRef.current();
+          setAreMapsReady(true);
+          reapplyBoundaryLayers();
+          // Deferred retry: ensures boundary is on top after applyColors async
+          // continuation and React boundary effect have both completed.
+          requestAnimationFrame(() => reapplyBoundaryLayers());
+        }
+      });
+
+      applyViewportLimits();
+      updateMapSizes();
+      return rightMap;
+    }
+
+    function destroyRightMap(): void {
+      const rightMap = rightMapRef.current;
+      if (!rightMap) return;
+      // Clear the ref before removing, so anything reading it mid-teardown
+      // sees "no right map" rather than a destroyed instance — the same
+      // ordering the effect cleanup below uses.
+      rightMapRef.current = null;
+      mapsReady.current.right = true;
+      rightMap.remove();
+    }
+
+    ensureRightMapRef.current = createRightMap;
+    destroyRightMapRef.current = destroyRightMap;
+
+    // This effect re-runs on its dependencies, and the lifecycle effect below
+    // only reacts to changes in compare mode, so restore the right map here if
+    // compare mode is already on.
+    if (isSwiperEnabledRef.current) createRightMap();
 
     // Slider drag handling with proper isolation from map events
     let sliderPointerId: number | null = null;
@@ -2999,7 +3073,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       slider.setPointerCapture(e.pointerId);
       // Disable map interactions while dragging slider
       leftMap.dragPan.disable();
-      rightMap.dragPan.disable();
+      rightMapRef.current?.dragPan.disable();
     }
 
     function onSliderPointerMove(e: PointerEvent) {
@@ -3061,7 +3135,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       sliderPointerId = null;
       // Re-enable map interactions
       leftMap.dragPan.enable();
-      rightMap.dragPan.enable();
+      rightMapRef.current?.dragPan.enable();
 
       // Ensure a final resize after drag ends; add a tiny delay for layout settle
       window.setTimeout(() => {
@@ -3070,7 +3144,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             resizeFrameRef.current = null;
             updateMapSizes();
             leftMap.resize();
-            rightMap.resize();
+            rightMapRef.current?.resize();
             updateIdentifyOverlayPosition();
           });
         }
@@ -3084,7 +3158,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     return () => {
       clearTimeout(readyTimeoutId);
-      mapsReady.current = { left: false, right: false };
+      mapsReady.current = { left: false, right: true };
       onReadyFiredRef.current = false;
       setAreMapsReady(false);
       if (fetchTimerRef.current) {
@@ -3098,10 +3172,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       // Clear refs BEFORE removing maps to prevent other cleanup effects from
       // trying to access destroyed map instances
       leftMapRef.current = null;
-      rightMapRef.current = null;
+      ensureRightMapRef.current = null;
+      destroyRightMapRef.current = null;
+      destroyRightMap();
       removeIdentifyOverlay(false);
       leftMap.remove();
-      rightMap.remove();
       leftClipContainerRef.current = null;
       compareContainerRef.current = null;
       sliderRef.current = null;
@@ -3118,15 +3193,32 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing; see the tracking issue
   }, [debouncedApplyColors, handleIdentifyClick, removeIdentifyOverlay, updateIdentifyOverlayPosition]);
 
+  // Compare mode owns the right map's lifetime: created on entering, released
+  // on leaving, so a pane that is not comparing holds one WebGL context rather
+  // than two (issue #76).
+  //
+  // Declared directly after the map-init effect and before every effect that
+  // touches the right map, which matters twice over. React runs all changed
+  // effects' cleanups before any effect body, so the effects listing
+  // isSwiperEnabled detach from a live instance before this one removes it;
+  // and effect bodies run in declaration order, so those same effects see the
+  // new instance on the way back in.
+  useEffect(() => {
+    if (isSwiperEnabled) {
+      ensureRightMapRef.current?.();
+    } else {
+      destroyRightMapRef.current?.();
+    }
+  }, [isSwiperEnabled]);
+
   // Resize maps when layout changes or container size updates
   useEffect(() => {
     const container = mapContainerRef.current;
     const leftClipContainer = leftClipContainerRef.current;
     const rightClipContainer = compareContainerRef.current;
     const leftMap = leftMapRef.current;
-    const rightMap = rightMapRef.current;
 
-    if (!container || !leftClipContainer || !rightClipContainer || !leftMap || !rightMap) {
+    if (!container || !leftClipContainer || !rightClipContainer || !leftMap) {
       return;
     }
 
@@ -3135,18 +3227,22 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (!leftContainer || !rightContainer) return;
 
     const updateSizes = () => {
+      // The compare map is read from the ref on each call rather than captured:
+      // this effect outlives several compare-mode toggles, and a container
+      // resize has to reach whichever instance exists at that moment.
+      const rightMap = rightMapRef.current;
       const parentWidth = container.offsetWidth;
       const rightClipWidth = rightClipContainer.offsetWidth;
       leftContainer.style.width = `${parentWidth}px`;
       rightContainer.style.width = `${parentWidth}px`;
       rightContainer.style.left = `${-(parentWidth - rightClipWidth)}px`;
       leftMap.resize();
-      rightMap.resize();
+      rightMap?.resize();
 
       const bounds = viewportBoundsRef.current;
       if (bounds) {
         applyZoomOutClipToBounds(leftMap, bounds);
-        applyZoomOutClipToBounds(rightMap, bounds);
+        if (rightMap) applyZoomOutClipToBounds(rightMap, bounds);
       }
 
       if (siteId) {
@@ -3190,7 +3286,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!container || !leftClipContainer || !rightClipContainer || !slider || !leftMap || !rightMap) {
+    if (!container || !leftClipContainer || !rightClipContainer || !slider || !leftMap) {
       return;
     }
 
@@ -3222,7 +3318,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     rightContainer.style.left = `${-(parentWidth - rightClipWidth)}px`;
 
     leftMap.resize();
-    rightMap.resize();
+    rightMap?.resize();
   }, [isSwiperEnabled]);
 
   // Synchronize slider position when prop changes (from another pane)
@@ -3237,7 +3333,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!container || !slider || !handle || !leftClipContainer || !rightClipContainer || !leftMap || !rightMap) return;
+    if (!container || !slider || !handle || !leftClipContainer || !rightClipContainer || !leftMap) return;
 
     // Don't update if we're currently dragging (to avoid feedback loop)
     if (isDragging.current) return;
@@ -3309,13 +3405,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     rightContainer.style.left = `${-(parentWidth - rightClipWidth)}px`;
 
     leftMap.resize();
-    rightMap.resize();
+    rightMap?.resize();
   }, [swiperPosition, isSwiperEnabled]);
 
   useEffect(() => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
-    if (!leftMap || !rightMap || !mapsReady.current.left || !mapsReady.current.right) return;
+    if (!leftMap || !mapsReady.current.left || !mapsReady.current.right) return;
 
     if (isChoroplethEnabled) {
       applyColorsRef.current();
@@ -3382,7 +3478,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap) return;
+    if (!leftMap) return;
     if (!mapsReady.current.left || !mapsReady.current.right) return;
 
     // Helper to remove highlight layers from a map
@@ -3443,14 +3539,16 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     // Remove existing highlights
     removeHighlight(leftMap);
-    removeHighlight(rightMap);
+    if (rightMap) removeHighlight(rightMap);
 
     // Add highlight if there's an identify result
     if (identifyResult?.catchmentID) {
       addHighlight(leftMap, 'left', identifyResult.catchmentID);
-      addHighlight(rightMap, 'right', identifyResult.catchmentID);
+      if (rightMap) addHighlight(rightMap, 'right', identifyResult.catchmentID);
     }
-  }, [identifyResult]);
+  // isSwiperEnabled: the right map is created and destroyed with compare mode,
+  // so a highlight raised while it was absent has to be mirrored onto it.
+  }, [identifyResult, isSwiperEnabled]);
 
   // Fetch and display site boundary when siteId changes or maps become ready
   useEffect(() => {
@@ -3458,12 +3556,16 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const rightMap = rightMapRef.current;
 
     // Wait until maps are ready (state-based trigger ensures re-run)
-    if (!leftMap || !rightMap || !areMapsReady) return;
+    if (!leftMap || !areMapsReady) return;
+
+    // rightMap is null outside compare mode, so the per-map helpers below take
+    // a nullable map and no-op on absence — that keeps every left/right pair of
+    // calls in this effect as it was.
 
     // Helper to remove site boundary layers from a map
-    const removeSiteBoundary = (map: maplibregl.Map) => {
+    const removeSiteBoundary = (map: maplibregl.Map | null) => {
       // Safety check: map.style is undefined after map.remove() is called
-      if (!map.style) return;
+      if (!map?.style) return;
       if (map.getLayer(SITE_BOUNDARY_LINE)) map.removeLayer(SITE_BOUNDARY_LINE);
       if (map.getLayer(SITE_BOUNDARY_GLOW_MIDDLE)) map.removeLayer(SITE_BOUNDARY_GLOW_MIDDLE);
       if (map.getLayer(SITE_BOUNDARY_OFFWHITE)) map.removeLayer(SITE_BOUNDARY_OFFWHITE);
@@ -3478,7 +3580,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       addBoundaryLayersIfMissing(map, normalized);
     };
 
-    const addSiteBoundaryWhenReady = (map: maplibregl.Map, geometry: GeoJSON.Geometry) => {
+    const addSiteBoundaryWhenReady = (map: maplibregl.Map | null, geometry: GeoJSON.Geometry) => {
+      if (!map) return;
       if (map.style) {
         addSiteBoundary(map, geometry);
         moveSiteBoundaryToTop(map);
@@ -3503,8 +3606,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       addSiteBoundaryWhenReady(map, geometry);
     };
 
-    const updateSiteBoundarySource = (map: maplibregl.Map, geometry: GeoJSON.Geometry): boolean => {
-      if (!map.style) return false;
+    const updateSiteBoundarySource = (map: maplibregl.Map | null, geometry: GeoJSON.Geometry): boolean => {
+      if (!map?.style) return false;
       const source = map.getSource(SITE_BOUNDARY_SOURCE) as maplibregl.GeoJSONSource;
       if (!source) return false;
 
@@ -3582,17 +3685,19 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             zoomToLoadedSiteBounds();
           };
 
-          if (leftMap.loaded() && rightMap.loaded()) {
+          const allLoaded = () => leftMap.loaded() && (rightMap?.loaded() ?? true);
+
+          if (allLoaded()) {
             addToMaps();
           } else {
             // Wait for both maps to be ready
             const checkAndAdd = () => {
-              if (leftMap.loaded() && rightMap.loaded()) {
+              if (allLoaded()) {
                 addToMaps();
               }
             };
             leftMap.once('idle', checkAndAdd);
-            rightMap.once('idle', checkAndAdd);
+            rightMap?.once('idle', checkAndAdd);
           }
         } else {
           zoomToLoadedSiteBounds();
@@ -3601,16 +3706,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       .catch((err) => console.error('Failed to fetch site boundary:', err));
 
     const handleLeftStyleData = () => ensureBoundaryLayers(leftMap);
-    const handleRightStyleData = () => ensureBoundaryLayers(rightMap);
 
     leftMap.on('styledata', handleLeftStyleData);
-    rightMap.on('styledata', handleRightStyleData);
+    // The compare map's equivalent listener is wired in createRightMap, since
+    // that map can outlive or postdate any single run of this effect.
 
     // Cleanup on unmount or siteId change
     return () => {
       siteCatchmentIdsRef.current = null;
       leftMap.off('styledata', handleLeftStyleData);
-      rightMap.off('styledata', handleRightStyleData);
       if (leftMapRef.current) removeSiteBoundary(leftMapRef.current);
       if (rightMapRef.current) removeSiteBoundary(rightMapRef.current);
     };
@@ -4031,7 +4135,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const updateEditVerticesLayer = useCallback((vertices: [number, number][]) => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
-    if (!leftMap || !rightMap) return;
+    if (!leftMap) return;
 
     const updateMapVertices = (map: maplibregl.Map) => {
       // Safety check: map.style is undefined after map.remove() is called
@@ -4098,7 +4202,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     };
 
     if (leftMap.style) updateMapVertices(leftMap);
-    if (rightMap.style) updateMapVertices(rightMap);
+    if (rightMap?.style) updateMapVertices(rightMap);
   }, []);
 
   // Remove edit vertices layers
@@ -4123,7 +4227,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const updateBoundaryDisplay = useCallback((vertices: [number, number][]) => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
-    if (!leftMap || !rightMap || !siteGeometryRef.current) return;
+    if (!leftMap || !siteGeometryRef.current) return;
 
     const newGeometry = buildGeometryFromVertices(vertices, siteGeometryRef.current);
 
@@ -4143,7 +4247,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     };
 
     updateSource(leftMap);
-    updateSource(rightMap);
+    if (rightMap) updateSource(rightMap);
 
     // Keep the ref in sync so any style/resize-triggered re-apply of the
     // boundary layers (e.g. reapplyBoundaryLayers) uses the live-edited
@@ -4156,9 +4260,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap || !mapsReady.current.left || !mapsReady.current.right) {
+    if (!leftMap || !mapsReady.current.left || !mapsReady.current.right) {
       return;
     }
+
+    // The compare map exists only while compare mode is on, so edit
+    // interactions are wired onto whichever instances are live right now.
+    // isSwiperEnabled is in the dependency list below so one created or
+    // released mid-edit is picked up.
+    const maps = rightMap ? [leftMap, rightMap] : [leftMap];
 
     if (isBoundaryEditMode && siteGeometryRef.current) {
       // Enter edit mode
@@ -4170,8 +4280,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       zoomToSiteRef.current({ pitch: 0 });
 
       // Change cursor to indicate draggable points
-      leftMap.getCanvas().style.cursor = 'grab';
-      rightMap.getCanvas().style.cursor = 'grab';
+      for (const map of maps) map.getCanvas().style.cursor = 'grab';
 
       // Set up drag handlers
       const handleMouseDown = (e: maplibregl.MapMouseEvent, map: maplibregl.Map) => {
@@ -4217,10 +4326,10 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       const handleMouseUp = () => {
         if (draggingVertexIndexRef.current !== null) {
           draggingVertexIndexRef.current = null;
-          leftMap.getCanvas().style.cursor = 'grab';
-          rightMap.getCanvas().style.cursor = 'grab';
-          leftMap.dragPan.enable();
-          rightMap.dragPan.enable();
+          for (const map of maps) {
+            map.getCanvas().style.cursor = 'grab';
+            map.dragPan.enable();
+          }
 
           // Notify parent of the updated geometry
           if (onBoundaryUpdateRef.current && siteGeometryRef.current) {
@@ -4230,33 +4339,27 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         }
       };
 
-      const onLeftMouseDown = (e: maplibregl.MapMouseEvent) => handleMouseDown(e, leftMap);
-      const onRightMouseDown = (e: maplibregl.MapMouseEvent) => handleMouseDown(e, rightMap);
+      const cleanups: Array<() => void> = [];
+      for (const map of maps) {
+        const onMouseDown = (e: maplibregl.MapMouseEvent) => handleMouseDown(e, map);
+        map.on('mousedown', onMouseDown);
+        map.on('mousemove', handleMouseMove);
+        map.on('mouseup', handleMouseUp);
+        cleanups.push(() => {
+          map.off('mousedown', onMouseDown);
+          map.off('mousemove', handleMouseMove);
+          map.off('mouseup', handleMouseUp);
+          map.getCanvas().style.cursor = '';
+        });
+      }
 
-      leftMap.on('mousedown', onLeftMouseDown);
-      rightMap.on('mousedown', onRightMouseDown);
-      leftMap.on('mousemove', handleMouseMove);
-      rightMap.on('mousemove', handleMouseMove);
-      leftMap.on('mouseup', handleMouseUp);
-      rightMap.on('mouseup', handleMouseUp);
-
-      return () => {
-        leftMap.off('mousedown', onLeftMouseDown);
-        rightMap.off('mousedown', onRightMouseDown);
-        leftMap.off('mousemove', handleMouseMove);
-        rightMap.off('mousemove', handleMouseMove);
-        leftMap.off('mouseup', handleMouseUp);
-        rightMap.off('mouseup', handleMouseUp);
-        leftMap.getCanvas().style.cursor = '';
-        rightMap.getCanvas().style.cursor = '';
-      };
+      return () => cleanups.forEach((cleanup) => cleanup());
     } else {
       // Exit edit mode
       removeEditVerticesLayers();
       editVerticesRef.current = [];
       draggingVertexIndexRef.current = null;
-      leftMap.getCanvas().style.cursor = '';
-      rightMap.getCanvas().style.cursor = '';
+      for (const map of maps) map.getCanvas().style.cursor = '';
     }
     // siteGeometry intentionally excluded: this effect sets up/tears down
     // the vertex-drag handlers for entering/exiting edit mode. It read
@@ -4268,14 +4371,14 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // exiting edit mode. siteGeometryRef.current is used instead so this
     // only reacts to isBoundaryEditMode transitions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isBoundaryEditMode, extractVertices, updateEditVerticesLayer, removeEditVerticesLayers, updateBoundaryDisplay, buildGeometryFromVertices]);
+  }, [isBoundaryEditMode, isSwiperEnabled, extractVertices, updateEditVerticesLayer, removeEditVerticesLayers, updateBoundaryDisplay, buildGeometryFromVertices]);
 
   // Handle catchment add/remove click events
   useEffect(() => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap || !isBoundaryEditMode || !catchmentEditMode) {
+    if (!leftMap || !isBoundaryEditMode || !catchmentEditMode) {
       return;
     }
 
@@ -4283,50 +4386,48 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       setVertexEditMode(null);
     }
 
+    // The compare map exists only while compare mode is on, so edit
+    // interactions are wired onto whichever instances are live right now.
+    // isSwiperEnabled is in the dependency list below so one created or
+    // released mid-edit is picked up.
+    const maps = rightMap ? [leftMap, rightMap] : [leftMap];
+
     // Change cursor based on mode
     const cursor = catchmentEditMode === 'add' ? ADD_CATCHMENT_CURSOR : REMOVE_CATCHMENT_CURSOR;
-    leftMap.getCanvas().style.cursor = cursor;
-    rightMap.getCanvas().style.cursor = cursor;
 
-    // Prevent drag-pan from stealing the click for catchment edits
-    leftMap.dragPan.disable();
-    rightMap.dragPan.disable();
+    const cleanups: Array<() => void> = [];
+    for (const map of maps) {
+      map.getCanvas().style.cursor = cursor;
+      // Prevent drag-pan from stealing the click for catchment edits
+      map.dragPan.disable();
 
-    const onLeftClick = (e: maplibregl.MapMouseEvent) => handleCatchmentEditClick(leftMap, e);
-    const onRightClick = (e: maplibregl.MapMouseEvent) => handleCatchmentEditClick(rightMap, e);
-    const onLeftMove = () => {
-      leftMap.getCanvas().style.cursor = cursor;
-    };
-    const onRightMove = () => {
-      rightMap.getCanvas().style.cursor = cursor;
-    };
+      const onClick = (e: maplibregl.MapMouseEvent) => handleCatchmentEditClick(map, e);
+      const onMove = () => {
+        map.getCanvas().style.cursor = cursor;
+      };
+      map.on('click', onClick);
+      map.on('mousemove', onMove);
 
-    leftMap.on('click', onLeftClick);
-    rightMap.on('click', onRightClick);
-    leftMap.on('mousemove', onLeftMove);
-    rightMap.on('mousemove', onRightMove);
+      cleanups.push(() => {
+        map.off('click', onClick);
+        map.off('mousemove', onMove);
+        map.dragPan.enable();
+        // Restore cursor based on whether we're still in edit mode
+        if (isBoundaryEditModeRef.current) {
+          map.getCanvas().style.cursor = 'grab';
+        }
+      });
+    }
 
-    return () => {
-      leftMap.off('click', onLeftClick);
-      rightMap.off('click', onRightClick);
-      leftMap.off('mousemove', onLeftMove);
-      rightMap.off('mousemove', onRightMove);
-      leftMap.dragPan.enable();
-      rightMap.dragPan.enable();
-      // Restore cursor based on whether we're still in edit mode
-      if (isBoundaryEditModeRef.current) {
-        leftMap.getCanvas().style.cursor = 'grab';
-        rightMap.getCanvas().style.cursor = 'grab';
-      }
-    };
-  }, [isBoundaryEditMode, catchmentEditMode, handleCatchmentEditClick]);
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [isBoundaryEditMode, isSwiperEnabled, catchmentEditMode, handleCatchmentEditClick]);
 
   // Handle vertex delete/add mode
   useEffect(() => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
 
-    if (!leftMap || !rightMap || !isBoundaryEditMode || !vertexEditMode) {
+    if (!leftMap || !isBoundaryEditMode || !vertexEditMode) {
       return;
     }
 
@@ -4334,9 +4435,14 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       setCatchmentEditMode(null);
     }
 
+    // The compare map exists only while compare mode is on, so edit
+    // interactions are wired onto whichever instances are live right now.
+    // isSwiperEnabled is in the dependency list below so one created or
+    // released mid-edit is picked up.
+    const maps = rightMap ? [leftMap, rightMap] : [leftMap];
+
     const cursor = vertexEditMode === 'delete' ? DELETE_VERTEX_CURSOR : ADD_VERTEX_CURSOR;
-    leftMap.getCanvas().style.cursor = cursor;
-    rightMap.getCanvas().style.cursor = cursor;
+    for (const map of maps) map.getCanvas().style.cursor = cursor;
 
     const handleVertexDelete = (map: maplibregl.Map, e: maplibregl.MapMouseEvent) => {
       const features = map.queryRenderedFeatures(e.point, {
@@ -4383,45 +4489,35 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       }
     };
 
-    const onLeftClick = (e: maplibregl.MapMouseEvent) => {
-      if (vertexEditMode === 'delete') {
-        handleVertexDelete(leftMap, e);
-      } else {
-        handleVertexAdd(e);
-      }
-    };
-    const onRightClick = (e: maplibregl.MapMouseEvent) => {
-      if (vertexEditMode === 'delete') {
-        handleVertexDelete(rightMap, e);
-      } else {
-        handleVertexAdd(e);
-      }
-    };
-    const onLeftMove = () => {
-      leftMap.getCanvas().style.cursor = cursor;
-    };
-    const onRightMove = () => {
-      rightMap.getCanvas().style.cursor = cursor;
-    };
+    const cleanups: Array<() => void> = [];
+    for (const map of maps) {
+      const onClick = (e: maplibregl.MapMouseEvent) => {
+        if (vertexEditMode === 'delete') {
+          handleVertexDelete(map, e);
+        } else {
+          handleVertexAdd(e);
+        }
+      };
+      const onMove = () => {
+        map.getCanvas().style.cursor = cursor;
+      };
 
-    leftMap.on('click', onLeftClick);
-    rightMap.on('click', onRightClick);
-    leftMap.on('mousemove', onLeftMove);
-    rightMap.on('mousemove', onRightMove);
+      map.on('click', onClick);
+      map.on('mousemove', onMove);
 
-    return () => {
-      leftMap.off('click', onLeftClick);
-      rightMap.off('click', onRightClick);
-      leftMap.off('mousemove', onLeftMove);
-      rightMap.off('mousemove', onRightMove);
-      if (isBoundaryEditModeRef.current) {
-        leftMap.getCanvas().style.cursor = 'grab';
-        rightMap.getCanvas().style.cursor = 'grab';
-      }
-    };
+      cleanups.push(() => {
+        map.off('click', onClick);
+        map.off('mousemove', onMove);
+        if (isBoundaryEditModeRef.current) {
+          map.getCanvas().style.cursor = 'grab';
+        }
+      });
+    }
+
+    return () => cleanups.forEach((cleanup) => cleanup());
   // useEffect has missing dependencies: 'ADD_VERTEX_CURSOR', 'DELETE_VERTEX_CURSOR', and 'notifyBoundaryUpdate'
   // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing; see the tracking issue
-  }, [isBoundaryEditMode, vertexEditMode, updateEditVerticesLayer, updateBoundaryDisplay, buildGeometryFromVertices, insertVertexAtClosestSegment]);
+  }, [isBoundaryEditMode, isSwiperEnabled, vertexEditMode, updateEditVerticesLayer, updateBoundaryDisplay, buildGeometryFromVertices, insertVertexAtClosestSegment]);
 
   // Reset catchment edit mode when boundary edit mode is disabled
   useEffect(() => {

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -70,6 +70,17 @@ interface ViewPaneProps {
 // View mode cycle order
 const VIEW_MODES: ViewMode[] = ['map', 'chart', 'dial', 'table'];
 
+// How long a pane keeps its map mounted after switching to another view.
+//
+// A mounted MapView holds a WebGL context (two in compare mode), and browsers
+// cap the simultaneous total at around sixteen, silently dropping the oldest
+// past that. Quad view renders six panes, so a pane showing a chart must not
+// keep a map alive for the rest of the session — which is what the previous
+// one-way "has shown a map" latch did. The delay is here because a teardown is
+// not free: map -> chart -> map is a normal way to read a pane, and that round
+// trip should not pay for a fresh MapLibre init and tile fetch. See issue #76.
+const MAP_RELEASE_DELAY_MS = 15_000;
+
 // Icons and labels for each view mode
 const VIEW_MODE_CONFIG: Record<ViewMode, { icon: React.ReactElement; label: string; nextLabel: string }> = {
   map: { icon: <FiMap />, label: 'Map', nextLabel: 'Show line chart' },
@@ -130,26 +141,32 @@ function ViewPane({
   const { dial0Middle: attributeDial0Middle } = useAttributeDial0Middle();
   const [isCalcModalOpen, setIsCalcModalOpen] = useState(false);
 
-  // Lazy-mount MapView: only render once the pane has been in map mode at least once.
-  // This prevents full map initialization (tile loading, WebGL context) for panes that
-  // start in chart/dial/table mode, which was the main cause of slow quad-view transitions.
-  const [hasShownMap, setHasShownMap] = useState(viewMode === 'map');
+  // Mount MapView only while the pane is showing a map, plus a grace period.
+  // A pane that has never been in map mode never pays for map initialization
+  // (tile loading, WebGL context) — the main cause of slow quad-view
+  // transitions — and one that has left map mode gives its contexts back.
+  const [mapMounted, setMapMounted] = useState(viewMode === 'map');
   // mapReady starts false; it becomes true once MapView fires onReady.
-  // If the pane starts in map mode, hasShownMap is true but mapReady stays
+  // If the pane starts in map mode, mapMounted is true but mapReady stays
   // false until onReady fires — the spinner shows only during that initial load.
   const [mapReady, setMapReady] = useState(false);
   useEffect(() => {
     if (viewMode === 'map') {
-      setHasShownMap(prev => {
-        // Only show the spinner on the very first transition into map mode.
-        // On subsequent returns (chart → map, dial → map) MapView is still
-        // mounted and areMapsReady is already true, so onReady will never
-        // re-fire — the spinner would get stuck indefinitely.
-        if (!prev) setMapReady(false);
-        return true;
-      });
+      setMapMounted(true);
+      return;
     }
+    const releaseTimer = setTimeout(() => setMapMounted(false), MAP_RELEASE_DELAY_MS);
+    // Returning to map mode inside the grace period cancels the release, so the
+    // still-mounted MapView is simply revealed again — no reload, no spinner.
+    return () => clearTimeout(releaseTimer);
   }, [viewMode]);
+
+  // onReady fires once per MapView instance, so the spinner has to be re-armed
+  // whenever the instance goes away. Doing it here rather than on the way into
+  // map mode also guarantees it can never be left showing over a live map.
+  useEffect(() => {
+    if (!mapMounted) setMapReady(false);
+  }, [mapMounted]);
 
   // Stagger WebGL context creation across panes so the browser/GPU isn't hit with
   // 8 simultaneous map initializations. Pane 0 starts immediately; each subsequent
@@ -534,7 +551,7 @@ function ViewPane({
       border={compact ? '1px' : 'none'}
       borderColor={borderColor}
     >
-      {/* Map layer — only mounted after the pane has first entered map mode */}
+      {/* Map layer — mounted only while this pane is showing a map (issue #76) */}
       <Box
         position="absolute"
         top={0}
@@ -545,7 +562,7 @@ function ViewPane({
         transition="opacity 0.5s cubic-bezier(0.4, 0, 0.2, 1)"
         pointerEvents={viewMode === 'map' ? 'auto' : 'none'}
       >
-        {hasShownMap && mapMountReady && <MapView
+        {mapMounted && mapMountReady && <MapView
           comparison={comparison}
           onOpenSettings={() => onFocusPane(paneIndex)}
           onIdentify={onIdentify}

--- a/frontend/src/hooks/useMapSync.ts
+++ b/frontend/src/hooks/useMapSync.ts
@@ -14,7 +14,42 @@ type MapEntry = {
 const registry: MapEntry[] = [];
 let syncing = false;
 
+/** A map view, in the four properties every sync path already copies. */
+export interface SyncedMapView {
+  center: [number, number];
+  zoom: number;
+  bearing: number;
+  pitch: number;
+}
+
+// The last view any registered map reported.
+//
+// Map instances are transient: the compare map is created only while compare
+// mode is on, and a pane releases its maps when it stops displaying one, so the
+// browser is not holding WebGL contexts nothing is drawing to (issue #76). The
+// view therefore has to outlive the instances that produced it — without this,
+// every recreate would drop the user back to the default world view.
+let lastView: SyncedMapView | null = null;
+
+function captureView(map: maplibregl.Map): void {
+  const center = map.getCenter();
+  lastView = {
+    center: [center.lng, center.lat],
+    zoom: map.getZoom(),
+    bearing: map.getBearing(),
+    pitch: map.getPitch(),
+  };
+}
+
+/** The view a freshly created map should open at, or null on a cold start. */
+export function getLastMapView(): SyncedMapView | null {
+  return lastView;
+}
+
 function broadcastMove(sourceId: string, source: maplibregl.Map) {
+  // Recorded before the re-entrancy guard: a programmatic jump driven by
+  // another map still leaves the registry at a view worth restoring.
+  captureView(source);
   if (syncing) return;
   syncing = true;
   for (const entry of registry) {
@@ -60,6 +95,9 @@ export function unregisterMap(id: string) {
   const idx = registry.findIndex((e) => e.id === id);
   if (idx !== -1) {
     const entry = registry[idx];
+    // Last chance to record where this map was looking: it is about to be
+    // removed, and it may be the only one left.
+    captureView(entry.map);
     // Remove the event listener to prevent memory leaks
     entry.map.off('move', entry.handler);
     registry.splice(idx, 1);

--- a/frontend/src/test/mapSyncView.test.ts
+++ b/frontend/src/test/mapSyncView.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Map view survival across a teardown (issue #76).
+ *
+ * Map instances are no longer permanent: the compare map lives only while
+ * compare mode is on, and a pane releases its maps when it stops showing one.
+ * A recreated map therefore has to open where the last one was looking, or
+ * every release would throw the user back out to the default world view.
+ *
+ * The sync registry is where that view already flows through, so it is what
+ * remembers it.
+ */
+import { describe, it, expect } from 'vitest';
+import type maplibregl from 'maplibre-gl';
+import { registerMap, unregisterMap, getLastMapView } from '../hooks/useMapSync';
+
+/** Minimal stand-in for the handful of methods the registry touches. */
+function fakeMap(view: { lng: number; lat: number; zoom: number; bearing?: number; pitch?: number }) {
+  const listeners: Array<() => void> = [];
+  const state = { ...view, bearing: view.bearing ?? 0, pitch: view.pitch ?? 0 };
+
+  const map = {
+    getCenter: () => ({ lng: state.lng, lat: state.lat }),
+    getZoom: () => state.zoom,
+    getBearing: () => state.bearing,
+    getPitch: () => state.pitch,
+    jumpTo: (target: { center: { lng: number; lat: number }; zoom: number }) => {
+      state.lng = target.center.lng;
+      state.lat = target.center.lat;
+      state.zoom = target.zoom;
+    },
+    on: (_event: string, handler: () => void) => listeners.push(handler),
+    off: () => {},
+    /** Move the map the way a user pan/zoom would, then notify the registry. */
+    moveTo(next: { lng: number; lat: number; zoom: number }) {
+      Object.assign(state, next);
+      for (const handler of listeners) handler();
+    },
+  };
+
+  return map as unknown as maplibregl.Map & { moveTo: (n: { lng: number; lat: number; zoom: number }) => void };
+}
+
+describe('map sync view memory', () => {
+  it('round-trips the view through a teardown and recreate', () => {
+    const first = fakeMap({ lng: 0, lat: 0, zoom: 3 });
+    const firstId = registerMap(first);
+
+    first.moveTo({ lng: 28.19, lat: -25.75, zoom: 11.5 });
+
+    // The pane switches away from map view, or compare mode ends: the instance
+    // goes, the view must not.
+    unregisterMap(firstId);
+
+    const remembered = getLastMapView();
+    expect(remembered).not.toBeNull();
+    expect(remembered?.center[0]).toBeCloseTo(28.19);
+    expect(remembered?.center[1]).toBeCloseTo(-25.75);
+    expect(remembered?.zoom).toBeCloseTo(11.5);
+  });
+
+  it('records the view of a map that never moved before being released', () => {
+    const map = fakeMap({ lng: 18.42, lat: -33.92, zoom: 9 });
+    unregisterMap(registerMap(map));
+
+    expect(getLastMapView()?.center[0]).toBeCloseTo(18.42);
+    expect(getLastMapView()?.zoom).toBeCloseTo(9);
+  });
+
+  it('still syncs a newly registered map to a live one', () => {
+    const live = fakeMap({ lng: 0, lat: 0, zoom: 3 });
+    const liveId = registerMap(live);
+    live.moveTo({ lng: 31.05, lat: -17.83, zoom: 8 });
+
+    const fresh = fakeMap({ lng: 0, lat: 0, zoom: 3 });
+    const freshId = registerMap(fresh);
+
+    expect(fresh.getCenter().lng).toBeCloseTo(31.05);
+    expect(fresh.getZoom()).toBeCloseTo(8);
+
+    unregisterMap(freshId);
+    unregisterMap(liveId);
+  });
+});

--- a/frontend/src/test/paneMapLifecycle.test.tsx
+++ b/frontend/src/test/paneMapLifecycle.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Pane map lifecycle (issue #76).
+ *
+ * ViewPane used to latch "this pane has shown a map" on first display and never
+ * clear it: the map stayed mounted behind `opacity: 0` for the rest of the
+ * session, so a quad view where every pane had once shown a map held six panes'
+ * worth of WebGL contexts no matter what those panes were displaying.
+ *
+ * MapView is stubbed here — this is about when the pane mounts and unmounts it,
+ * not about what it draws.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState } from '../types';
+
+vi.mock('../components/MapView', async () => {
+  const { useEffect } = await import('react');
+  return {
+    default: function MapViewStub({ onReady }: { onReady?: () => void }) {
+      useEffect(() => {
+        onReady?.();
+      }, [onReady]);
+      return <div data-testid="map-view" />;
+    },
+  };
+});
+
+// Rendered alongside the map in every pane, and irrelevant here: ChartView and
+// DialChart pull in plotly.
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { headers: { 'content-type': 'application/json' } })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'current',
+  rightScenario: 'future',
+  attribute: '',
+};
+
+describe('ViewPane map mounting', () => {
+  const renderPane = async (viewMode: 'map' | 'chart') => {
+    const ViewPane = (await import('../components/ViewPane')).default;
+
+    const pane = (mode: 'map' | 'chart') => (
+      <ChakraProvider theme={theme}>
+        <ViewPane
+          comparison={comparison}
+          paneIndex={0}
+          layoutMode="quad"
+          viewMode={mode}
+          onViewModeChange={() => {}}
+          onFocusPane={() => {}}
+          onGoQuad={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+        />
+      </ChakraProvider>
+    );
+
+    const utils = render(pane(viewMode));
+    return { ...utils, pane };
+  };
+
+  it('mounts no map for a pane that has never shown one', async () => {
+    await renderPane('chart');
+    expect(screen.queryByTestId('map-view')).toBeNull();
+  });
+
+  it('unmounts the map once the pane has stopped showing one', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { rerender, pane } = await renderPane('map');
+      expect(screen.getByTestId('map-view')).toBeInTheDocument();
+
+      rerender(pane('chart'));
+      // Still mounted inside the grace period: a quick map -> chart -> map
+      // round trip must not pay for a full re-init.
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(screen.queryByTestId('map-view')).not.toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(20_000);
+      });
+      expect(screen.queryByTestId('map-view')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the map mounted when the pane returns to map view in time', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { rerender, pane } = await renderPane('map');
+
+      rerender(pane('chart'));
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+      rerender(pane('map'));
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(screen.queryByTestId('map-view')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/test/webglContextBudget.test.tsx
+++ b/frontend/src/test/webglContextBudget.test.tsx
@@ -1,0 +1,363 @@
+/**
+ * WebGL context budget (issue #76).
+ *
+ * Every MapLibre instance holds a WebGL context, browsers cap the simultaneous
+ * total at around sixteen, and quad view renders six panes. Two unconditional
+ * instances per pane put the application at twelve before Plotly asks for any.
+ *
+ * WebGL itself cannot be exercised in jsdom, so this counts the decision that
+ * sets the context budget instead: how many MapLibre instances one MapView
+ * constructs, and whether it gives the compare one back. The context count as
+ * the browser sees it still has to be read in a browser.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState, ViewMode } from '../types';
+
+// --- MapLibre stand-in --------------------------------------------------------
+// Records every construction and removal so a test can count contexts asked for.
+
+const constructed: FakeMap[] = [];
+
+class FakeMap {
+  container: unknown;
+  removed = false;
+  private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  private canvas = document.createElement('canvas');
+
+  constructor(options: { container: unknown }) {
+    this.container = options.container;
+    constructed.push(this);
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler);
+    this.handlers.set(event, existing);
+    return this;
+  }
+
+  once(event: string, handler: (...args: unknown[]) => void) {
+    return this.on(event, handler);
+  }
+
+  off() {
+    return this;
+  }
+
+  fire(event: string) {
+    for (const handler of this.handlers.get(event) ?? []) handler();
+  }
+
+  addControl() {
+    return this;
+  }
+
+  getCenter() {
+    return { lng: 20, lat: 0 };
+  }
+
+  getZoom() {
+    return 3;
+  }
+
+  getBearing() {
+    return 0;
+  }
+
+  getPitch() {
+    return 0;
+  }
+
+  getBounds() {
+    return {
+      getWest: () => 0,
+      getSouth: () => 0,
+      getEast: () => 1,
+      getNorth: () => 1,
+    };
+  }
+
+  getCanvas() {
+    return this.canvas;
+  }
+
+  getStyle() {
+    return { sources: {} };
+  }
+
+  getSource() {
+    return undefined;
+  }
+
+  getLayer() {
+    return undefined;
+  }
+
+  get style() {
+    return undefined;
+  }
+
+  loaded() {
+    return false;
+  }
+
+  isStyleLoaded() {
+    return false;
+  }
+
+  jumpTo() {}
+  easeTo() {}
+  fitBounds() {}
+  setStyle() {}
+  resize() {}
+  triggerRepaint() {}
+  setMaxBounds() {}
+  setMinZoom() {}
+  setMaxZoom() {}
+  queryRenderedFeatures() {
+    return [];
+  }
+
+  project() {
+    return { x: 0, y: 0 };
+  }
+
+  dragPan = { enable() {}, disable() {} };
+
+  remove() {
+    this.removed = true;
+  }
+}
+
+vi.mock('maplibre-gl', () => {
+  class NavigationControl {}
+  const api = { Map: FakeMap, NavigationControl };
+  return { ...api, default: api };
+});
+
+// The quad-view count below renders whole panes. Only the map matters here, and
+// ChartView and DialChart pull in plotly.
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+// The map init effect kicks off catchment/tile bounds requests and the attribute
+// metadata hooks fetch on mount. Nothing here asserts on them; this only keeps
+// them from reaching the network or rejecting into the console.
+beforeEach(() => {
+  constructed.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { headers: { 'content-type': 'application/json' } })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'current',
+  rightScenario: 'future',
+  attribute: '',
+};
+
+describe('MapView WebGL instances', () => {
+  it('creates one map, not two, when compare mode is off', async () => {
+    const MapView = (await import('../components/MapView')).default;
+
+    render(
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled={false}
+        />
+      </ChakraProvider>,
+    );
+
+    expect(constructed).toHaveLength(1);
+  });
+
+  it('creates the compare map only on entering compare mode', async () => {
+    const MapView = (await import('../components/MapView')).default;
+
+    const view = (isSwiperEnabled: boolean) => (
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled={isSwiperEnabled}
+        />
+      </ChakraProvider>
+    );
+
+    const { rerender } = render(view(false));
+    expect(constructed).toHaveLength(1);
+
+    rerender(view(true));
+    expect(constructed).toHaveLength(2);
+    expect(constructed[1].removed).toBe(false);
+  });
+
+  it('releases the compare map on leaving compare mode', async () => {
+    const MapView = (await import('../components/MapView')).default;
+
+    const view = (isSwiperEnabled: boolean) => (
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled={isSwiperEnabled}
+        />
+      </ChakraProvider>
+    );
+
+    const { rerender } = render(view(true));
+    expect(constructed).toHaveLength(2);
+
+    rerender(view(false));
+
+    const [leftMap, rightMap] = constructed;
+    expect(rightMap.removed).toBe(true);
+    // The map the user is actually looking at must not be disturbed by the
+    // compare map coming and going.
+    expect(leftMap.removed).toBe(false);
+    expect(constructed).toHaveLength(2);
+  });
+
+  it('releases both maps on unmount', async () => {
+    const MapView = (await import('../components/MapView')).default;
+
+    const { unmount } = render(
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled
+        />
+      </ChakraProvider>,
+    );
+
+    expect(constructed).toHaveLength(2);
+    unmount();
+    expect(constructed.every((map) => map.removed)).toBe(true);
+  });
+});
+
+// The number the issue asks to see fall: not a browser context counter, which
+// jsdom cannot provide, but the count of MapLibre instances a full quad view
+// asks for. Before this change it was six panes x two maps = twelve, whatever
+// compare mode was doing and whatever each pane was displaying.
+//
+// Note the compare swiper defaults to ON in App.tsx, so the twelve only falls
+// to six once the user turns it off — the pane-level release below is what
+// bounds the default configuration.
+describe('quad view map instance count', () => {
+  const PANES = 6;
+
+  const renderQuad = async (viewModes: ViewMode[], isSwiperEnabled: boolean) => {
+    const ViewPane = (await import('../components/ViewPane')).default;
+
+    const quad = (modes: ViewMode[]) => (
+      <ChakraProvider theme={theme}>
+        {modes.map((mode, index) => (
+          <ViewPane
+            key={index}
+            comparison={comparison}
+            paneIndex={index}
+            layoutMode="quad"
+            viewMode={mode}
+            isSwiperEnabled={isSwiperEnabled}
+            onViewModeChange={() => {}}
+            onFocusPane={() => {}}
+            onGoQuad={() => {}}
+            colorScaleMode="rainbow"
+            colorScaleType="linear"
+          />
+        ))}
+      </ChakraProvider>
+    );
+
+    const utils = render(quad(viewModes));
+    // Panes stagger their map creation by 250 ms each; let them all land.
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    return { ...utils, quad };
+  };
+
+  const allMaps = () => Array.from({ length: PANES }, () => 'map' as ViewMode);
+
+  it('asks for one context per pane when compare mode is off', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await renderQuad(allMaps(), false);
+      expect(constructed).toHaveLength(PANES);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('asks for two per pane in compare mode, which is the worst case', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await renderQuad(allMaps(), true);
+      // Twelve is the pre-existing ceiling, and it is only reachable now with
+      // every pane on a map and the swiper on — not, as before, by six panes
+      // having each shown a map once at some point in the session.
+      expect(constructed).toHaveLength(PANES * 2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Two panes stay on the map; the other four move to a chart, dial or table.
+  const mixed: ViewMode[] = ['map', 'map', 'chart', 'chart', 'dial', 'table'];
+
+  it('holds nothing for panes that have left map view', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { rerender, quad } = await renderQuad(allMaps(), true);
+      expect(constructed).toHaveLength(PANES * 2);
+
+      rerender(quad(mixed));
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      const live = constructed.filter((map) => !map.removed);
+      expect(live).toHaveLength(2 * 2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('bottoms out at one context per displayed map', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { rerender, quad } = await renderQuad(allMaps(), false);
+      rerender(quad(mixed));
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      const live = constructed.filter((map) => !map.removed);
+      expect(live).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## What was happening

Each `MapView` built **two** MapLibre instances unconditionally, and quad view
renders all six panes — twelve WebGL contexts. They were never released either:
`ViewPane` latched `hasShownMap` on first display and never cleared it, hiding the
map with `opacity={0}` while leaving `MapView` mounted. Once a pane had shown a
map, its two contexts persisted for the session regardless of what it displayed
afterwards. Browsers cap simultaneous contexts around 16 and silently drop the
oldest past that.

## What changed

**The compare map is created on entering compare mode** and removed on leaving.
Both functions live inside the map-init effect because they need its container and
helpers, driven by a small effect keyed on `isSwiperEnabled` declared immediately
after it. That placement is load-bearing: React runs all changed effects' cleanups
before any effect body, so effects listing `isSwiperEnabled` detach from a live
instance before it is removed, and bodies run in declaration order so they see the
new one.

**The pane latch becomes two-way.** `mapMounted` clears 15 s after a pane leaves
map view, cancelled if it returns. The latch's original purpose is preserved — a
pane that has never shown a map still pays nothing, and a quick map→chart→map flip
doesn't remount.

**The view survives a teardown.** `useMapSync` now records the last view each map
reported and on unregister, and a fresh map's constructor opens there. Without
this a release would snap the user back to `[20,0]`/zoom 3, because the
site-bounds fit keys on `siteBounds` and doesn't re-run on remount. This had to be
solved before anything could be released.

## Measured

MapLibre constructor calls, six real `ViewPane`s in quad under jsdom with
`maplibre-gl` mocked. **Not browser context counts** — but they are what decides
how many contexts the browser is asked for. The "before" column is the same test
file run against the unmodified components, not an estimate.

| quad view, six panes | before | after |
|---|---:|---:|
| all six on a map, compare off | 12 | **6** |
| all six on a map, compare on | 12 | 12 |
| two on a map, four on chart/dial/table (compare on) | 12 live | **4** |
| two on a map, four elsewhere (compare off) | 12 live | **2** |

## The finding worth your attention

**The compare swiper defaults to on** — `App.tsx:95`, `useState(true)`. So the
issue's premise that "creating `rightMap` lazily roughly halves this" **does not
hold in the default configuration**: with compare on and six maps shown, it is
still twelve. Lazy creation pays when the user turns the swiper off; what bounds
the default case is the pane release — row three is the real shape of the win,
because the count now tracks what is on screen instead of ratcheting to twelve and
staying there.

Whether that default should flip is a UX call, not one to make inside a
performance fix. It is the biggest remaining lever.

## Tests

14 new tests across three files: context counting with maplibre stubbed, pane
mount/release with MapView stubbed, and the view round-trip.

**Verified against the unfixed code by restoring main's `MapView.tsx`,
`ViewPane.tsx` and `useMapSync.ts`: 9 fail, 5 pass.** The 5 that pass are
regression guards rather than proofs of this change, and the notes say so.

Full suite 16 files / 101 tests (was 13 / 87), `tsc --noEmit` clean, `eslint src/`
clean.

## Not verified here

- **The browser-side criteria.** A context counter and "no context-loss warning on
  integrated graphics" need a real browser and GPU. The constructor counts are a
  proxy for the first and say nothing about the second — worth checking in the
  desktop app with `about:gpu` before closing the issue.
- **"No visible jump" is reasoned, not observed.** The view value round-trips and
  the constructor consumes it; the restore is in the constructor rather than a
  post-hoc `jumpTo`, which is the safest place for it. Only a browser confirms the
  absence of a flash.
- **15 s is a judgement call**, not a measured optimum — one constant in
  `ViewPane.tsx`.
- **A brief pause in choropleth updates while the compare map loads.**
  `applyColors` waits for both maps, so a pan won't recolour for roughly its load
  time after entering compare mode. It self-corrects on the map's `load`. Same
  semantics as the existing initial load.

Fixes #76
