### PR TITLE
perf(choropleth): serve catchment geometry from vector tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **The choropleth is served as vector tiles instead of a GeoJSON source.** The tile
+  pipeline already carried the catchment polygons — `gpkg_to_mbtiles.sh` tiles
+  `catchments_lev12` alongside the basemap layers — but the layer users actually look
+  at was not using them. It refetched the same geometry as GeoJSON on every viewport
+  change and handed it to `setData`, so every pan paid for a fresh parse, tessellation
+  and GPU upload, once per map instance, twelve instances live in grid view.
+
+  From the tiled zoom range up, geometry now comes from the tiles: MapLibre fetches and
+  tessellates each tile once and reuses it for every later pan, zoom and indicator
+  change. The values are fetched separately from the new geometry-free
+  `GET /api/catchment-values` and joined onto the tiles as feature state, which is why
+  switching indicator no longer moves geometry at all.
+
+  | one viewport's payload, 5,000 catchments, modelled at the ~1.5 KB/catchment the server records | raw | gzip (level 5) | main-thread `JSON.parse` |
+  |---|---:|---:|---:|
+  | `/api/choropleth` GeoJSON | 7,810,860 B | 2,448,201 B | 79.2 ms |
+  | `/api/catchment-values` | 146,017 B | 55,494 B | 0.53 ms |
+
+  Colouring is unchanged: the same data-driven `fill-color` expression, evaluated on the
+  GPU, with no per-feature JavaScript. Only where the expression reads a catchment's
+  value from differs — feature properties on the GeoJSON path, feature state on the tile
+  path — and the two are asserted to be identical expressions bar that accessor.
+
+  Below the tiled zoom range nothing changes: the server returns grid-aggregated cells
+  there, which have no tiled equivalent, and the GeoJSON path still serves them. The
+  choice is made from the served TileJSON, so a datapack whose tiles predate catchment
+  tiling stays on the GeoJSON path at every zoom rather than rendering nothing.
+
 - **The browser stored three to eight times more than it needed to, and rewrote all
   of it on every save.** A user's sites live in their browser — that is the design
   brief — so this is the system of record, not a cache. Three things made it

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -274,6 +274,9 @@ Each pane supports three visualization modes, cycled via toolbar button:
   `canmap`, `cangraph`, `axislabels`, `xaxislabels`, `units`, `charttypes`,
   `groupingvariables`, `groupingvalues`, `dial0middle`
 - `GET /api/choropleth` - GeoJSON for viewport (`valuesOnly=1` returns every catchment's raw value)
+- `GET /api/catchment-values` - catchment ids and values for a viewport, no geometry; the
+  join payload for the vector-tile choropleth, which sources geometry from
+  `catchments_lev12` in the tile pipeline and applies values as MapLibre feature state
 - `GET /api/scenario/{scenario}/{attribute}` - Attribute values for all catchments
 - `GET /api/catchment/{id}` - Catchment details
 - `GET /api/aggregate` - Area-weighted aggregates for an extent

--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -146,8 +146,10 @@ if the ID is not found.
 
 ### `GET /api/choropleth`
 
-The main map data endpoint. Returns a GeoJSON `FeatureCollection` of catchment polygons
-with the requested attribute in each feature's properties.
+Returns a GeoJSON `FeatureCollection` of catchment polygons with the requested attribute
+in each feature's properties. Used below the zoom range covered by the catchment vector
+tiles, where the server returns grid-aggregated cells rather than catchments; above it the
+map uses `/api/catchment-values` against the tiled geometry instead.
 
 | Query parameter | Description |
 |---|---|
@@ -157,6 +159,36 @@ with the requested attribute in each feature's properties.
 | `zoom` | Current map zoom; selects the server-side aggregation tier |
 | `siteId` | Optional; applies site-specific ideal overrides |
 | `valuesOnly` | `1` bypasses zoom aggregation and returns every catchment's raw value with null geometry |
+
+### `GET /api/catchment-values`
+
+The values half of the vector-tile choropleth: every catchment's value for one attribute
+within a viewport, with **no geometry at all**. Geometry comes from the tile pipeline and
+is reused across attributes, so this is the only thing a pan or an indicator change has to
+move over the wire. The response is two index-aligned arrays rather than one object per
+catchment, which at these sizes is roughly an order of magnitude smaller than the
+equivalent `FeatureCollection` scaffolding.
+
+| Query parameter | Description |
+|---|---|
+| `scenario` | `reference`, `current` or `future` |
+| `attribute` | Attribute column name |
+| `minx`, `miny`, `maxx`, `maxy` | Viewport bounding box |
+| `siteId` | Optional; applies site-specific ideal overrides (`future` only) |
+
+```json
+{
+  "scenario": "current",
+  "attribute": "rainfall_mm",
+  "ids": [1120000010, 1120000011],
+  "values": [812.4, 903.1],
+  "domain_min": 0,
+  "domain_max": 2400
+}
+```
+
+The `domain_min`/`domain_max` are resolved exactly as `/api/choropleth` resolves them, so
+the colour scale does not shift when the map crosses between the two transports.
 
 ### `GET /api/aggregate`
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -97,24 +97,33 @@ comparison. In grid view the six panes therefore hold up to twelve WebGL context
 
 - **Base layers** (MapLibre GL JS) — ecoregions, countries, rivers, lakes, catchment
   outlines, populated places, served from MBTiles via `/tiles/`.
-- **Choropleth layer** (MapLibre GL JS GeoJSON source) — catchment polygons fetched from
-  `/api/choropleth` for the current viewport and coloured by a data-driven
-  `fill-color` expression built in `buildFillColorExpression`. Colouring happens GPU-side;
-  there is no per-feature JavaScript.
+- **Choropleth layer** — catchment polygons coloured by a data-driven `fill-color`
+  expression built in `buildFillColorExpression` (`frontend/src/lib/choroplethPaint.ts`).
+  Colouring happens GPU-side; there is no per-feature JavaScript. The polygons reach
+  the map by one of two transports, chosen by zoom:
+
+    - **Vector tiles**, from the tiled zoom range up (`catchments_lev12` in
+      `africa.mbtiles`, zoom 8-15 as generated). MapLibre fetches and tessellates each
+      tile once and reuses it for every later pan, zoom and attribute change. The
+      attribute values are fetched separately from `/api/catchment-values` — geometry-free
+      — and joined onto the tiles as **feature state**, so switching indicator moves
+      values only and never geometry.
+    - **GeoJSON**, below the tiled zoom range, from `/api/choropleth`. There the server
+      returns grid-aggregated cells rather than catchments (see
+      `queryCatchmentsGridAggregated`), which have no tiled equivalent.
+
+    The choice is made from the served TileJSON: if the tileset does not declare a
+    `catchments_lev12` layer *with* its zoom range, the GeoJSON path is used at every
+    zoom, exactly as before. A datapack built before catchments were tiled keeps working.
+
 - **3D extrusion** (optional) — catchments extruded by indicator value.
 - **Site boundary and edit handles** — small GeoJSON sources holding the user's own polygon.
 
 !!! warning "Expected to change"
-    The choropleth is currently a GeoJSON source, parsed on the main thread and uploaded
-    per map instance. It is expected to move into the vector tile pipeline. The
-    data-driven `fill-color` expression is correct and will be preserved.
+    The right-hand map is currently created eagerly whether or not the user is comparing,
+    and map instances are not released when a pane switches to a non-map view.
 
-    Also expected to change: the right-hand map is currently created eagerly whether or
-    not the user is comparing, and map instances are not released when a pane switches
-    to a non-map view.
-
-    Tickets: *Serve the choropleth as vector tiles rather than a GeoJSON source*,
-    *Twelve WebGL contexts are created in grid view and never released*,
+    Tickets: *Twelve WebGL contexts are created in grid view and never released*,
     *Clamp devicePixelRatio on low-end devices*.
 
 ## Auxiliary Tile Servers

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -13,6 +13,24 @@ import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
 import { evictExpired } from '../lib/ttlCache';
 import { satelliteAttribution, satelliteTileUrl } from '../lib/satelliteBasemap';
+import {
+  PRISM_STOPS,
+  attributeValueAccessor,
+  featureStateValueAccessor,
+  buildFillColorExpression,
+  buildOpacityColorExpression,
+  buildExtrusionExpression,
+  zoneStatsFromValues,
+  type ChoroplethValueAccessor,
+} from '../lib/choroplethPaint';
+import {
+  applyCatchmentValues,
+  CATCHMENT_TILE_SOURCE_LAYER,
+  catchmentTileSourceSpec,
+  fetchCatchmentTileset,
+  forgetCatchmentValues,
+  type CatchmentTileset,
+} from '../lib/choroplethTiles';
 
 interface MapViewProps {
   comparison: ComparisonState;
@@ -115,27 +133,6 @@ const CHOROPLETH_3D_RIGHT = 'choropleth-right-3d';
 const IDENTIFY_HIGHLIGHT_GLOW = 'identify-highlight-glow';
 const IDENTIFY_HIGHLIGHT_LINE = 'identify-highlight-line';
 
-// Prism colour gradient for data visualization
-// Spectrum: violet -> indigo -> blue -> cyan -> green -> yellow -> orange -> red
-const PRISM_STOPS: [number, string][] = [
-  [0, '#6a0dad'],       // violet
-  [0.143, '#4b0082'],   // indigo
-  [0.286, '#0074d9'],   // blue
-  [0.429, '#00bcd4'],   // cyan
-  [0.571, '#2ecc40'],   // green
-  [0.714, '#ffdc00'],   // yellow
-  [0.857, '#ff851b'],   // orange
-  [1, '#e8003f'],       // red
-];
-
-// Steepness (k) of the logistic curve used by the 'logistic' color scale type.
-// Higher values sharpen the transition around the domain midpoint.
-const LOGISTIC_STEEPNESS = 10;
-
-// Strength (C) of the log1p curve used by the 'logarithmic' color scale type.
-// Higher values exaggerate contrast among low values at the expense of high ones.
-const LOGARITHMIC_STRENGTH = 9;
-
 // CSS gradient for legend
 export const PRISM_CSS_GRADIENT =
   `linear-gradient(to right, ${PRISM_STOPS.map(([, c]) => c).join(', ')})`;
@@ -150,9 +147,6 @@ const CATCHMENT_ID_PROP = 'HYBAS_ID';
 // blowup - the actual zoom value is always forwarded, so the crossover is
 // controlled entirely on the backend.
 const MIN_CATCHMENT_ZOOM = 3;
-
-// Maximum extrusion height in metres for 3D mode
-const MAX_EXTRUSION_HEIGHT = 50000;
 
 // Choropleth fill-opacity depends on which basemap is showing beneath it:
 // the busier Google satellite imagery needs a touch of transparency to read
@@ -271,23 +265,6 @@ function padBoundsForFit(bounds: BoundingBox): [[number, number], [number, numbe
   ];
 }
 
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const normalized = hex.trim().replace('#', '');
-  if (normalized.length === 3) {
-    const r = parseInt(normalized[0] + normalized[0], 16);
-    const g = parseInt(normalized[1] + normalized[1], 16);
-    const b = parseInt(normalized[2] + normalized[2], 16);
-    return Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) ? null : { r, g, b };
-  }
-  if (normalized.length === 6) {
-    const r = parseInt(normalized.slice(0, 2), 16);
-    const g = parseInt(normalized.slice(2, 4), 16);
-    const b = parseInt(normalized.slice(4, 6), 16);
-    return Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) ? null : { r, g, b };
-  }
-  return null;
-}
-
 // Debounce delay for fetching choropleth data on map move (ms)
 const FETCH_DEBOUNCE_MS = 300;
 
@@ -328,24 +305,10 @@ function computeZoneStats(data: ChoroplethData, attribute: string): ZoneStats | 
     }
   }
 
-  if (values.length === 0) return null;
-
-  let min = Infinity;
-  let max = -Infinity;
-  let sum = 0;
-
-  for (const v of values) {
-    if (v < min) min = v;
-    if (v > max) max = v;
-    sum += v;
-  }
-
-  return {
-    min,
-    max,
-    mean: sum / values.length,
-    count: values.length,
-  };
+  // The arithmetic itself lives in the paint library so that the vector-tile
+  // path, which has the values as a plain array and never builds a feature per
+  // catchment, summarises them identically rather than in a parallel copy.
+  return zoneStatsFromValues(values);
 }
 
 function simplifyBoundaryForComputation(geometry: GeoJSON.Geometry): GeoJSON.Geometry {
@@ -644,6 +607,123 @@ function clearSiteComputationCaches(siteId: string): void {
 }
 
 /**
+ * The colour-scale domain both render paths share.
+ *
+ * Always the attribute's global domain across every catchment, independent of
+ * the selected zone range (Full/Extent/Site). The backend's max is
+ * scenario-specific (metadata.csv's curated maxval_curr/maxval_ref rather than a
+ * scan of every catchment), so the two sides can disagree when comparing
+ * reference against current — take the larger of the two so neither side's
+ * colors get clipped, and the result doesn't depend on which scenario happens to
+ * be on the left.
+ */
+function resolveDomainRange(
+  payloads: Array<{ domain_min?: number; domain_max?: number } | null>,
+): { min: number; max: number } {
+  const mins: number[] = [];
+  const maxes: number[] = [];
+  for (const payload of payloads) {
+    if (payload && payload.domain_min !== undefined && payload.domain_max !== undefined) {
+      mins.push(payload.domain_min);
+      maxes.push(payload.domain_max);
+    }
+  }
+  return {
+    min: mins.length > 0 ? Math.min(...mins) : 0,
+    max: maxes.length > 0 ? Math.max(...maxes) : 1,
+  };
+}
+
+/**
+ * The vector-tile path's payload: catchment ids and their values for the
+ * viewport, with no geometry. Mirrors CatchmentValuesResponse in
+ * internal/api/handler.go.
+ */
+interface ChoroplethValues {
+  scenario: string;
+  attribute: string;
+  ids: number[];
+  values: number[];
+  domain_min: number;
+  domain_max: number;
+}
+
+// Companion to _choroplethCache for the values endpoint. Six panes x two
+// scenarios ask for the same viewport at the same moment; one fetch serves all
+// of them.
+const _choroplethValuesCache = new Map<string, { promise: Promise<ChoroplethValues | null>; ts: number }>();
+
+/**
+ * Fetch the attribute values for the current viewport, for the vector-tile
+ * path. Geometry comes from the tiles, so this is the only thing a pan or an
+ * attribute change has to move over the wire.
+ *
+ * Site ideal overrides are applied here for the browser runtime exactly as
+ * fetchChoroplethData does for the GeoJSON path: the backend store is never
+ * updated in that runtime, so the edits live in browser storage.
+ */
+async function fetchChoroplethValues(
+  scenario: Scenario,
+  attribute: string,
+  bounds: maplibregl.LngLatBounds,
+  siteId?: string | null,
+  idealOverrides?: Map<number, number>,
+): Promise<ChoroplethValues | null> {
+  const sw = bounds.getSouthWest();
+  const ne = bounds.getNorthEast();
+
+  const params = new URLSearchParams({
+    scenario,
+    attribute,
+    minx: sw.lng.toString(),
+    miny: sw.lat.toString(),
+    maxx: ne.lng.toString(),
+    maxy: ne.lat.toString(),
+  });
+
+  const hasSiteOverride = siteId && scenario === 'future';
+  if (hasSiteOverride) {
+    params.set('siteId', siteId);
+  }
+
+  const canCache = !hasSiteOverride && (!idealOverrides || idealOverrides.size === 0);
+  const key = params.toString();
+  const now = Date.now();
+
+  if (canCache) {
+    const hit = _choroplethValuesCache.get(key);
+    if (hit && now - hit.ts < CHOROPLETH_CACHE_TTL_MS) return hit.promise;
+    evictExpired(_choroplethValuesCache, CHOROPLETH_CACHE_TTL_MS, now);
+  }
+
+  const promise = (async (): Promise<ChoroplethValues | null> => {
+    try {
+      const resp = await fetch(`/api/catchment-values?${params}`);
+      if (!resp.ok) return null;
+      const data = await resp.json() as ChoroplethValues;
+
+      if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
+        for (let i = 0; i < data.ids.length; i++) {
+          const override = idealOverrides.get(data.ids[i]);
+          if (override !== undefined) data.values[i] = override;
+        }
+      }
+
+      return data;
+    } catch (err) {
+      console.error('Failed to fetch catchment values:', err);
+      return null;
+    }
+  })();
+
+  if (canCache) {
+    promise.catch(() => _choroplethValuesCache.delete(key));
+    _choroplethValuesCache.set(key, { promise, ts: now });
+  }
+  return promise;
+}
+
+/**
  * Fetch choropleth GeoJSON data for the current viewport.
  */
 async function fetchChoroplethData(
@@ -731,161 +811,6 @@ async function fetchChoroplethData(
     console.error('Failed to fetch choropleth data:', err);
     return null;
   }
-}
-
-/**
- * Build a MapLibre expression producing the 0-1 normalized position of an
- * attribute's value within [min, max].
- *
- * - 'logistic' passes the linear ratio through a sigmoid centered on the
- *   domain midpoint, which compresses values near the extremes and expands
- *   contrast around the middle of the range - useful when most values
- *   cluster around the mean with a long tail.
- * - 'logarithmic' passes the linear ratio through a log1p curve, which
- *   expands contrast among low values at the expense of high ones - useful
- *   when most values are small with a few large outliers. log1p (rather than
- *   a plain log of the raw value) is used so the domain minimum, which can
- *   legitimately be 0, never hits an undefined log(0).
- */
-function buildNormalizedValueExpression(
-  attribute: string,
-  min: number,
-  range: number,
-  scaleType: ColorScaleType
-): maplibregl.ExpressionSpecification {
-  const linearRatio = [
-    '/',
-    ['-', ['coalesce', ['get', attribute], min], min],
-    range,
-  ] as maplibregl.ExpressionSpecification;
-
-  if (scaleType === 'linear') {
-    return linearRatio;
-  }
-
-  if (scaleType === 'logarithmic') {
-    return [
-      'let',
-      't',
-      linearRatio,
-      [
-        '/',
-        ['ln', ['+', 1, ['*', LOGARITHMIC_STRENGTH, ['var', 't']]]],
-        Math.log(1 + LOGARITHMIC_STRENGTH),
-      ],
-    ] as maplibregl.ExpressionSpecification;
-  }
-
-  return [
-    'let',
-    't',
-    linearRatio,
-    [
-      '/',
-      1,
-      ['+', 1, ['^', Math.E, ['*', -LOGISTIC_STEEPNESS, ['-', ['var', 't'], 0.5]]]],
-    ],
-  ] as maplibregl.ExpressionSpecification;
-}
-
-/**
- * Build a MapLibre expression for fill-color based on attribute value and global min/max.
- */
-function buildFillColorExpression(
-  attribute: string,
-  min: number,
-  max: number,
-  baseColor?: string | null,
-  scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | string {
-  // When a metadata base color is provided, blend from white (low values)
-  // to the base color (high values) instead of using opacity.
-  if (baseColor) {
-    const rgb = hexToRgb(baseColor);
-    if (!rgb) return baseColor;
-
-    const range = max - min;
-    if (range === 0) {
-      // Degenerate domain (every visible value equals min) - treat it as the
-      // low end of the white-to-baseColor scale rather than the high end.
-      return '#FFFFFF';
-    }
-
-    return [
-      'interpolate',
-      ['linear'],
-      buildNormalizedValueExpression(attribute, min, range, scaleType),
-      0,
-      '#FFFFFF',
-      1,
-      baseColor,
-    ] as maplibregl.ExpressionSpecification;
-  }
-
-  const range = max - min;
-  if (range === 0) {
-    // Single value - use middle color
-    return PRISM_STOPS[Math.floor(PRISM_STOPS.length / 2)][1];
-  }
-
-  // Build interpolate expression: normalize value to 0-1 then map to colors
-  return [
-    'interpolate',
-    ['linear'],
-    buildNormalizedValueExpression(attribute, min, range, scaleType),
-    ...PRISM_STOPS.flatMap(([t, color]) => [t, color]),
-  ] as maplibregl.ExpressionSpecification;
-}
-
-function buildOpacityColorExpression(
-  attribute: string,
-  min: number,
-  max: number,
-  baseColor: string,
-  scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | string {
-  // Blend color from white (low values) to the metadata base color
-  // (high values). Opacity will be handled separately by layer paint.
-  const rgb = hexToRgb(baseColor);
-  if (!rgb) return baseColor;
-
-  const range = max - min;
-  if (range === 0) {
-    // Degenerate domain (every visible value equals min) - treat it as the
-    // low end of the white-to-baseColor scale rather than the high end.
-    return '#FFFFFF';
-  }
-
-  return [
-    'interpolate',
-    ['linear'],
-    buildNormalizedValueExpression(attribute, min, range, scaleType),
-    0,
-    '#FFFFFF',
-    1,
-    baseColor,
-  ] as maplibregl.ExpressionSpecification;
-}
-
-/**
- * Build a MapLibre expression for fill-extrusion-height based on attribute value.
- */
-function buildExtrusionExpression(
-  attribute: string,
-  min: number,
-  max: number,
-  scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | number {
-  const range = max - min;
-  if (range === 0) {
-    return MAX_EXTRUSION_HEIGHT / 2;
-  }
-
-  return [
-    '*',
-    buildNormalizedValueExpression(attribute, min, range, scaleType),
-    MAX_EXTRUSION_HEIGHT,
-  ] as maplibregl.ExpressionSpecification;
 }
 
 function setCatchmentOutlinesSoftness(map: maplibregl.Map, soften: boolean) {
@@ -1082,6 +1007,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Debounce timer for choropleth fetching
   const fetchTimerRef = useRef<number | null>(null);
 
+  // Whether the served tileset carries catchment geometry, and from which zoom.
+  // Null until resolved, and null for good on a datapack whose tiles predate
+  // catchment tiling — in which case every zoom uses the GeoJSON path, exactly
+  // as before.
+  const catchmentTilesetRef = useRef<CatchmentTileset | null>(null);
+
   /** Fetch and apply choropleth data to both maps based on current viewport.
    *  Only shown when zoomed in past MIN_CATCHMENT_ZOOM. */
   const applyColors = useCallback(async () => {
@@ -1180,6 +1111,95 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       }
     }
 
+    const attributeColor = colorScaleMode === 'metadata'
+      ? attributeColorsRef.current?.[c.attribute]
+      : undefined;
+
+    /** Publish the domain range and extent statistics. Shared by both paths. */
+    const publishStats = (
+      min: number,
+      max: number,
+      leftStats: ZoneStats | null,
+      rightStats: ZoneStats | null,
+    ) => {
+      lastDomainRangeRef.current = { min, max };
+      // Extent-based stats are always derived from the current viewport.
+      extentZoneStatsRef.current = { left: leftStats, right: rightStats };
+      if (onStatisticsChangeRef.current) {
+        onStatisticsChangeRef.current({
+          domainRange: { min, max },
+          leftStats,
+          rightStats,
+          fullStats: fullZoneStatsRef.current,
+          siteStats: siteZoneStatsRef.current,
+        });
+      }
+    };
+
+    // Vector-tile path. From the tileset's minimum zoom up, the catchment
+    // geometry is already in the tile pipeline, so only the values are fetched
+    // and they are joined onto the tiles as feature state. MapLibre keeps the
+    // tessellated geometry across pans, zooms and attribute switches, which is
+    // the whole point: the GeoJSON path re-parsed and re-tessellated every
+    // catchment in view on every viewport change, once per map instance.
+    //
+    // The site catchment-id inference below is deliberately not run here: it
+    // works by intersecting fetched geometry against the site boundary, and
+    // there is no fetched geometry on this path. It is a fallback in any case —
+    // the authoritative ids come from the server's AOI fractions (see the stats
+    // effect), which is also why it is already skipped for anything but a very
+    // small feature count.
+    const tileset = catchmentTilesetRef.current;
+    if (tileset && currentZoom >= tileset.minzoom) {
+      try {
+        const [leftValues, rightValues] = await Promise.all([
+          fetchChoroplethValues(c.leftScenario, c.attribute, bounds, siteId, browserIdealOverrides),
+          fetchChoroplethValues(c.rightScenario, c.attribute, bounds, siteId, browserIdealOverrides),
+        ]);
+
+        const { min, max } = resolveDomainRange([leftValues, rightValues]);
+        publishStats(
+          min,
+          max,
+          leftValues ? zoneStatsFromValues(leftValues.values) : null,
+          rightValues ? zoneStatsFromValues(rightValues.values) : null,
+        );
+
+        const applySide = (
+          map: maplibregl.Map,
+          side: 'left' | 'right',
+          values: ChoroplethValues | null,
+          scenario: Scenario,
+        ) => {
+          if (!values || values.ids.length === 0) {
+            removeChoroplethLayers(map, side);
+            return;
+          }
+          const layerSource = {
+            kind: 'tiles' as const,
+            tileset,
+            values,
+            // Feature state persists across viewport changes, so it has to be
+            // cleared when what it means changes — scenario or attribute.
+            stateKey: `${scenario}|${c.attribute}`,
+          };
+          const apply = () => applyChoroplethLayer(
+            map, side, layerSource, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          if (map.loaded()) {
+            apply();
+          } else {
+            map.once('idle', apply);
+          }
+        };
+
+        applySide(leftMap, 'left', leftValues, c.leftScenario);
+        applySide(rightMap, 'right', rightValues, c.rightScenario);
+      } catch (err) {
+        console.error('Failed to apply choropleth:', err);
+      }
+      return;
+    }
+
     try {
       // Fetch data for both scenarios in parallel
       const [leftData, rightData] = await Promise.all([
@@ -1252,55 +1272,21 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       const leftDisplay = leftData;
       const rightDisplay = rightData;
 
-      // Color scale always uses the attribute's global domain across every
-      // catchment, independent of the selected zone range (Full/Extent/Site).
-      // The backend's max is now scenario-specific (metadata.csv's curated
-      // maxval_curr/maxval_ref rather than a scan of every catchment), so the
-      // two sides can disagree when comparing reference against current —
-      // take the larger of the two so neither side's colors get clipped, and
-      // the result doesn't depend on which scenario happens to be on the left.
-      let min = 0;
-      let max = 1;
-      const domainMins: number[] = [];
-      const domainMaxes: number[] = [];
-      if (leftData && leftData.domain_min !== undefined && leftData.domain_max !== undefined) {
-        domainMins.push(leftData.domain_min);
-        domainMaxes.push(leftData.domain_max);
-      }
-      if (rightData && rightData.domain_min !== undefined && rightData.domain_max !== undefined) {
-        domainMins.push(rightData.domain_min);
-        domainMaxes.push(rightData.domain_max);
-      }
-      if (domainMins.length > 0) min = Math.min(...domainMins);
-      if (domainMaxes.length > 0) max = Math.max(...domainMaxes);
-      lastDomainRangeRef.current = { min, max };
-
-      // Extent-based stats are always derived from the current viewport.
-      const leftExtentStats = leftData ? computeZoneStats(leftData, c.attribute) : null;
-      const rightExtentStats = rightData ? computeZoneStats(rightData, c.attribute) : null;
-      extentZoneStatsRef.current = { left: leftExtentStats, right: rightExtentStats };
-
-      if (onStatisticsChangeRef.current) {
-        onStatisticsChangeRef.current({
-          domainRange: { min, max },
-          leftStats: leftExtentStats,
-          rightStats: rightExtentStats,
-          fullStats: fullZoneStatsRef.current,
-          siteStats: siteZoneStatsRef.current,
-        });
-      }
-
-      const attributeColor = colorScaleMode === 'metadata'
-        ? attributeColorsRef.current?.[c.attribute]
-        : undefined;
+      const { min, max } = resolveDomainRange([leftData, rightData]);
+      publishStats(
+        min,
+        max,
+        leftData ? computeZoneStats(leftData, c.attribute) : null,
+        rightData ? computeZoneStats(rightData, c.attribute) : null,
+      );
 
       // Apply to left map - verify the map is ready
       if (leftDisplay && leftDisplay.features.length > 0) {
         if (leftMap.loaded()) {
-          applyChoroplethLayer(leftMap, 'left', leftDisplay, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           leftMap.once('idle', () => {
-            applyChoroplethLayer(leftMap, 'left', leftDisplay, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+            applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
       } else {
@@ -1310,10 +1296,10 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       // Apply to right map - verify the map is ready
       if (rightDisplay && rightDisplay.features.length > 0) {
         if (rightMap.loaded()) {
-          applyChoroplethLayer(rightMap, 'right', rightDisplay, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           rightMap.once('idle', () => {
-            applyChoroplethLayer(rightMap, 'right', rightDisplay, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+            applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
       } else {
@@ -1344,6 +1330,19 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   useEffect(() => {
     applyColorsRef.current = applyColors;
   }, [applyColors]);
+
+  // Resolve the catchment tileset once (the lookup itself is module-cached, so
+  // twelve panes make one request) and repaint, because the first applyColors
+  // may well have run against a still-null ref and taken the GeoJSON path.
+  useEffect(() => {
+    let cancelled = false;
+    void fetchCatchmentTileset().then((tileset) => {
+      if (cancelled || !tileset) return;
+      catchmentTilesetRef.current = tileset;
+      applyColorsRef.current();
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Reset site stats when boundary geometry changes so stats recompute.
   useEffect(() => {
@@ -1794,17 +1793,98 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (map.getSource(sourceId)) {
       map.removeSource(sourceId);
     }
+    // Feature state lives on the source, so removing it discards the join;
+    // the bookkeeping that tracks which ids carry a value has to go too, or
+    // the next application would think it had already set them.
+    forgetCatchmentValues(map, sourceId);
 
     setCatchmentOutlinesSoftness(map, false);
   }
 
   /**
-   * Apply choropleth layer to a map with GeoJSON data.
+   * Where a choropleth layer's geometry and values come from.
+   *
+   * 'tiles' is the fast path: geometry from the vector tile pipeline, values
+   * joined on as feature state. 'geojson' is the fallback for the low-zoom
+   * range the tiles do not cover, where the backend serves grid-aggregated
+   * cells instead of catchments (see queryCatchmentsGridAggregated).
+   */
+  type ChoroplethLayerSource =
+    | { kind: 'geojson'; data: ChoroplethData }
+    | { kind: 'tiles'; tileset: CatchmentTileset; values: ChoroplethValues; stateKey: string };
+
+  /**
+   * Ensure the per-side choropleth source exists and holds the current data.
+   *
+   * Returns the source layer name for tile sources, or undefined for GeoJSON -
+   * every layer added below needs it, and getting it wrong is silent (the layer
+   * renders nothing rather than erroring).
+   *
+   * A source can never change type in place, so crossing the zoom threshold
+   * between the two paths tears the old source down first. That is also why the
+   * layers are removed with it: MapLibre refuses to leave a layer pointing at a
+   * source that has gone.
+   */
+  function ensureChoroplethSource(
+    map: maplibregl.Map,
+    side: string,
+    sourceId: string,
+    source: ChoroplethLayerSource,
+  ): string | undefined {
+    const wanted = source.kind === 'tiles' ? 'vector' : 'geojson';
+    const existing = map.getSource(sourceId);
+    if (existing && existing.type !== wanted) {
+      removeChoroplethLayers(map, side);
+    }
+
+    if (source.kind === 'geojson') {
+      const geojsonSource = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (geojsonSource) {
+        geojsonSource.setData(source.data as unknown as GeoJSON.FeatureCollection);
+      } else {
+        map.addSource(sourceId, {
+          type: 'geojson',
+          data: source.data as unknown as GeoJSON.FeatureCollection,
+        });
+      }
+      return undefined;
+    }
+
+    if (!map.getSource(sourceId)) {
+      map.addSource(sourceId, catchmentTileSourceSpec(source.tileset));
+    }
+
+    // Feature state, not a source update: the geometry in the tiles is already
+    // loaded and tessellated, and re-setting it is exactly the work this path
+    // exists to avoid. MapLibre carries the state onto tiles that load later,
+    // so panning into new ground needs no re-application.
+    const applied = applyCatchmentValues(
+      map,
+      sourceId,
+      source.tileset.sourceLayer,
+      source.stateKey,
+      source.values.ids,
+      source.values.values,
+    );
+    if (applied.cleared > 0) {
+      console.debug(`[perf] choropleth-${side} feature state: set ${applied.set}, cleared ${applied.cleared}`);
+    }
+
+    return source.tileset.sourceLayer;
+  }
+
+  /**
+   * Apply the choropleth layers to a map.
+   *
+   * The paint expressions are identical on both paths; only how they reach a
+   * catchment's value differs (feature properties vs. feature state). Colouring
+   * remains a data-driven expression evaluated on the GPU - nothing here walks
+   * features in JavaScript.
    */
   function applyChoroplethLayer(
     map: maplibregl.Map,
     side: string,
-    data: ChoroplethData,
+    source: ChoroplethLayerSource,
     attribute: string,
     min: number,
     max: number,
@@ -1823,15 +1903,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         ? CHOROPLETH_FILL_OPACITY_SATELLITE
         : CHOROPLETH_FILL_OPACITY_DEFAULT;
 
-      const source = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
-      if (source) {
-        source.setData(data as unknown as GeoJSON.FeatureCollection);
-      } else {
-        map.addSource(sourceId, {
-          type: 'geojson',
-          data: data as unknown as GeoJSON.FeatureCollection,
-        });
-      }
+      const sourceLayer = ensureChoroplethSource(map, side, sourceId, source);
+      const value: ChoroplethValueAccessor = source.kind === 'tiles'
+        ? featureStateValueAccessor()
+        : attributeValueAccessor(attribute);
+      // Spread into each addLayer call: 'source-layer' must be absent, not
+      // undefined, for a GeoJSON source.
+      const sourceLayerSpec = sourceLayer ? { 'source-layer': sourceLayer } : {};
 
       setCatchmentOutlinesSoftness(map, true);
 
@@ -1848,11 +1926,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             id: layer3dId,
             type: 'fill-extrusion',
             source: sourceId,
+            ...sourceLayerSpec,
             paint: {
               'fill-extrusion-color': useOpacityScale && attributeColor
-                ? buildOpacityColorExpression(attribute, min, max, attributeColor, scaleType)
-                : buildFillColorExpression(attribute, min, max, attributeColor, scaleType),
-              'fill-extrusion-height': buildExtrusionExpression(attribute, min, max, scaleType),
+                ? buildOpacityColorExpression(value, min, max, attributeColor, scaleType)
+                : buildFillColorExpression(value, min, max, attributeColor, scaleType),
+              'fill-extrusion-height': buildExtrusionExpression(value, min, max, scaleType),
               'fill-extrusion-base': 0,
               'fill-extrusion-opacity': fillOpacity,
             },
@@ -1862,13 +1941,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             layer3dId,
             'fill-extrusion-color',
             useOpacityScale && attributeColor
-              ? buildOpacityColorExpression(attribute, min, max, attributeColor, scaleType)
-              : buildFillColorExpression(attribute, min, max, attributeColor, scaleType),
+              ? buildOpacityColorExpression(value, min, max, attributeColor, scaleType)
+              : buildFillColorExpression(value, min, max, attributeColor, scaleType),
           );
           map.setPaintProperty(
             layer3dId,
             'fill-extrusion-height',
-            buildExtrusionExpression(attribute, min, max, scaleType),
+            buildExtrusionExpression(value, min, max, scaleType),
           );
           map.setPaintProperty(layer3dId, 'fill-extrusion-opacity', fillOpacity);
         }
@@ -1882,8 +1961,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             id: layerId,
             type: 'fill',
             source: sourceId,
+            ...sourceLayerSpec,
             paint: {
-              'fill-color': buildFillColorExpression(attribute, min, max, attributeColor, scaleType),
+              'fill-color': buildFillColorExpression(value, min, max, attributeColor, scaleType),
               // Keep boundaries soft so adjacent catchments blend visually.
               'fill-outline-color': CHOROPLETH_OUTLINE_COLOR,
               'fill-opacity': fillOpacity,
@@ -1893,21 +1973,22 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           map.setPaintProperty(
             layerId,
             'fill-color',
-            buildFillColorExpression(attribute, min, max, attributeColor, scaleType),
+            buildFillColorExpression(value, min, max, attributeColor, scaleType),
           );
           map.setPaintProperty(layerId, 'fill-outline-color', CHOROPLETH_OUTLINE_COLOR);
           map.setPaintProperty(layerId, 'fill-opacity', fillOpacity);
         }
 
         const edgeColorExpression = useOpacityScale && attributeColor
-          ? buildOpacityColorExpression(attribute, min, max, attributeColor, scaleType)
-          : buildFillColorExpression(attribute, min, max, attributeColor, scaleType);
+          ? buildOpacityColorExpression(value, min, max, attributeColor, scaleType)
+          : buildFillColorExpression(value, min, max, attributeColor, scaleType);
 
         if (!map.getLayer(edgeBlendLayerId)) {
           map.addLayer({
             id: edgeBlendLayerId,
             type: 'line',
             source: sourceId,
+            ...sourceLayerSpec,
             paint: {
               'line-color': edgeColorExpression,
               'line-width': CHOROPLETH_EDGE_BLEND_WIDTH,
@@ -3397,28 +3478,37 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const addHighlight = (map: maplibregl.Map, side: 'left' | 'right', catchmentId: string) => {
       removeHighlight(map);
 
-      // Use the same per-side choropleth GeoJSON source the color layer already
-      // renders from (always present once a choropleth is showing) rather than
-      // the base style's "UoW Tiles" vector source, which doesn't exist at all
-      // when the Google satellite basemap is active — the default for browser
-      // runtime — leaving the highlight silently missing.
+      // Use the same per-side choropleth source the color layer already renders
+      // from (always present once a choropleth is showing) rather than the base
+      // style's "UoW Tiles" vector source, which doesn't exist at all when the
+      // Google satellite basemap is active — the default for browser runtime —
+      // leaving the highlight silently missing.
       const sourceId = `choropleth-source-${side}`;
 
       // Check if the source exists
-      if (!map.getSource(sourceId)) {
+      const choroplethSource = map.getSource(sourceId);
+      if (!choroplethSource) {
         console.warn('Identify highlight: source not found:', sourceId);
         return;
       }
 
-      // Parse catchmentId as number for filtering (HYBAS_ID is numeric)
+      // On the vector-tile path the source has a layer within it, and the tiles
+      // may encode HYBAS_ID as a string — to-number normalises both encodings
+      // so the same filter works whichever transport is in use.
+      const sourceLayerSpec = choroplethSource.type === 'vector'
+        ? { 'source-layer': CATCHMENT_TILE_SOURCE_LAYER }
+        : {};
       const catchmentIdNum = parseInt(catchmentId, 10);
+      const idFilter: maplibregl.FilterSpecification =
+        ['==', ['to-number', ['get', CATCHMENT_ID_PROP]], catchmentIdNum];
 
       // Add outer glow layer (neon blue)
       map.addLayer({
         id: IDENTIFY_HIGHLIGHT_GLOW,
         type: 'line',
         source: sourceId,
-        filter: ['==', ['get', CATCHMENT_ID_PROP], catchmentIdNum],
+        ...sourceLayerSpec,
+        filter: idFilter,
         paint: {
           'line-color': '#00BFFF',  // Bright blue
           'line-width': 12,
@@ -3432,7 +3522,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         id: IDENTIFY_HIGHLIGHT_LINE,
         type: 'line',
         source: sourceId,
-        filter: ['==', ['get', CATCHMENT_ID_PROP], catchmentIdNum],
+        ...sourceLayerSpec,
+        filter: idFilter,
         paint: {
           'line-color': '#AEEFFF',  // Pale blue
           'line-width': 4,

--- a/frontend/src/lib/choroplethPaint.ts
+++ b/frontend/src/lib/choroplethPaint.ts
@@ -1,0 +1,277 @@
+import type maplibregl from 'maplibre-gl';
+import type { ColorScaleType, ZoneStats } from '../types';
+
+/**
+ * The choropleth's paint expressions, and the colour scale they encode.
+ *
+ * These live outside MapView because two transports now feed them. The GeoJSON
+ * path reads the value from the feature's own properties; the vector-tile path
+ * reads it from feature state, because the tiles carry geometry only and the
+ * values are joined onto them per attribute. Everything downstream of that one
+ * difference - the normalisation curve, the colour ramp, the extrusion height -
+ * is identical, and has to stay identical, or the same catchment would be a
+ * different colour depending on which zoom range it was viewed at.
+ *
+ * Colouring stays a data-driven expression evaluated on the GPU either way.
+ * Nothing here walks features in JavaScript.
+ */
+
+// Prism colour gradient for data visualization
+// Spectrum: violet -> indigo -> blue -> cyan -> green -> yellow -> orange -> red
+export const PRISM_STOPS: [number, string][] = [
+  [0, '#6a0dad'],       // violet
+  [0.143, '#4b0082'],   // indigo
+  [0.286, '#0074d9'],   // blue
+  [0.429, '#00bcd4'],   // cyan
+  [0.571, '#2ecc40'],   // green
+  [0.714, '#ffdc00'],   // yellow
+  [0.857, '#ff851b'],   // orange
+  [1, '#e8003f'],       // red
+];
+
+// Steepness (k) of the logistic curve used by the 'logistic' color scale type.
+// Higher values sharpen the transition around the domain midpoint.
+export const LOGISTIC_STEEPNESS = 10;
+
+// Strength (C) of the log1p curve used by the 'logarithmic' color scale type.
+// Higher values exaggerate contrast among low values at the expense of high ones.
+export const LOGARITHMIC_STRENGTH = 9;
+
+// Maximum extrusion height in metres for 3D mode
+export const MAX_EXTRUSION_HEIGHT = 50000;
+
+/**
+ * The feature-state key the vector-tile path stores a catchment's value under.
+ *
+ * Short deliberately: it is repeated once per catchment in the state object,
+ * which at the tile pipeline's minimum zoom can hold tens of thousands of
+ * entries per map instance, twelve map instances live.
+ */
+export const CHOROPLETH_VALUE_STATE_KEY = 'v';
+
+/**
+ * How a paint expression reaches a catchment's value.
+ *
+ * `['get', attribute]` for the GeoJSON path, where the value travelled with the
+ * geometry; `['feature-state', 'v']` for the vector-tile path, where it was
+ * joined on afterwards.
+ */
+export type ChoroplethValueAccessor = maplibregl.ExpressionSpecification;
+
+/** Reads the value from the feature's own properties (GeoJSON path). */
+export function attributeValueAccessor(attribute: string): ChoroplethValueAccessor {
+  return ['get', attribute] as maplibregl.ExpressionSpecification;
+}
+
+/** Reads the value from feature state (vector-tile path). */
+export function featureStateValueAccessor(): ChoroplethValueAccessor {
+  return ['feature-state', CHOROPLETH_VALUE_STATE_KEY] as maplibregl.ExpressionSpecification;
+}
+
+export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const normalized = hex.trim().replace('#', '');
+  if (normalized.length === 3) {
+    const r = parseInt(normalized[0] + normalized[0], 16);
+    const g = parseInt(normalized[1] + normalized[1], 16);
+    const b = parseInt(normalized[2] + normalized[2], 16);
+    return Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) ? null : { r, g, b };
+  }
+  if (normalized.length === 6) {
+    const r = parseInt(normalized.slice(0, 2), 16);
+    const g = parseInt(normalized.slice(2, 4), 16);
+    const b = parseInt(normalized.slice(4, 6), 16);
+    return Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) ? null : { r, g, b };
+  }
+  return null;
+}
+
+/**
+ * Build a MapLibre expression producing the 0-1 normalized position of an
+ * attribute's value within [min, max].
+ *
+ * - 'logistic' passes the linear ratio through a sigmoid centered on the
+ *   domain midpoint, which compresses values near the extremes and expands
+ *   contrast around the middle of the range - useful when most values
+ *   cluster around the mean with a long tail.
+ * - 'logarithmic' passes the linear ratio through a log1p curve, which
+ *   expands contrast among low values at the expense of high ones - useful
+ *   when most values are small with a few large outliers. log1p (rather than
+ *   a plain log of the raw value) is used so the domain minimum, which can
+ *   legitimately be 0, never hits an undefined log(0).
+ *
+ * The coalesce to `min` is what makes a catchment with no value for this
+ * attribute render as the low end of the scale rather than as a hole. On the
+ * vector-tile path it does the same job for a catchment whose feature state has
+ * not been set - either because the datapack has no value for it, or because it
+ * lies outside the viewport the values were fetched for.
+ */
+export function buildNormalizedValueExpression(
+  value: ChoroplethValueAccessor,
+  min: number,
+  range: number,
+  scaleType: ColorScaleType
+): maplibregl.ExpressionSpecification {
+  const linearRatio = [
+    '/',
+    ['-', ['coalesce', value, min], min],
+    range,
+  ] as maplibregl.ExpressionSpecification;
+
+  if (scaleType === 'linear') {
+    return linearRatio;
+  }
+
+  if (scaleType === 'logarithmic') {
+    return [
+      'let',
+      't',
+      linearRatio,
+      [
+        '/',
+        ['ln', ['+', 1, ['*', LOGARITHMIC_STRENGTH, ['var', 't']]]],
+        Math.log(1 + LOGARITHMIC_STRENGTH),
+      ],
+    ] as maplibregl.ExpressionSpecification;
+  }
+
+  return [
+    'let',
+    't',
+    linearRatio,
+    [
+      '/',
+      1,
+      ['+', 1, ['^', Math.E, ['*', -LOGISTIC_STEEPNESS, ['-', ['var', 't'], 0.5]]]],
+    ],
+  ] as maplibregl.ExpressionSpecification;
+}
+
+/**
+ * Build a MapLibre expression for fill-color based on attribute value and global min/max.
+ */
+export function buildFillColorExpression(
+  value: ChoroplethValueAccessor,
+  min: number,
+  max: number,
+  baseColor?: string | null,
+  scaleType: ColorScaleType = 'linear'
+): maplibregl.ExpressionSpecification | string {
+  // When a metadata base color is provided, blend from white (low values)
+  // to the base color (high values) instead of using opacity.
+  if (baseColor) {
+    const rgb = hexToRgb(baseColor);
+    if (!rgb) return baseColor;
+
+    const range = max - min;
+    if (range === 0) {
+      // Degenerate domain (every visible value equals min) - treat it as the
+      // low end of the white-to-baseColor scale rather than the high end.
+      return '#FFFFFF';
+    }
+
+    return [
+      'interpolate',
+      ['linear'],
+      buildNormalizedValueExpression(value, min, range, scaleType),
+      0,
+      '#FFFFFF',
+      1,
+      baseColor,
+    ] as maplibregl.ExpressionSpecification;
+  }
+
+  const range = max - min;
+  if (range === 0) {
+    // Single value - use middle color
+    return PRISM_STOPS[Math.floor(PRISM_STOPS.length / 2)][1];
+  }
+
+  // Build interpolate expression: normalize value to 0-1 then map to colors
+  return [
+    'interpolate',
+    ['linear'],
+    buildNormalizedValueExpression(value, min, range, scaleType),
+    ...PRISM_STOPS.flatMap(([t, color]) => [t, color]),
+  ] as maplibregl.ExpressionSpecification;
+}
+
+export function buildOpacityColorExpression(
+  value: ChoroplethValueAccessor,
+  min: number,
+  max: number,
+  baseColor: string,
+  scaleType: ColorScaleType = 'linear'
+): maplibregl.ExpressionSpecification | string {
+  // Blend color from white (low values) to the metadata base color
+  // (high values). Opacity will be handled separately by layer paint.
+  const rgb = hexToRgb(baseColor);
+  if (!rgb) return baseColor;
+
+  const range = max - min;
+  if (range === 0) {
+    // Degenerate domain (every visible value equals min) - treat it as the
+    // low end of the white-to-baseColor scale rather than the high end.
+    return '#FFFFFF';
+  }
+
+  return [
+    'interpolate',
+    ['linear'],
+    buildNormalizedValueExpression(value, min, range, scaleType),
+    0,
+    '#FFFFFF',
+    1,
+    baseColor,
+  ] as maplibregl.ExpressionSpecification;
+}
+
+/**
+ * Build a MapLibre expression for fill-extrusion-height based on attribute value.
+ */
+export function buildExtrusionExpression(
+  value: ChoroplethValueAccessor,
+  min: number,
+  max: number,
+  scaleType: ColorScaleType = 'linear'
+): maplibregl.ExpressionSpecification | number {
+  const range = max - min;
+  if (range === 0) {
+    return MAX_EXTRUSION_HEIGHT / 2;
+  }
+
+  return [
+    '*',
+    buildNormalizedValueExpression(value, min, range, scaleType),
+    MAX_EXTRUSION_HEIGHT,
+  ] as maplibregl.ExpressionSpecification;
+}
+
+/**
+ * Summarise a set of attribute values for the statistics panel.
+ *
+ * Split out from computeZoneStats so that the vector-tile path, which receives
+ * a plain array of values and never materialises a feature per catchment, uses
+ * the same arithmetic as the GeoJSON path rather than a parallel copy of it.
+ */
+export function zoneStatsFromValues(values: number[]): ZoneStats | null {
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  let count = 0;
+
+  for (const v of values) {
+    // Guard here rather than at each call site: one path reads values out of
+    // GeoJSON properties (which can hold booleans and undefined) and the other
+    // out of a JSON number array, and neither should be able to turn a single
+    // bad entry into a NaN mean for the whole panel.
+    if (typeof v !== 'number' || !Number.isFinite(v)) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+    count += 1;
+  }
+
+  if (count === 0) return null;
+
+  return { min, max, mean: sum / count, count };
+}

--- a/frontend/src/lib/choroplethTiles.ts
+++ b/frontend/src/lib/choroplethTiles.ts
@@ -1,0 +1,216 @@
+import type maplibregl from 'maplibre-gl';
+import { CHOROPLETH_VALUE_STATE_KEY } from './choroplethPaint';
+
+/**
+ * The vector-tile transport for the choropleth.
+ *
+ * The catchment geometry is already in the tile pipeline - `gpkg_to_mbtiles.sh`
+ * tiles `catchments_lev12` alongside the basemap layers - but the choropleth
+ * was not using it: it fetched the same polygons as GeoJSON on every viewport
+ * change, for every map instance, and paid for the parse and the tessellation
+ * each time. Sourcing the geometry from tiles means MapLibre fetches and
+ * tessellates each tile once and then reuses it for every subsequent pan, zoom
+ * and attribute change.
+ *
+ * What tiles cannot carry is the value being rendered: there are dozens of
+ * indicators across three scenarios, and baking them all into the tiles would
+ * multiply their size at every zoom level. So the values are fetched separately
+ * (`/api/catchment-values`, geometry-free) and joined onto the tiles with
+ * feature state, which MapLibre applies to tiles as they load - including tiles
+ * loaded long after the state was set. Colouring itself stays exactly what it
+ * was: a data-driven paint expression, evaluated on the GPU.
+ */
+
+/** The layer name `gpkg_to_mbtiles.sh` gives catchment geometry in the tiles. */
+export const CATCHMENT_TILE_SOURCE_LAYER = 'catchments_lev12';
+
+/**
+ * The tile attribute holding a catchment's HYBAS_ID, promoted to the feature id
+ * so feature state can be keyed by it. MapLibre stringifies both sides of that
+ * lookup, so an integer id here matches an integer-valued tile attribute
+ * whether the tiles encoded it as a number or as a string - but not one encoded
+ * with a decimal part ("1120000010.0"), which would never match.
+ */
+export const CATCHMENT_TILE_ID_PROPERTY = 'HYBAS_ID';
+
+/** A catchment vector layer found in the served tileset. */
+export interface CatchmentTileset {
+  sourceLayer: string;
+  /** Lowest zoom at which the tiles actually contain catchment geometry. */
+  minzoom: number;
+  /** Highest zoom generated; MapLibre overzooms beyond it. */
+  maxzoom: number;
+  /** Tile URL templates, taken from the TileJSON (several, for parallelism). */
+  tiles: string[];
+}
+
+interface TileJSONVectorLayer {
+  id?: unknown;
+  minzoom?: unknown;
+  maxzoom?: unknown;
+}
+
+/**
+ * Find the catchment layer in a TileJSON document.
+ *
+ * Returns null - meaning "fall back to the GeoJSON path" - unless the tileset
+ * declares the catchment layer *and* the zoom range it covers. The zoom range is
+ * not optional on purpose: catchments are tiled from zoom 8 up, and rendering a
+ * tile source below its minimum zoom shows nothing at all. Guessing the range
+ * from the tileset-level minzoom would silently blank the choropleth across the
+ * low-zoom range that the grid-aggregated GeoJSON path exists to serve.
+ */
+export function resolveCatchmentTileset(tilejson: unknown): CatchmentTileset | null {
+  if (!tilejson || typeof tilejson !== 'object') return null;
+  const doc = tilejson as { vector_layers?: unknown; tiles?: unknown };
+
+  const tiles = Array.isArray(doc.tiles)
+    ? doc.tiles.filter((t): t is string => typeof t === 'string')
+    : [];
+  if (tiles.length === 0) return null;
+
+  if (!Array.isArray(doc.vector_layers)) return null;
+  for (const raw of doc.vector_layers) {
+    const layer = raw as TileJSONVectorLayer;
+    if (layer?.id !== CATCHMENT_TILE_SOURCE_LAYER) continue;
+    if (typeof layer.minzoom !== 'number' || typeof layer.maxzoom !== 'number') return null;
+    return {
+      sourceLayer: CATCHMENT_TILE_SOURCE_LAYER,
+      minzoom: layer.minzoom,
+      maxzoom: layer.maxzoom,
+      tiles,
+    };
+  }
+  return null;
+}
+
+// Module-level cache: every map instance asks the same question, and in grid
+// view there are twelve of them. Mirrors the style cache in MapView.
+let _tilesetPromise: Promise<CatchmentTileset | null> | null = null;
+
+/**
+ * Resolve (once per page load) whether the served tileset carries catchments.
+ *
+ * Never rejects: a datapack whose tiles predate catchment tiling, or a tile
+ * store that is mid-install, simply means the GeoJSON path stays in use.
+ */
+export function fetchCatchmentTileset(url = '/data/tiles.json'): Promise<CatchmentTileset | null> {
+  if (!_tilesetPromise) {
+    _tilesetPromise = fetch(url)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((doc) => resolveCatchmentTileset(doc))
+      .catch(() => null);
+  }
+  return _tilesetPromise;
+}
+
+/** Test seam: forget the cached tileset lookup. */
+export function resetCatchmentTilesetCache(): void {
+  _tilesetPromise = null;
+}
+
+/**
+ * The vector source specification for the choropleth's own catchment source.
+ *
+ * Its own source rather than the basemap style's: the satellite basemap
+ * replaces the whole style, taking the basemap's vector source with it, and the
+ * choropleth has to keep working underneath either one.
+ *
+ * `tiles` is inlined from the already-fetched TileJSON so MapLibre does not
+ * re-request it once per map instance, and minzoom bounds tile requests to the
+ * range that actually contains catchments.
+ */
+export function catchmentTileSourceSpec(tileset: CatchmentTileset): maplibregl.VectorSourceSpecification {
+  return {
+    type: 'vector',
+    tiles: tileset.tiles,
+    minzoom: tileset.minzoom,
+    maxzoom: tileset.maxzoom,
+    promoteId: { [tileset.sourceLayer]: CATCHMENT_TILE_ID_PROPERTY },
+  };
+}
+
+/**
+ * Which catchment ids currently carry a value, per map and source.
+ *
+ * Kept so that a change of attribute or scenario can clear exactly the ids it
+ * previously set. The obvious alternative, `map.removeFeatureState({source,
+ * sourceLayer})`, is quadratic: MapLibre marks the whole layer for deletion and
+ * then, on *each* subsequent setFeatureState, walks every already-known feature
+ * to re-queue its deletion. With tens of thousands of catchments in view that is
+ * hundreds of millions of operations on the main thread - the exact cost this
+ * whole change exists to remove.
+ */
+interface AppliedValues {
+  /** scenario+attribute the ids were set for. */
+  key: string;
+  ids: number[];
+}
+const appliedByMap = new WeakMap<maplibregl.Map, Map<string, AppliedValues>>();
+
+/** How much work applyCatchmentValues did, for the [perf] log. */
+export interface ValueApplication {
+  set: number;
+  cleared: number;
+}
+
+/**
+ * Join a viewport's attribute values onto the catchment tiles as feature state.
+ *
+ * `key` identifies what the values mean (scenario and attribute). When it
+ * changes, ids set for the previous key are nulled first - feature state
+ * survives the switch otherwise, and a catchment that scrolled out of view
+ * would keep the previous indicator's colour. When it does not change, nothing
+ * is cleared: a catchment's value for a given attribute does not depend on the
+ * viewport, so values accumulate as the user pans and re-panning over ground
+ * already covered sets nothing new.
+ */
+export function applyCatchmentValues(
+  map: maplibregl.Map,
+  sourceId: string,
+  sourceLayer: string,
+  key: string,
+  ids: number[],
+  values: number[],
+): ValueApplication {
+  if (!map.style || !map.getSource(sourceId)) return { set: 0, cleared: 0 };
+
+  let perSource = appliedByMap.get(map);
+  if (!perSource) {
+    perSource = new Map<string, AppliedValues>();
+    appliedByMap.set(map, perSource);
+  }
+
+  const previous = perSource.get(sourceId);
+  let cleared = 0;
+  if (previous && previous.key !== key) {
+    // null rather than removeFeatureState: the paint expression coalesces a
+    // null value to the domain minimum, which is what an unknown catchment
+    // should look like, and it costs one flat pass instead of a quadratic one.
+    for (const id of previous.ids) {
+      map.setFeatureState({ source: sourceId, sourceLayer, id }, { [CHOROPLETH_VALUE_STATE_KEY]: null });
+    }
+    cleared = previous.ids.length;
+  }
+
+  const applied = new Set<number>(previous && previous.key === key ? previous.ids : []);
+  const count = Math.min(ids.length, values.length);
+  for (let i = 0; i < count; i++) {
+    map.setFeatureState(
+      { source: sourceId, sourceLayer, id: ids[i] },
+      { [CHOROPLETH_VALUE_STATE_KEY]: values[i] },
+    );
+    applied.add(ids[i]);
+  }
+
+  perSource.set(sourceId, { key, ids: Array.from(applied) });
+  return { set: count, cleared };
+}
+
+/**
+ * Forget what was applied to a source, for when the source itself goes away
+ * (feature state is stored on the source, so removing it discards the state).
+ */
+export function forgetCatchmentValues(map: maplibregl.Map, sourceId: string): void {
+  appliedByMap.get(map)?.delete(sourceId);
+}

--- a/frontend/src/test/choroplethPaint.test.ts
+++ b/frontend/src/test/choroplethPaint.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PRISM_STOPS,
+  MAX_EXTRUSION_HEIGHT,
+  CHOROPLETH_VALUE_STATE_KEY,
+  attributeValueAccessor,
+  featureStateValueAccessor,
+  buildFillColorExpression,
+  buildOpacityColorExpression,
+  buildExtrusionExpression,
+  zoneStatsFromValues,
+} from '../lib/choroplethPaint';
+
+// The choropleth's colouring is a data-driven paint expression evaluated on the
+// GPU. Moving the geometry onto vector tiles changes only where the expression
+// reads a catchment's value from; the expression itself has to be preserved, or
+// the same value would render as a different colour depending on the zoom range
+// it was viewed at.
+
+/** Replace every occurrence of `from` inside a nested expression with `to`. */
+function substitute(expr: unknown, from: unknown, to: unknown): unknown {
+  const fromJSON = JSON.stringify(from);
+  if (JSON.stringify(expr) === fromJSON) return to;
+  if (Array.isArray(expr)) return expr.map((e) => substitute(e, from, to));
+  return expr;
+}
+
+describe('choropleth paint expressions', () => {
+  const attribute = 'rainfall_mm';
+  const propertyAccess = attributeValueAccessor(attribute);
+  const stateAccess = featureStateValueAccessor();
+
+  it('reads a value from properties on the GeoJSON path and feature state on the tile path', () => {
+    expect(propertyAccess).toEqual(['get', attribute]);
+    expect(stateAccess).toEqual(['feature-state', CHOROPLETH_VALUE_STATE_KEY]);
+  });
+
+  it('produces the same fill-color expression on both paths bar the value accessor', () => {
+    for (const scaleType of ['linear', 'logistic', 'logarithmic'] as const) {
+      const fromProperties = buildFillColorExpression(propertyAccess, 0, 100, null, scaleType);
+      const fromState = buildFillColorExpression(stateAccess, 0, 100, null, scaleType);
+      expect(substitute(fromState, stateAccess, propertyAccess)).toEqual(fromProperties);
+    }
+  });
+
+  it('produces the same extrusion and metadata-colour expressions on both paths', () => {
+    expect(substitute(buildExtrusionExpression(stateAccess, 0, 100), stateAccess, propertyAccess))
+      .toEqual(buildExtrusionExpression(propertyAccess, 0, 100));
+    expect(substitute(buildOpacityColorExpression(stateAccess, 0, 100, '#00bcd4'), stateAccess, propertyAccess))
+      .toEqual(buildOpacityColorExpression(propertyAccess, 0, 100, '#00bcd4'));
+  });
+
+  it('interpolates the full prism ramp against the normalised value', () => {
+    const expr = buildFillColorExpression(propertyAccess, 10, 110, null, 'linear') as unknown[];
+
+    expect(expr[0]).toBe('interpolate');
+    expect(expr[1]).toEqual(['linear']);
+    // A ratio of the value's distance above the domain minimum, with a
+    // coalesce so a catchment with no value renders as the low end of the
+    // scale rather than as a hole.
+    expect(expr[2]).toEqual(['/', ['-', ['coalesce', propertyAccess, 10], 10], 100]);
+    expect(expr.slice(3)).toEqual(PRISM_STOPS.flatMap(([t, color]) => [t, color]));
+  });
+
+  it('falls back to a flat colour on a degenerate domain', () => {
+    expect(buildFillColorExpression(propertyAccess, 5, 5)).toBe(PRISM_STOPS[PRISM_STOPS.length / 2][1]);
+    expect(buildFillColorExpression(propertyAccess, 5, 5, '#00bcd4')).toBe('#FFFFFF');
+    expect(buildExtrusionExpression(propertyAccess, 5, 5)).toBe(MAX_EXTRUSION_HEIGHT / 2);
+  });
+
+  it('wraps the linear ratio in the documented curve for the non-linear scales', () => {
+    const logarithmic = buildFillColorExpression(propertyAccess, 0, 1, null, 'logarithmic') as unknown[];
+    expect((logarithmic[2] as unknown[])[0]).toBe('let');
+    expect(JSON.stringify(logarithmic[2])).toContain('"ln"');
+
+    const logistic = buildFillColorExpression(propertyAccess, 0, 1, null, 'logistic') as unknown[];
+    expect((logistic[2] as unknown[])[0]).toBe('let');
+    expect(JSON.stringify(logistic[2])).toContain('"^"');
+  });
+});
+
+describe('zoneStatsFromValues', () => {
+  it('summarises a set of values', () => {
+    expect(zoneStatsFromValues([1, 2, 6])).toEqual({ min: 1, max: 6, mean: 3, count: 3 });
+  });
+
+  it('returns null when there is nothing to summarise', () => {
+    expect(zoneStatsFromValues([])).toBeNull();
+  });
+
+  // Both callers feed this from loosely typed sources - GeoJSON properties on
+  // one path, a parsed JSON array on the other - and a single bad entry must
+  // not turn the whole panel's mean into NaN.
+  it('ignores entries that are not finite numbers', () => {
+    const values = [1, NaN, 3, Infinity, 5] as number[];
+    expect(zoneStatsFromValues(values)).toEqual({ min: 1, max: 5, mean: 3, count: 3 });
+  });
+});

--- a/frontend/src/test/choroplethRenderPath.test.ts
+++ b/frontend/src/test/choroplethRenderPath.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// MapView is far too entangled with WebGL to instantiate in a test, so these are
+// source-level guards on the two invariants of the vector-tile render path that
+// fail silently rather than loudly: a layer on a vector source without a
+// source-layer renders nothing at all, and a viewport change that refetches
+// geometry looks correct while undoing the entire point of the change.
+//
+// Same approach, and the same caveats, as renderCost.test.ts.
+
+const src = join(dirname(fileURLToPath(import.meta.url)), '..');
+const mapView = readFileSync(join(src, 'components', 'MapView.tsx'), 'utf8');
+
+describe('choropleth vector-tile render path', () => {
+  it('sources catchment geometry from the tile pipeline', () => {
+    expect(mapView).toMatch(/map\.addSource\(sourceId, catchmentTileSourceSpec\(/);
+  });
+
+  it('gives every layer on the choropleth source its source-layer', () => {
+    // Count the layers added onto the choropleth source, and require each to
+    // spread the source-layer specification (empty for the GeoJSON fallback,
+    // where the property must be absent rather than undefined).
+    const addLayerCalls = mapView.match(/map\.addLayer\(\{[\s\S]*?\n {6}\}\);/g) ?? [];
+    const onChoroplethSource = addLayerCalls.filter((call) => /source: sourceId,/.test(call));
+
+    expect(onChoroplethSource.length).toBeGreaterThan(0);
+    for (const call of onChoroplethSource) {
+      expect(call).toMatch(/\.\.\.sourceLayerSpec,/);
+    }
+  });
+
+  it('fetches values, not geometry, once the tiled zoom range is in use', () => {
+    expect(mapView).toMatch(/fetch\(`\/api\/catchment-values\?\$\{params\}`\)/);
+    // The values request carries no zoom: the server's detailed-vs-aggregated
+    // choice does not apply when geometry comes from tiles.
+    const valuesFetch = mapView.slice(
+      mapView.indexOf('async function fetchChoroplethValues('),
+      mapView.indexOf('async function fetchChoroplethData('),
+    );
+    expect(valuesFetch).not.toMatch(/zoom:/);
+  });
+
+  it('keeps the GeoJSON path for the zoom range the tiles do not cover', () => {
+    // Catchments are tiled from zoom 8 up; below that the backend serves
+    // grid-aggregated cells, which have no tiled equivalent.
+    expect(mapView).toMatch(/currentZoom >= tileset\.minzoom/);
+    expect(mapView).toMatch(/kind: 'geojson', data: leftDisplay/);
+  });
+});

--- a/frontend/src/test/choroplethTiles.test.ts
+++ b/frontend/src/test/choroplethTiles.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type maplibregl from 'maplibre-gl';
+import {
+  CATCHMENT_TILE_ID_PROPERTY,
+  CATCHMENT_TILE_SOURCE_LAYER,
+  applyCatchmentValues,
+  catchmentTileSourceSpec,
+  fetchCatchmentTileset,
+  forgetCatchmentValues,
+  resetCatchmentTilesetCache,
+  resolveCatchmentTileset,
+} from '../lib/choroplethTiles';
+import { CHOROPLETH_VALUE_STATE_KEY } from '../lib/choroplethPaint';
+
+const TILE_URLS = [
+  'http://localhost:8080/tiles/africa/{z}/{x}/{y}.pbf',
+  'http://localhost:8081/tiles/africa/{z}/{x}/{y}.pbf',
+];
+
+function tilejson(vectorLayers: unknown, tiles: unknown = TILE_URLS) {
+  return { tilejson: '2.2.0', name: 'africa', tiles, vector_layers: vectorLayers };
+}
+
+describe('resolveCatchmentTileset', () => {
+  it('finds the catchment layer and the zoom range it covers', () => {
+    const tileset = resolveCatchmentTileset(tilejson([
+      { id: 'ne_10m_rivers', minzoom: 6, maxzoom: 15 },
+      { id: CATCHMENT_TILE_SOURCE_LAYER, minzoom: 8, maxzoom: 15 },
+    ]));
+
+    expect(tileset).toEqual({
+      sourceLayer: CATCHMENT_TILE_SOURCE_LAYER,
+      minzoom: 8,
+      maxzoom: 15,
+      tiles: TILE_URLS,
+    });
+  });
+
+  // A datapack built before catchments were tiled must keep working: the
+  // choropleth stays on the GeoJSON path at every zoom rather than rendering
+  // nothing.
+  it('returns null when the tileset has no catchment layer', () => {
+    expect(resolveCatchmentTileset(tilejson([{ id: 'ecoregions', minzoom: 2, maxzoom: 8 }]))).toBeNull();
+  });
+
+  // Catchments are tiled from zoom 8 up. Guessing a missing zoom range would
+  // blank the choropleth across the low-zoom range the grid-aggregated GeoJSON
+  // path exists to serve, which is far worse than not using tiles at all.
+  it('refuses to guess a missing zoom range', () => {
+    expect(resolveCatchmentTileset(tilejson([{ id: CATCHMENT_TILE_SOURCE_LAYER }]))).toBeNull();
+    expect(resolveCatchmentTileset(tilejson([{ id: CATCHMENT_TILE_SOURCE_LAYER, minzoom: 8 }]))).toBeNull();
+  });
+
+  it('returns null without tile URLs or without vector layers', () => {
+    expect(resolveCatchmentTileset(tilejson([{ id: CATCHMENT_TILE_SOURCE_LAYER, minzoom: 8, maxzoom: 15 }], []))).toBeNull();
+    expect(resolveCatchmentTileset({ tiles: TILE_URLS })).toBeNull();
+    expect(resolveCatchmentTileset(null)).toBeNull();
+  });
+});
+
+describe('fetchCatchmentTileset', () => {
+  beforeEach(() => {
+    resetCatchmentTilesetCache();
+  });
+
+  it('asks the server once however many map instances ask it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => tilejson([{ id: CATCHMENT_TILE_SOURCE_LAYER, minzoom: 8, maxzoom: 15 }]),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await Promise.all([fetchCatchmentTileset(), fetchCatchmentTileset(), fetchCatchmentTileset()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(results.every((r) => r?.minzoom === 8)).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  // A tile store that is mid-install answers with an error. That must mean
+  // "use the GeoJSON path", never an unhandled rejection.
+  it('resolves to null when the tileset cannot be read', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('unavailable')));
+    await expect(fetchCatchmentTileset()).resolves.toBeNull();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('catchmentTileSourceSpec', () => {
+  it('promotes HYBAS_ID to the feature id so feature state can be keyed by it', () => {
+    const spec = catchmentTileSourceSpec({
+      sourceLayer: CATCHMENT_TILE_SOURCE_LAYER,
+      minzoom: 8,
+      maxzoom: 15,
+      tiles: TILE_URLS,
+    });
+
+    expect(spec.type).toBe('vector');
+    expect(spec.promoteId).toEqual({ [CATCHMENT_TILE_SOURCE_LAYER]: CATCHMENT_TILE_ID_PROPERTY });
+    // Inlined tile URLs, not a TileJSON url: otherwise every map instance
+    // re-fetches the document that has already been read once.
+    expect(spec.tiles).toEqual(TILE_URLS);
+    expect(spec.url).toBeUndefined();
+    // Bounded to the zooms that actually contain catchments, so no tile
+    // request is made below the tiled range.
+    expect(spec.minzoom).toBe(8);
+    expect(spec.maxzoom).toBe(15);
+  });
+});
+
+interface FakeMap {
+  map: maplibregl.Map;
+  state: Map<string, Record<string, unknown>>;
+  setCalls: number;
+  removeFeatureState: ReturnType<typeof vi.fn>;
+}
+
+function fakeMap(sourceIds: string[] = ['choropleth-source-left']): FakeMap {
+  const state = new Map<string, Record<string, unknown>>();
+  const removeFeatureState = vi.fn();
+  const fake = {
+    state,
+    setCalls: 0,
+    removeFeatureState,
+  } as unknown as FakeMap;
+
+  const map = {
+    style: {},
+    getSource: (id: string) => (sourceIds.includes(id) ? { type: 'vector' } : undefined),
+    setFeatureState: (target: { source: string; sourceLayer: string; id: number }, values: Record<string, unknown>) => {
+      fake.setCalls += 1;
+      state.set(`${target.source}/${target.sourceLayer}/${target.id}`, { ...state.get(`${target.source}/${target.sourceLayer}/${target.id}`), ...values });
+    },
+    removeFeatureState,
+  } as unknown as maplibregl.Map;
+
+  fake.map = map;
+  fake.state = state;
+  return fake;
+}
+
+const SOURCE = 'choropleth-source-left';
+
+describe('applyCatchmentValues', () => {
+  it('joins each value onto its catchment as feature state', () => {
+    const f = fakeMap();
+
+    const applied = applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11, 22], [1.5, 2.5]);
+
+    expect(applied).toEqual({ set: 2, cleared: 0 });
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/11`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: 1.5 });
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/22`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: 2.5 });
+  });
+
+  // A catchment's value for a given attribute does not depend on the viewport,
+  // so panning must not throw away what is already joined - that is what makes
+  // re-panning over covered ground cost nothing.
+  it('accumulates across viewports while the attribute is unchanged', () => {
+    const f = fakeMap();
+
+    applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11], [1]);
+    const second = applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [22], [2]);
+
+    expect(second.cleared).toBe(0);
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/11`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: 1 });
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/22`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: 2 });
+  });
+
+  // Feature state outlives the viewport it was set for, so a catchment left
+  // holding the previous indicator's value would paint with it the moment it
+  // scrolled back into view.
+  it('clears the previous attribute’s values when the attribute changes', () => {
+    const f = fakeMap();
+
+    applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11, 22], [1, 2]);
+    const second = applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|runoff', [22], [9]);
+
+    expect(second).toEqual({ set: 1, cleared: 2 });
+    // 11 is not in the new viewport's values, so it must be left with no value
+    // at all rather than the old attribute's.
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/11`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: null });
+    expect(f.state.get(`${SOURCE}/${CATCHMENT_TILE_SOURCE_LAYER}/22`)).toEqual({ [CHOROPLETH_VALUE_STATE_KEY]: 9 });
+  });
+
+  // map.removeFeatureState({source, sourceLayer}) marks the whole layer for
+  // deletion, after which MapLibre walks every known feature on each subsequent
+  // setFeatureState call - quadratic in the number of catchments in view, which
+  // at the tiled minimum zoom is tens of thousands.
+  it('never clears by removing the whole source layer', () => {
+    const f = fakeMap();
+
+    applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11], [1]);
+    applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|runoff', [11], [2]);
+
+    expect(f.removeFeatureState).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the source is not on the map', () => {
+    const f = fakeMap([]);
+
+    expect(applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11], [1]))
+      .toEqual({ set: 0, cleared: 0 });
+    expect(f.setCalls).toBe(0);
+  });
+
+  // Feature state is stored on the source, so once the source goes the join
+  // goes with it; a stale record of what was applied would make the next
+  // application skip the clearing it still owes.
+  it('forgets what was applied once the source is removed', () => {
+    const f = fakeMap();
+
+    applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|rain', [11], [1]);
+    forgetCatchmentValues(f.map, SOURCE);
+    const after = applyCatchmentValues(f.map, SOURCE, CATCHMENT_TILE_SOURCE_LAYER, 'current|runoff', [11], [2]);
+
+    expect(after.cleared).toBe(0);
+  });
+});

--- a/internal/api/catchment_values_test.go
+++ b/internal/api/catchment_values_test.go
@@ -1,0 +1,188 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+	"github.com/kartoza/decision-theatre/internal/geodata"
+	"github.com/kartoza/decision-theatre/internal/gpkgtest"
+)
+
+// newValuesTestHandler wires a Handler over a synthetic datapack so the
+// values endpoint is exercised through the real SQL, not a stub.
+func newValuesTestHandler(t *testing.T) *mux.Router {
+	t.Helper()
+
+	dir := gpkgtest.Build(t, t.TempDir(), []gpkgtest.Catchment{
+		{ID: 1000000001, Lat: 0, Long: 0, SizeDeg: 0.5, Current: gpkgtest.Float(10), Reference: gpkgtest.Float(1)},
+		{ID: 1000000002, Lat: 0, Long: 1, SizeDeg: 0.5, Current: gpkgtest.Float(20), Reference: gpkgtest.Float(2)},
+	}, 0, 100)
+
+	store, err := geodata.NewGpkgStore(dir)
+	if err != nil {
+		t.Fatalf("NewGpkgStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+	return r
+}
+
+func getValues(t *testing.T, r *mux.Router, target string) (*httptest.ResponseRecorder, CatchmentValuesResponse) {
+	t.Helper()
+	req := httptest.NewRequest("GET", target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var resp CatchmentValuesResponse
+	if w.Code == http.StatusOK {
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v (body %s)", err, w.Body.String())
+		}
+	}
+	return w, resp
+}
+
+func TestCatchmentValuesReturnsIDsValuesAndDomain(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	w, resp := getValues(t, r,
+		"/catchment-values?scenario=current&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(resp.IDs) != 2 || len(resp.Values) != 2 {
+		t.Fatalf("expected 2 ids and 2 values, got %v / %v", resp.IDs, resp.Values)
+	}
+	if resp.DomainMin != 0 || resp.DomainMax != 100 {
+		t.Errorf("domain range %v..%v, want 0..100", resp.DomainMin, resp.DomainMax)
+	}
+	if resp.Attribute != gpkgtest.Attribute || resp.Scenario != "current" {
+		t.Errorf("echoed scenario/attribute wrong: %q %q", resp.Scenario, resp.Attribute)
+	}
+}
+
+// The whole point of the endpoint: it must not carry geometry. A response that
+// quietly grew a geometry field would reintroduce the cost the vector-tile path
+// exists to remove, while still passing every other assertion here.
+func TestCatchmentValuesCarriesNoGeometry(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	req := httptest.NewRequest("GET",
+		"/catchment-values?scenario=current&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, forbidden := range []string{"geometry", "features", "coordinates"} {
+		if _, present := raw[forbidden]; present {
+			t.Errorf("response carries a %q field; the tile pipeline supplies geometry", forbidden)
+		}
+	}
+}
+
+// The colour scale must not depend on which transport delivered the geometry:
+// /choropleth and /catchment-values have to agree on the domain, or switching
+// between the aggregated and tiled zoom ranges would recolour the map.
+func TestCatchmentValuesDomainMatchesChoropleth(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	_, values := getValues(t, r,
+		"/catchment-values?scenario=current&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5")
+
+	req := httptest.NewRequest("GET",
+		"/choropleth?scenario=current&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("choropleth status %d: %s", w.Code, w.Body.String())
+	}
+	var choropleth ChoroplethResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &choropleth); err != nil {
+		t.Fatalf("decode choropleth: %v", err)
+	}
+
+	if values.DomainMin != choropleth.DomainMin || values.DomainMax != choropleth.DomainMax {
+		t.Errorf("domain %v..%v from values, %v..%v from choropleth",
+			values.DomainMin, values.DomainMax, choropleth.DomainMin, choropleth.DomainMax)
+	}
+}
+
+func TestCatchmentValuesRespectsBBox(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	_, resp := getValues(t, r,
+		"/catchment-values?scenario=current&attribute="+gpkgtest.Attribute+"&minx=-0.4&miny=-0.4&maxx=0.4&maxy=0.4")
+	if len(resp.IDs) != 1 || resp.IDs[0] != 1000000001 {
+		t.Fatalf("expected only the catchment at the origin, got %v", resp.IDs)
+	}
+}
+
+func TestCatchmentValuesValidatesParameters(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	cases := []struct {
+		name   string
+		target string
+		status int
+	}{
+		{"missing attribute", "/catchment-values?scenario=current&minx=-5&miny=-5&maxx=5&maxy=5", http.StatusBadRequest},
+		{"unparseable bbox", "/catchment-values?scenario=current&attribute=" + gpkgtest.Attribute + "&minx=west&miny=-5&maxx=5&maxy=5", http.StatusBadRequest},
+		{"unknown attribute", "/catchment-values?scenario=current&attribute=not_a_column&minx=-5&miny=-5&maxx=5&maxy=5", http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.target, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tc.status {
+				t.Errorf("status %d, want %d (body %s)", w.Code, tc.status, w.Body.String())
+			}
+		})
+	}
+}
+
+// "future" is the reference scenario recoloured by a site's saved targets. With
+// no site it must fall back to reference values, exactly as /choropleth does.
+func TestCatchmentValuesFutureFallsBackToReference(t *testing.T) {
+	r := newValuesTestHandler(t)
+
+	_, future := getValues(t, r,
+		"/catchment-values?scenario=future&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5")
+	_, reference := getValues(t, r,
+		"/catchment-values?scenario=reference&attribute="+gpkgtest.Attribute+"&minx=-5&miny=-5&maxx=5&maxy=5")
+
+	if len(future.Values) != len(reference.Values) {
+		t.Fatalf("future returned %d values, reference %d", len(future.Values), len(reference.Values))
+	}
+	for i := range future.Values {
+		if future.Values[i] != reference.Values[i] {
+			t.Errorf("value %d: future %v != reference %v", i, future.Values[i], reference.Values[i])
+		}
+	}
+}
+
+func TestCatchmentValuesWithoutStoreIsUnavailable(t *testing.T) {
+	handler := newTestHandler()
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET",
+		"/catchment-values?scenario=current&attribute=x&minx=-5&miny=-5&maxx=5&maxy=5", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status %d, want 503", w.Code)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -123,6 +124,11 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 
 	// Choropleth endpoint - returns GeoJSON filtered by bbox
 	r.HandleFunc("/choropleth", h.handleChoropleth).Methods("GET")
+
+	// Values-only companion to /choropleth, for the vector-tile render path:
+	// geometry comes from the tile pipeline, so only the attribute values for
+	// the viewport need fetching. See handleCatchmentValues.
+	r.HandleFunc("/catchment-values", h.handleCatchmentValues).Methods("GET")
 
 	// Site management is desktop-only; see registerDesktopSiteRoutes.
 	h.registerDesktopSiteRoutes(r)
@@ -662,26 +668,12 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse bbox parameters
-	minx, err := strconv.ParseFloat(q.Get("minx"), 64)
-	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid minx parameter")
+	bbox, badParam := parseBBoxParams(q)
+	if badParam != "" {
+		respondError(w, http.StatusBadRequest, "invalid "+badParam+" parameter")
 		return
 	}
-	miny, err := strconv.ParseFloat(q.Get("miny"), 64)
-	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid miny parameter")
-		return
-	}
-	maxx, err := strconv.ParseFloat(q.Get("maxx"), 64)
-	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid maxx parameter")
-		return
-	}
-	maxy, err := strconv.ParseFloat(q.Get("maxy"), 64)
-	if err != nil {
-		respondError(w, http.StatusBadRequest, "invalid maxy parameter")
-		return
-	}
+	minx, miny, maxx, maxy := bbox[0], bbox[1], bbox[2], bbox[3]
 
 	// zoom is optional; callers that omit it (or send a non-numeric value)
 	// get full-detail geometry, matching the pre-existing behaviour.
@@ -692,25 +684,7 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 
 	// For the future/target scenario with a known site, build a lookup of
 	// per-catchment ideal values so the choropleth shows user-edited targets.
-	siteID := q.Get("siteId")
-	var idealOverrides map[int64]float64
-	if scenario == "future" && siteID != "" && h.siteStore != nil {
-		if site, siteErr := h.siteStore.Get(siteID); siteErr == nil {
-			idealOverrides = make(map[int64]float64, len(site.Catchments))
-			for _, c := range site.Catchments {
-				if c.Ideal == nil {
-					continue
-				}
-				val, ok := c.Ideal[attribute]
-				if !ok {
-					continue
-				}
-				if idF, parseErr := strconv.ParseFloat(c.ID, 64); parseErr == nil {
-					idealOverrides[int64(idF)] = val
-				}
-			}
-		}
-	}
+	idealOverrides := h.siteIdealOverrides(scenario, q.Get("siteId"), attribute)
 
 	// Use reference geometry when overlaying ideal values; future without a
 	// site falls back to reference as before.
@@ -753,21 +727,86 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get domain range for consistent color scaling across scenarios
-	domainStart := time.Now()
-	domainRange, err := h.gpkgStore.GetDomainRange(attribute)
-	log.Printf("[perf] handleChoropleth step=getDomainRange attribute=%s duration_ms=%d", attribute, time.Since(domainStart).Milliseconds())
+	domainMin, domainMax := h.domainRangeFor(scenario, attribute)
+
+	// Build response with domain range
+	response := ChoroplethResponse{
+		Type:      "FeatureCollection",
+		Features:  fc.Features,
+		DomainMin: domainMin,
+		DomainMax: domainMax,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// parseBBoxParams reads the minx/miny/maxx/maxy query parameters shared by every
+// viewport-scoped endpoint. It returns the name of the first parameter that
+// failed to parse, or "" when all four are valid, so the caller can report which
+// one was wrong rather than a generic "bad bbox".
+func parseBBoxParams(q url.Values) (bbox [4]float64, badParam string) {
+	for i, name := range [4]string{"minx", "miny", "maxx", "maxy"} {
+		v, err := strconv.ParseFloat(q.Get(name), 64)
+		if err != nil {
+			return bbox, name
+		}
+		bbox[i] = v
+	}
+	return bbox, ""
+}
+
+// siteIdealOverrides builds the per-catchment target values a site's editor has
+// saved, keyed by HYBAS_ID. Only the "future" scenario has them: it is the
+// reference geometry recoloured by the user's edits, so everything else returns
+// nil and the callers skip the overlay entirely.
+func (h *Handler) siteIdealOverrides(scenario, siteID, attribute string) map[int64]float64 {
+	if scenario != "future" || siteID == "" || h.siteStore == nil {
+		return nil
+	}
+	site, err := h.siteStore.Get(siteID)
 	if err != nil {
-		// If domain tables don't exist, fall back to no domain range
+		return nil
+	}
+
+	overrides := make(map[int64]float64, len(site.Catchments))
+	for _, c := range site.Catchments {
+		if c.Ideal == nil {
+			continue
+		}
+		val, ok := c.Ideal[attribute]
+		if !ok {
+			continue
+		}
+		if idF, parseErr := strconv.ParseFloat(c.ID, 64); parseErr == nil {
+			overrides[int64(idF)] = val
+		}
+	}
+	return overrides
+}
+
+// domainRangeFor resolves the colour-scale bounds for an attribute.
+//
+// The minimum comes from the datapack's scanned domain_minima table. The maximum
+// prefers metadata.csv's curated maxval_curr/maxval_ref, which are authoritative
+// per-scenario ceilings rather than a value derived from scanning every
+// catchment; "future" (target) values are edited starting from current, so they
+// share current's ceiling. Falls back to the scanned max when the metadata
+// column is missing or blank for this attribute.
+//
+// Both the GeoJSON and the vector-tile choropleth paths call this: the colours
+// must not shift depending on which transport delivered the geometry.
+func (h *Handler) domainRangeFor(scenario, attribute string) (min, max float64) {
+	start := time.Now()
+	domainRange, err := h.gpkgStore.GetDomainRange(attribute)
+	log.Printf("[perf] domainRangeFor attribute=%s duration_ms=%d", attribute, time.Since(start).Milliseconds())
+	if err != nil {
+		// If domain tables don't exist, fall back to no domain range.
 		log.Printf("Warning: could not get domain range for %s: %v", attribute, err)
 		domainRange = &geodata.DomainRange{Min: 0, Max: 0}
 	}
 
-	// Prefer metadata.csv's curated maxval_curr/maxval_ref over the scanned
-	// domain_maxima table for the max bound — these are authoritative
-	// per-scenario ceilings rather than a value derived from scanning every
-	// catchment. "future" (target) values are edited starting from current,
-	// so they share current's ceiling. Falls back to the scanned max when a
-	// column is missing/blank for this attribute.
 	maxvalByScenario := h.metaCache.MaxValReference
 	if scenario != "reference" {
 		maxvalByScenario = h.metaCache.MaxValCurrent
@@ -776,17 +815,98 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 		domainRange.Max = metaMax
 	}
 
-	// Build response with domain range
-	response := ChoroplethResponse{
-		Type:      "FeatureCollection",
-		Features:  fc.Features,
-		DomainMin: domainRange.Min,
-		DomainMax: domainRange.Max,
+	return domainRange.Min, domainRange.Max
+}
+
+// CatchmentValuesResponse is the join payload for the vector-tile choropleth:
+// the attribute values for a viewport, with no geometry, plus the same domain
+// range /choropleth returns so the colour scale is identical on both paths.
+type CatchmentValuesResponse struct {
+	Scenario  string    `json:"scenario"`
+	Attribute string    `json:"attribute"`
+	IDs       []int64   `json:"ids"`
+	Values    []float64 `json:"values"`
+	DomainMin float64   `json:"domain_min"`
+	DomainMax float64   `json:"domain_max"`
+}
+
+// handleCatchmentValues returns catchment attribute values for a bbox with no
+// geometry at all.
+//
+// It is the other half of the vector-tile choropleth. Geometry arrives from the
+// tile pipeline, is tessellated once per map instance and then reused for every
+// subsequent viewport and every attribute; the values are what actually change,
+// and they are joined onto the tiles client-side by feature state. That is why
+// this endpoint exists rather than the client reusing /choropleth: sending
+// geometry again on an attribute switch is exactly the cost the tile path is
+// there to remove.
+//
+// Query params: scenario, attribute, minx, miny, maxx, maxy, siteId (optional).
+func (h *Handler) handleCatchmentValues(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	q := r.URL.Query()
+	scenario := q.Get("scenario")
+	if scenario == "" {
+		scenario = "current"
+	}
+	attribute := q.Get("attribute")
+	count := 0
+	defer func() {
+		log.Printf("[perf] handleCatchmentValues scenario=%s attribute=%s values=%d duration_ms=%d", scenario, attribute, count, time.Since(start).Milliseconds())
+	}()
+
+	if h.gpkgStore == nil {
+		respondError(w, http.StatusServiceUnavailable, "geopackage store not available")
+		return
+	}
+	if attribute == "" {
+		respondError(w, http.StatusBadRequest, "attribute parameter is required")
+		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	bbox, badParam := parseBBoxParams(q)
+	if badParam != "" {
+		respondError(w, http.StatusBadRequest, "invalid "+badParam+" parameter")
+		return
+	}
+
+	// "future" is the reference scenario recoloured by the site's saved target
+	// values, exactly as in handleChoropleth - the two must agree or the same
+	// viewport would be coloured differently depending on the render path.
+	queryScenario := scenario
+	if scenario == "future" {
+		queryScenario = "reference"
+	}
+
+	values, err := h.gpkgStore.QueryCatchmentValueArrays(queryScenario, attribute, bbox[0], bbox[1], bbox[2], bbox[3])
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if overrides := h.siteIdealOverrides(scenario, q.Get("siteId"), attribute); len(overrides) > 0 {
+		for i, id := range values.IDs {
+			if idealVal, ok := overrides[id]; ok {
+				values.Values[i] = idealVal
+			}
+		}
+	}
+	count = len(values.IDs)
+
+	domainMin, domainMax := h.domainRangeFor(scenario, attribute)
+
+	// Same cache policy as /choropleth: the values for a given
+	// scenario+attribute+bbox are static for the life of the datapack, and the
+	// grid view issues the identical request from every pane.
 	w.Header().Set("Cache-Control", "public, max-age=300")
-	_ = json.NewEncoder(w).Encode(response)
+	respondJSON(w, http.StatusOK, CatchmentValuesResponse{
+		Scenario:  scenario,
+		Attribute: attribute,
+		IDs:       values.IDs,
+		Values:    values.Values,
+		DomainMin: domainMin,
+		DomainMax: domainMax,
+	})
 }
 
 // ============================================================================

--- a/internal/geodata/catchment_values_test.go
+++ b/internal/geodata/catchment_values_test.go
@@ -1,0 +1,115 @@
+package geodata_test
+
+import (
+	"testing"
+
+	"github.com/kartoza/decision-theatre/internal/geodata"
+	"github.com/kartoza/decision-theatre/internal/gpkgtest"
+)
+
+// newStore opens a GpkgStore over a synthetic datapack laid out around the
+// origin: three catchments in a row at longitudes 0, 1 and 2.
+func newStore(t *testing.T) *geodata.GpkgStore {
+	t.Helper()
+
+	dir := gpkgtest.Build(t, t.TempDir(), []gpkgtest.Catchment{
+		{ID: 1000000001, Lat: 0, Long: 0, SizeDeg: 0.5, Current: gpkgtest.Float(10), Reference: gpkgtest.Float(1)},
+		{ID: 1000000002, Lat: 0, Long: 1, SizeDeg: 0.5, Current: gpkgtest.Float(20), Reference: gpkgtest.Float(2)},
+		// No current value: the real datapack has catchments with no data for
+		// a given indicator, and the values query must leave them out rather
+		// than shipping a zero that would paint as the domain minimum.
+		{ID: 1000000003, Lat: 0, Long: 2, SizeDeg: 0.5, Current: nil, Reference: gpkgtest.Float(3)},
+	}, 0, 100)
+
+	store, err := geodata.NewGpkgStore(dir)
+	if err != nil {
+		t.Fatalf("NewGpkgStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return store
+}
+
+func TestQueryCatchmentValueArraysReturnsIDsAndValuesInBBox(t *testing.T) {
+	store := newStore(t)
+
+	// A bbox covering the first two catchments only.
+	values, err := store.QueryCatchmentValueArrays("current", gpkgtest.Attribute, -0.5, -0.5, 1.5, 0.5)
+	if err != nil {
+		t.Fatalf("QueryCatchmentValueArrays: %v", err)
+	}
+
+	if len(values.IDs) != len(values.Values) {
+		t.Fatalf("ids and values must be index-aligned: %d ids, %d values", len(values.IDs), len(values.Values))
+	}
+
+	got := map[int64]float64{}
+	for i, id := range values.IDs {
+		got[id] = values.Values[i]
+	}
+	want := map[int64]float64{1000000001: 10, 1000000002: 20}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for id, v := range want {
+		if got[id] != v {
+			t.Errorf("catchment %d: got %v, want %v", id, got[id], v)
+		}
+	}
+}
+
+func TestQueryCatchmentValueArraysSkipsNullValues(t *testing.T) {
+	store := newStore(t)
+
+	values, err := store.QueryCatchmentValueArrays("current", gpkgtest.Attribute, -5, -5, 5, 5)
+	if err != nil {
+		t.Fatalf("QueryCatchmentValueArrays: %v", err)
+	}
+
+	for _, id := range values.IDs {
+		if id == 1000000003 {
+			t.Fatalf("catchment with a NULL value was included; a missing value must stay missing "+
+				"so the paint expression's coalesce decides how to render it (ids=%v)", values.IDs)
+		}
+	}
+	if len(values.IDs) != 2 {
+		t.Fatalf("expected the two valued catchments, got %v", values.IDs)
+	}
+}
+
+// The values array and the GeoJSON feature collection are two shapes of one
+// query. If they ever disagree about which catchments are in view, the
+// vector-tile choropleth and the statistics panel would describe different data.
+func TestQueryCatchmentValuesAgreesWithValueArrays(t *testing.T) {
+	store := newStore(t)
+
+	arrays, err := store.QueryCatchmentValueArrays("reference", gpkgtest.Attribute, -5, -5, 5, 5)
+	if err != nil {
+		t.Fatalf("QueryCatchmentValueArrays: %v", err)
+	}
+	fc, err := store.QueryCatchmentValues("reference", gpkgtest.Attribute, -5, -5, 5, 5)
+	if err != nil {
+		t.Fatalf("QueryCatchmentValues: %v", err)
+	}
+
+	if len(fc.Features) != len(arrays.IDs) {
+		t.Fatalf("feature count %d != value count %d", len(fc.Features), len(arrays.IDs))
+	}
+	for i, f := range fc.Features {
+		if f.ID != arrays.IDs[i] {
+			t.Errorf("feature %d id %d != array id %d", i, f.ID, arrays.IDs[i])
+		}
+		if v, ok := f.Properties[gpkgtest.Attribute].(float64); !ok || v != arrays.Values[i] {
+			t.Errorf("feature %d value %v != array value %v", i, f.Properties[gpkgtest.Attribute], arrays.Values[i])
+		}
+	}
+}
+
+func TestQueryCatchmentValueArraysRejectsUnknownAttribute(t *testing.T) {
+	store := newStore(t)
+
+	// The attribute name is interpolated into SQL, so an unvalidated one is an
+	// injection point; the allow-list is loaded from scenario_current's columns.
+	if _, err := store.QueryCatchmentValueArrays("current", `x" FROM sqlite_master; --`, -5, -5, 5, 5); err == nil {
+		t.Fatal("expected an error for an attribute that is not a known column")
+	}
+}

--- a/internal/geodata/gpkg_store.go
+++ b/internal/geodata/gpkg_store.go
@@ -590,6 +590,24 @@ func (s *GpkgStore) queryCatchmentsDetailed(tableName, attribute string, minx, m
 	}, nil
 }
 
+// CatchmentValues is a bbox's attribute values with no geometry at all, held as
+// two parallel arrays rather than one object per catchment.
+//
+// This is the join payload for the vector-tile choropleth: geometry arrives from
+// the tile pipeline and is reused across every attribute, so the only thing a
+// viewport or attribute change has to move over the wire is the values. The
+// parallel-array shape matters at the sizes involved - a bbox at the tile
+// pipeline's minimum zoom can match tens of thousands of catchments, and one
+// GeoJSON Feature per catchment spends roughly ten times as many bytes on
+// repeated JSON scaffolding ("type", "geometry", "properties", the attribute
+// name) as it does on the id and value that are the actual content.
+type CatchmentValues struct {
+	// IDs and Values are index-aligned: Values[i] is the attribute value for
+	// the catchment whose HYBAS_ID is IDs[i].
+	IDs    []int64   `json:"ids"`
+	Values []float64 `json:"values"`
+}
+
 // QueryCatchmentValues returns every catchment's attribute value within a bounding
 // box, with no geometry and no LIMIT. It exists for statistics (min/max/mean/count)
 // where accuracy across the true full dataset matters and per-catchment HYBAS_ID is
@@ -599,9 +617,40 @@ func (s *GpkgStore) queryCatchmentsDetailed(tableName, attribute string, minx, m
 // (with a null geometry) doesn't carry the rendering cost that motivated those
 // other paths.
 func (s *GpkgStore) QueryCatchmentValues(scenario, attribute string, minx, miny, maxx, maxy float64) (*FeatureCollection, error) {
+	values, err := s.QueryCatchmentValueArrays(scenario, attribute, minx, miny, maxx, maxy)
+	if err != nil {
+		return nil, err
+	}
+
+	features := make([]GeoJSONFeature, 0, len(values.IDs))
+	for i, id := range values.IDs {
+		features = append(features, GeoJSONFeature{
+			Type:     "Feature",
+			ID:       id,
+			Geometry: json.RawMessage("null"),
+			Properties: map[string]interface{}{
+				"HYBAS_ID": id,
+				attribute:  values.Values[i],
+			},
+		})
+	}
+
+	return &FeatureCollection{
+		Type:     "FeatureCollection",
+		Features: features,
+	}, nil
+}
+
+// QueryCatchmentValueArrays is the geometry-free bbox query both value-shaped
+// callers share: QueryCatchmentValues wraps it back into GeoJSON features for
+// the statistics path, and the /catchment-values endpoint serves it directly to
+// the vector-tile choropleth. Keeping one query means the two can never drift
+// on which catchments they consider in view.
+func (s *GpkgStore) QueryCatchmentValueArrays(scenario, attribute string, minx, miny, maxx, maxy float64) (*CatchmentValues, error) {
 	start := time.Now()
+	count := 0
 	defer func() {
-		log.Printf("[perf] QueryCatchmentValues scenario=%s attribute=%s bbox=[%.2f,%.2f,%.2f,%.2f] duration_ms=%d", scenario, attribute, minx, miny, maxx, maxy, time.Since(start).Milliseconds())
+		log.Printf("[perf] QueryCatchmentValueArrays scenario=%s attribute=%s bbox=[%.2f,%.2f,%.2f,%.2f] values=%d duration_ms=%d", scenario, attribute, minx, miny, maxx, maxy, count, time.Since(start).Milliseconds())
 	}()
 
 	tableName := resolveScenarioTable(scenario)
@@ -626,29 +675,25 @@ func (s *GpkgStore) QueryCatchmentValues(scenario, attribute string, minx, miny,
 	}
 	defer rows.Close()
 
-	features := []GeoJSONFeature{}
+	// Non-nil slices: these are marshalled straight to JSON, and a nil slice
+	// encodes as null, which the client would have to special-case on every
+	// empty viewport.
+	result := &CatchmentValues{IDs: []int64{}, Values: []float64{}}
 	for rows.Next() {
+		// HYBAS_ID is scanned through float64 because the column is text in
+		// some datapacks and integer in others; the existing detailed path
+		// does the same (see queryCatchmentsDetailed).
 		var id, value float64
 		if err := rows.Scan(&id, &value); err != nil {
 			log.Printf("Warning: failed to scan row: %v", err)
 			continue
 		}
-
-		features = append(features, GeoJSONFeature{
-			Type:     "Feature",
-			ID:       int64(id),
-			Geometry: json.RawMessage("null"),
-			Properties: map[string]interface{}{
-				"HYBAS_ID": int64(id),
-				attribute:  value,
-			},
-		})
+		result.IDs = append(result.IDs, int64(id))
+		result.Values = append(result.Values, value)
 	}
+	count = len(result.IDs)
 
-	return &FeatureCollection{
-		Type:     "FeatureCollection",
-		Features: features,
-	}, nil
+	return result, nil
 }
 
 // ensureGridGeometryCache kicks off buildGridGeometryCache exactly once. Safe

--- a/internal/gpkgtest/gpkgtest.go
+++ b/internal/gpkgtest/gpkgtest.go
@@ -1,0 +1,133 @@
+// Package gpkgtest builds a minimal, in-memory-sized datapack geopackage on
+// disk so that the geodata and api packages can be tested against the real
+// SQLite queries rather than a hand-rolled fake.
+//
+// The real datapack is several gigabytes and is not present in a checkout, so
+// before this existed the only thing the tests could assert about a query was
+// what happened when the store was nil. Everything here is deliberately the
+// smallest schema those queries actually touch: get it wrong and the test fails
+// with a SQL error naming the missing table, which is itself the signal that a
+// query has grown a new dependency.
+package gpkgtest
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Catchment is one row of the synthetic datapack: a square polygon of side
+// SizeDeg centred on (Lat, Long), with one attribute value per scenario.
+type Catchment struct {
+	ID        int64
+	Lat, Long float64
+	SizeDeg   float64
+	// Current and Reference are the attribute values for the two scenario
+	// tables. A nil pointer writes SQL NULL, which is how the real datapack
+	// represents a catchment with no data for an indicator.
+	Current, Reference *float64
+}
+
+// Attribute is the single indicator column the synthetic datapack carries. The
+// queries under test build SQL by interpolating the attribute name, so the tests
+// need a name to pass in; one column is enough to exercise that.
+const Attribute = "rainfall_mm"
+
+// Build writes a datapack.gpkg into dir containing the given catchments and
+// returns the path to the directory (which is what NewGpkgStore takes).
+//
+// domainMin/domainMax populate the domain_minima/domain_maxima tables that
+// GetDomainRange reads.
+func Build(t *testing.T, dir string, catchments []Catchment, domainMin, domainMax float64) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "datapack.gpkg")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open synthetic geopackage: %v", err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		// The geojson column is what both the detailed render path and the
+		// grid geometry cache read; the lat/long/SUB_AREA columns are what the
+		// aggregation path bins and weights by.
+		`CREATE TABLE catchments_lev12 (
+			fid INTEGER PRIMARY KEY,
+			HYBAS_ID TEXT,
+			HYBAS_ID_int INTEGER,
+			lat REAL, long REAL, SUB_AREA REAL,
+			geojson TEXT
+		)`,
+		// Not a real rtree virtual table: every query only ever SELECTs
+		// id/minx/maxx/miny/maxy from it, so a plain table with those columns
+		// exercises the same join without depending on the rtree module being
+		// compiled into the driver.
+		`CREATE TABLE rtree_catchments_lev12_geom (
+			id INTEGER, minx REAL, maxx REAL, miny REAL, maxy REAL
+		)`,
+		fmt.Sprintf(`CREATE TABLE scenario_current (catchment_id_int INTEGER, "%s" REAL)`, Attribute),
+		fmt.Sprintf(`CREATE TABLE scenario_reference (catchment_id_int INTEGER, "%s" REAL)`, Attribute),
+		fmt.Sprintf(`CREATE TABLE domain_minima ("%s" REAL)`, Attribute),
+		fmt.Sprintf(`CREATE TABLE domain_maxima ("%s" REAL)`, Attribute),
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create synthetic schema: %v\n%s", err, s)
+		}
+	}
+
+	for i, c := range catchments {
+		half := c.SizeDeg / 2
+		minx, maxx := c.Long-half, c.Long+half
+		miny, maxy := c.Lat-half, c.Lat+half
+		geojson := fmt.Sprintf(
+			`{"type":"Polygon","coordinates":[[[%f,%f],[%f,%f],[%f,%f],[%f,%f],[%f,%f]]]}`,
+			minx, miny, maxx, miny, maxx, maxy, minx, maxy, minx, miny)
+
+		fid := int64(i + 1)
+		if _, err := db.Exec(
+			`INSERT INTO catchments_lev12 (fid, HYBAS_ID, HYBAS_ID_int, lat, long, SUB_AREA, geojson)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			fid, fmt.Sprintf("%d", c.ID), c.ID, c.Lat, c.Long, c.SizeDeg*c.SizeDeg, geojson,
+		); err != nil {
+			t.Fatalf("insert catchment: %v", err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO rtree_catchments_lev12_geom (id, minx, maxx, miny, maxy) VALUES (?, ?, ?, ?, ?)`,
+			fid, minx, maxx, miny, maxy,
+		); err != nil {
+			t.Fatalf("insert rtree row: %v", err)
+		}
+		for table, value := range map[string]*float64{
+			"scenario_current":   c.Current,
+			"scenario_reference": c.Reference,
+		} {
+			if _, err := db.Exec(
+				fmt.Sprintf(`INSERT INTO %s (catchment_id_int, "%s") VALUES (?, ?)`, table, Attribute),
+				c.ID, value,
+			); err != nil {
+				t.Fatalf("insert %s row: %v", table, err)
+			}
+		}
+	}
+
+	if _, err := db.Exec(
+		fmt.Sprintf(`INSERT INTO domain_minima ("%s") VALUES (?)`, Attribute), domainMin,
+	); err != nil {
+		t.Fatalf("insert domain minimum: %v", err)
+	}
+	if _, err := db.Exec(
+		fmt.Sprintf(`INSERT INTO domain_maxima ("%s") VALUES (?)`, Attribute), domainMax,
+	); err != nil {
+		t.Fatalf("insert domain maximum: %v", err)
+	}
+
+	return dir
+}
+
+// Float returns a pointer to v, for populating Catchment's nullable values.
+func Float(v float64) *float64 { return &v }


### PR DESCRIPTION
## The finding that reframes this issue

**The geometry is already in the tile pipeline; the choropleth simply wasn't using
it.** `resources/mbtiles/gpkg_to_mbtiles.sh` already tiles `catchments_lev12` at
zoom **8–15** into `africa.mbtiles` — line 107, `["catchments_lev12"]="8 15"`.

So this stops being "build a tile pipeline" and becomes "stop refetching what is
already tiled, and join the values onto it". That is a far smaller change than the
issue's size:L implies.

## Options considered

| | why not |
|---|---|
| **(a) Bake attributes into the tiles** | ~150k catchments × ~50 numeric columns × 8 zoom levels is order-of **800 MB** added to a distributed datapack — and it cannot represent per-site edited `future` targets at all |
| **(b) Generate MVT on demand in Go** | needs a new encoder dependency, and the tile cache key would have to include the attribute — so **attribute switching would refetch geometry**, violating a stated success criterion |
| **(c) Hybrid — recommended and built** | geometry from the existing tiles, values from a small geometry-free endpoint, joined with `setFeatureState` |

## What was built

Geometry comes from a `type: 'vector'` source with
`promoteId: {catchments_lev12: 'HYBAS_ID'}`. Values come from a new
`GET /api/catchment-values` and are joined with `setFeatureState`, so **switching
attribute re-fetches values only — never geometry**. Below zoom 8 the existing
GeoJSON path is retained, because the server serves grid-aggregated cells there
that have no tiled equivalent.

**The colour expression is preserved exactly.** The builders moved to
`lib/choroplethPaint.ts` verbatim, taking a value *accessor* instead of an
attribute name; a test substitutes the accessor back and deep-equals the two
expressions for every scale type.

`QueryCatchmentValues` now wraps the new `QueryCatchmentValueArrays`, so the stats
path and the render path cannot drift apart.

Two non-obvious choices, both commented and tested: feature state is cleared by
nulling tracked ids rather than `removeFeatureState`, because MapLibre's
`updateState` goes quadratic once a source layer is marked for wholesale deletion;
and `resolveCatchmentTileset` returns null unless the TileJSON declares the layer
*with* its zoom range, so a datapack whose tiles predate catchment tiling falls
back to the old path rather than rendering a blank map.

## Measured

One 5,000-catchment viewport, geometry modelled at the ~1.5 KB/catchment the
store's own comment records:

| | before | after | |
|---|---:|---:|---:|
| raw bytes | 7,810,860 | 146,017 | **53.5×** |
| gzip-5 | 2,448,201 | 55,494 | 44.1× |
| main-thread `JSON.parse` | 79.2 ms | 0.53 ms | **150×** |

The model's gzip ratio (3.19×) matches the 3.21× `compress.go` records for the
real payload, which is some evidence the model isn't wildly off.

## Tests

`go test -race ./...` passes (7 packages). `tsc --noEmit`, `eslint` and vitest
clean — **113 tests, was 87**. All new tests verified failing against the unfixed
code.

A new `internal/gpkgtest` builds a real minimal geopackage on disk, because
**`internal/geodata` had no test file at all** — 0 on `main`, which is the
substance of #45.

## Not verified — validation needs the network tab, not just the map

No datapack and no browser in the build environment, so:

- **The issue's two headline metrics are unmeasured**: viewport-change-to-painted,
  and main-thread blocking time. Not estimated, not invented.
- **Unconfirmed against real data**: that `africa.mbtiles` metadata declares
  `catchments_lev12` with per-layer `minzoom`/`maxzoom`, and that `HYBAS_ID` is
  integer-valued rather than `"…​.0"`. Both are inferred from the build script and
  the style's `Catchments Outlines` layer.

If either is wrong the code **fails safe** — it stays on the GeoJSON path, or
paints all-minimum — rather than crashing. Which is exactly why validating this
means checking the network tab to confirm tiles are actually being used, not just
looking at a map that renders. Visual parity at several zooms still needs eyes on
real data.

**Known behavioural difference:** the site catchment-id *inference* fallback is
skipped on the tile path, since it worked by intersecting fetched geometry. The
authoritative ids still come from the server's AOI fractions.

## Sequencing note

The issue says the compression and columnar-response tickets should land first.
Compression is in (#100). The columnar one is #75, which is being worked in
parallel and touches the same two Go files — expect a merge conflict in
`gpkg_store.go` and `handler.go`, and land #75 first.

Fixes #77
