### PR TITLE
fix(geodata): cancel database work when the client disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A client that gave up did not stop the work it had started.** No database call
+  took a `context.Context`, so when a user closed a tab, panned the map again, or
+  a proxy timed out, the query ran to completion against SQLite — holding a
+  connection and CPU for an answer nobody would read. The most expensive query in
+  the application takes over four seconds and the map issues one on every pan, so
+  abandoned work accumulated exactly when the server was already busy.
+
+  Every SQLite-touching method now takes a context and uses the `Context` query
+  variants, and a cancelled request is logged as cancelled rather than as a
+  failure. Cancellation is detected from both shapes it arrives in: `database/sql`
+  reports `context.Canceled`, while go-sqlite3 reports its own `SQLITE_INTERRUPT`
+  when a statement is stopped mid-flight. A blown deadline is deliberately *not*
+  treated as a cancellation — that is a real failure.
+
+  Some work is deliberately not cancellable, because it is started on behalf of
+  one request and serves all of them: the grid geometry cache build is guarded by
+  a `sync.Once`, so a cancellation would tear it down and nothing would restart
+  it, leaving the aggregated map path broken for the life of the process. What is
+  now cancellable there is the *wait*, not the build.
+
+  Ten result loops gained the `rows.Err()` check they lacked. This was required
+  rather than tidy: a cancelled scan ends iteration early, so without it a partial
+  choropleth or a partial statistics set would have been returned as complete —
+  threading a context would have created a new silent-failure path while closing
+  another.
+
 - **The container images built against a different WebKit than everything else ships.**
   `deployments/Dockerfile`, `deployments/Dockerfile.cross` and
   `deployments/Dockerfile.builder` all installed `libwebkit2gtk-4.0-dev`, while the

--- a/NOTES-dbctx.md
+++ b/NOTES-dbctx.md
@@ -1,0 +1,202 @@
+# Issue #38 — `context.Context` on database calls
+
+Branch `fix/db-context-cancellation`. Go backend only: `internal/geodata/`,
+`internal/api/`. Nothing in `internal/server/` needed changing — it only
+constructs the store.
+
+## What changed
+
+**`internal/geodata/gpkg_store.go`** — every method that touches SQLite now
+takes a `context.Context` as its first parameter and uses `QueryContext` /
+`QueryRowContext`. (There are no writes: the geopackage is opened `mode=ro`,
+so no `ExecContext` was needed.) That is 15 `Query` and 6 `QueryRow` call
+sites across 20 exported methods and 5 unexported helpers.
+
+**`internal/geodata/cancel.go`** (new) — `IsCancellation(ctx, err)`. It takes
+the context as well as the error on purpose: `database/sql` reports
+`context.Canceled` when the context is already done, but when SQLite is
+interrupted *mid-statement* go-sqlite3 reports its own `SQLITE_INTERRUPT`
+("interrupted"), which has no relation to `context.Canceled`. Consulting the
+context alongside the error covers both without importing the driver's error
+type into every caller. `context.DeadlineExceeded` is deliberately **not**
+treated as a cancellation — a query that blew a timeout is a real failure
+worth reporting.
+
+**`internal/api/cancel.go`** (new) — `respondStoreError` /
+`respondCancelled` / `clientGone`, plus `StatusClientClosedRequest` (499). A
+cancelled request logs at `[cancelled]`, never as an error, and writes no body.
+The 499 is not for the client (it has gone); it is so the outcome lands
+somewhere other than the 200 or 500 bucket in logs, tests and any future
+metrics middleware.
+
+**`internal/api/handler.go`** — `r.Context()` threaded to every store call;
+error paths routed through `respondStoreError`.
+
+**Row-iteration correctness.** Threading a context without checking
+`rows.Err()` would have *created* a new swallowed error: a cancelled scan ends
+the `rows.Next()` loop early, so the caller would receive a partial result
+reported as a complete one — a choropleth with holes in it, or a statistics
+panel silently summarising a subset. I added `rows.Err()` checks to the ten
+loops that lacked them (`loadColumns`, `resolveScenarioIDColumn`,
+`GetScenarioData`, `GetComparisonData`, `queryCatchmentsDetailed`,
+`QueryCatchmentValueArrays`, `fetchCatchmentGridRows`, `DissolveCatchments`,
+`GetCatchmentsByBBox`, `GetCatchmentIDsByBBox`). This does also surface
+genuine mid-scan database errors that were previously truncating results
+silently — an improvement, but flagging it because it is a behaviour change
+beyond the strict scope of the issue.
+
+## What I deliberately did *not* cancel
+
+1. **The grid geometry cache build** (`ensureGridGeometryCache` →
+   `buildGridGeometryCache`). ~150k polygon unions per tier, built once and
+   then serving every aggregated choropleth for the life of the process. It
+   runs on `context.Background()`. It is guarded by a `sync.Once`, so if one
+   request's cancellation tore the build down nothing would ever restart it and
+   the aggregated path would stay broken for the rest of the process's uptime —
+   one impatient user, permanent degradation for everyone.
+
+   What *is* cancellable is the **wait**: `queryCatchmentsGridAggregated` now
+   selects on `ctx.Done()` alongside the per-tier ready channel, so a request
+   that has been abandoned stops holding a goroutine while the build carries on
+   for everybody else. Covered by
+   `TestGivingUpOnTheGridCacheDoesNotCancelTheBuild`.
+
+2. **`handlePrecalculateFull`** — `context.WithoutCancel(r.Context())`.
+   Full-domain averages for every column across the whole dataset, cached for
+   the process lifetime and served to every pane of every later quad-view load.
+   One user reloading impatiently must not throw that away and leave the next
+   arrival to start from nothing. Covered by
+   `TestPrecalculateFullSurvivesTheRequestThatTriggeredIt`.
+
+3. **`populateSiteCatchmentDetailsDeferred`** and **`doSiteExtraction`** —
+   `context.Background()`. Both run in goroutines started by handlers that
+   respond (201 / 202) and return immediately, so the request context is
+   already cancelled by the time the goroutine gets going. Threading it there
+   would have aborted the work on *every* request, not only on a disconnect.
+   The client polls `GET /sites/{id}/indicators` for the result, so the work
+   has to outlive the request that asked for it.
+
+4. **`NewGpkgStore`** (`PingContext`, `loadColumns`) — `context.Background()`.
+   Startup work, run once at boot and again on a background goroutine when a
+   datapack is installed. There is no request whose cancellation should abandon
+   it, so this is `Background()` rather than `TODO()`. `NewGpkgStore`'s
+   signature is unchanged; I judged adding a context parameter there to be
+   churn across `internal/server/state.go` and three test files for no
+   behavioural gain, but it would be a reasonable follow-up if store opening
+   ever needs to abort on shutdown.
+
+There is no `context.TODO()` anywhere in the change — every call site reaches
+either a real request context or a deliberately-documented background one.
+
+## Distinguishing cancellation from failure at each layer
+
+- **geodata**: cancellations are returned, never logged. The two places that
+  logged unconditionally (`GetCatchmentIndicatorsByIDs`'s scenario query,
+  `ComputeWhiskerBounds`'s per-table query) now suppress the log for a
+  cancellation.
+- **api**: `respondStoreError` maps a cancellation to 499 with no body and an
+  info-level log.
+- **The two store methods with no error return** (`GetCatchmentAttributes`,
+  `ComputeWhiskerBounds`) come back empty for a cancellation exactly as they do
+  for a failure, so the handlers consult `clientGone(r)` instead. Without that,
+  `/catchment/{id}` would answer 404 "catchment not found" to a user who simply
+  clicked elsewhere, and `/sites/{id}/whiskers` would persist empty whisker
+  bounds into the site — poisoning the cache for every later reader.
+
+## Tests
+
+`internal/geodata/cancellation_test.go` (internal test — needs the pool):
+
+- `TestCancelledRequestStopsQueuedQuery` — the one that proves work actually
+  stops. It holds every connection in the pool (the state every extra request
+  lands in once the server is busy, which is exactly when abandoned work is
+  most expensive), starts a query, cancels it, and requires it to return with a
+  cancellation within 10s. Verified to fail before the change: with `db.Query`
+  the call waits on the pool forever and the test times out.
+- `TestEveryQueryHonoursCancellation` — table over 12 entry points, each run
+  twice: live context must succeed (so the cancelled case cannot pass for the
+  wrong reason), pre-cancelled context must report a cancellation. Verified to
+  fail before the change.
+- `TestGivingUpOnTheGridCacheDoesNotCancelTheBuild`.
+- `TestIsCancellation` — including the driver-interrupt and
+  deadline-exceeded cases.
+
+`internal/api/cancellation_test.go`:
+
+- `TestAbandonedRequestsAreNotReportedAsSuccessOrFailure` — five endpoints,
+  each asserted to return 499 with no body when the client has gone, and 200
+  when it has not.
+- `TestAbandonedIdentifyIsNotReportedAsNotFound`.
+- `TestPrecalculateFullSurvivesTheRequestThatTriggeredIt`.
+
+`go test ./...`, `go vet ./...` and `gofmt -l` are clean, before and after.
+`go test -race ./internal/geodata/ ./internal/api/` also passes. No module
+dependency added, so `go.mod`, `go.sum` and the flake's `vendorHash` are
+untouched.
+
+### On the test I did not write
+
+The brief suggested an `httptest` server where the client cancels mid-query. I
+could not make that deterministic: the synthetic datapack
+(`internal/gpkgtest`) is two catchments, so every query finishes in
+microseconds and "did the server stop early?" becomes a race. Building a
+datapack large enough to be slow would add seconds to the suite for a weaker
+assertion. The pool-saturation test above is the same scenario made
+deterministic — a request queued behind busy connections is precisely the case
+the issue is about — and the api-level tests prove the request context reaches
+the store. An end-to-end version would still be worth having if the project
+ever gains a fixture with a realistically-sized geopackage.
+
+## Found but out of scope
+
+- **`internal/tiles/mbtiles.go` has the same problem.** `GetTile` and
+  `GetMetadata` use `db.QueryRow` / `db.Query` with no context, and the tile
+  store is hit far more often than the geopackage — several tile requests per
+  pan, per pane. It was outside the territory I was given, so I left it, but it
+  is the obvious companion fix and the change is mechanical now that the
+  pattern exists.
+- **`handlePrecalculateFull` has no singleflight.** Concurrent first-requests
+  (quad-view: four panes on a cold start) each run the full computation and
+  each write the cache. Correct, but four times the work. Making it detached
+  from cancellation slightly increases the exposure, since none of the four now
+  bails out early. A `sync.Once` or `golang.org/x/sync/singleflight` would fix
+  it; the former needs no new dependency.
+- **`buildGridGeometryCache` does not check `rows.Err()`** on its scan loop, so
+  a genuine mid-scan database error would publish a *partial* geometry cache
+  and mark every tier ready. It runs on a background context so cancellation
+  cannot trigger it, and it is an instance of the swallowed-error pattern I was
+  told to leave alone — but it is the most consequential one I saw, because the
+  bad cache then persists for the life of the process.
+- **`ComputeWhiskerBounds` and `GetCatchmentAttributes` cannot report errors**
+  at all. That is the tracked swallowed-error issue; I worked around it in the
+  handlers rather than changing the signatures.
+- **`/sites/{id}/whiskers` writes to the site store on a GET** to cache the
+  computed bounds. Not related to this issue, but a GET with a side effect is
+  worth knowing about.
+
+## What I would not vouch for
+
+- **The exact error shape a mid-flight SQLite interrupt produces.**
+  `IsCancellation` handles both the `context.Canceled` and the driver-specific
+  "interrupted" shapes, and `TestIsCancellation` covers both, but I could not
+  exercise a real mid-statement interrupt against a multi-second query — the
+  synthetic datapack is too small. My reading of `database/sql` is that
+  `Rows.Err()` prefers the stored context error over the driver's, which makes
+  the context check belt-and-braces rather than load-bearing. If a real
+  4-second query on the production datapack turns out to surface a bare
+  `interrupted` error to a client somewhere, that is where to look.
+- **Whether 499 is the right response code for this codebase.** Nothing reads
+  it today. If there is an existing access-log or metrics convention I have not
+  seen, it should follow that instead.
+- **Behaviour under a real datapack.** Everything here was exercised against
+  `internal/gpkgtest`'s two-catchment synthetic pack; I had no multi-gigabyte
+  `datapack.gpkg` to run against. The paths that only appear at scale —
+  the aggregated grid render, whisker bounds over the
+  `scenario_*_lower/upper` tables — are covered by signature threading and
+  compilation, not by execution. `GetScenarioData`, `GetComparisonData`,
+  `GetScenarioBoundAverages` and `ComputeWhiskerBounds` are absent from the
+  cancellation table test for the same reason: the synthetic schema has no
+  `catchment_id` column and no bound tables.
+- **`internal/api/site_shapefile_test.go`** is an integration test gated on a
+  real data directory. It compiles against the new signatures but I could not
+  run it.

--- a/internal/api/cancel.go
+++ b/internal/api/cancel.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/kartoza/decision-theatre/internal/geodata"
+)
+
+// StatusClientClosedRequest is nginx's non-standard 499, used here for a
+// request whose client disconnected before the answer was ready.
+//
+// Nothing reads the status: the connection is already gone, and net/http
+// discards the write. It exists so that the outcome is visible where outcomes
+// are recorded - access logs, tests, and any future metrics middleware - as
+// something other than the 200 or 500 it would otherwise be indistinguishable
+// from. A cancelled request must never land in the error bucket, because the
+// error bucket is what someone pages on.
+const StatusClientClosedRequest = 499
+
+// respondStoreError writes the response for an error returned by a data-store
+// call, separating "the client went away" from "the query failed".
+//
+// A cancellation is reported at info level and never as an error, and carries
+// no message body: there is no one left to read it, and a body would only
+// serve to make a routine disconnect look like a server fault in a log
+// aggregator.
+func respondStoreError(w http.ResponseWriter, r *http.Request, status int, err error) {
+	if geodata.IsCancellation(r.Context(), err) {
+		respondCancelled(w, r)
+		return
+	}
+	respondError(w, status, err.Error())
+}
+
+// respondCancelled records a request abandoned by its client.
+func respondCancelled(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[cancelled] %s %s: client disconnected before the response was ready", r.Method, r.URL.Path)
+	w.WriteHeader(StatusClientClosedRequest)
+}
+
+// clientGone reports whether this request's client has already disconnected.
+//
+// It exists for the two store calls whose signatures return no error at all
+// (GetCatchmentAttributes and ComputeWhiskerBounds): those return an empty
+// result for a cancellation exactly as they do for a genuine failure, so the
+// handler has to consult the context to know which it is. Giving them error
+// returns is the separately-tracked swallowed-error issue; this keeps the
+// cancellation path honest in the meantime without touching it.
+func clientGone(r *http.Request) bool {
+	return errors.Is(r.Context().Err(), context.Canceled)
+}

--- a/internal/api/cancellation_test.go
+++ b/internal/api/cancellation_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+	"github.com/kartoza/decision-theatre/internal/geodata"
+	"github.com/kartoza/decision-theatre/internal/gpkgtest"
+)
+
+// newCancelTestHandler wires a Handler over a synthetic datapack and returns
+// both the router and the handler, so a test can look at cached state the
+// router alone would not expose.
+func newCancelTestHandler(t *testing.T) (*mux.Router, *Handler) {
+	t.Helper()
+
+	dir := gpkgtest.Build(t, t.TempDir(), []gpkgtest.Catchment{
+		{ID: 1000000001, Lat: 0, Long: 0, SizeDeg: 0.5, Current: gpkgtest.Float(10), Reference: gpkgtest.Float(1)},
+		{ID: 1000000002, Lat: 0, Long: 1, SizeDeg: 0.5, Current: gpkgtest.Float(20), Reference: gpkgtest.Float(2)},
+	}, 0, 100)
+
+	store, err := geodata.NewGpkgStore(dir)
+	if err != nil {
+		t.Fatalf("NewGpkgStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+	return r, handler
+}
+
+// cancelledRequest builds a request whose client has already gone away, which
+// is what net/http hands a handler when the connection drops mid-request.
+func cancelledRequest(target string) *http.Request {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return httptest.NewRequest("GET", target, nil).WithContext(ctx)
+}
+
+// A disconnected client must not be served a 200 carrying whatever the query
+// happened to have read, nor a 500 that would show up as a server fault. The
+// data endpoints are the ones that matter: the map issues one of these on every
+// pan and zoom, so the abandoned ones vastly outnumber the completed ones.
+func TestAbandonedRequestsAreNotReportedAsSuccessOrFailure(t *testing.T) {
+	targets := []struct {
+		name   string
+		target string
+	}{
+		{"catchment values", "/catchment-values?scenario=current&attribute=" + gpkgtest.Attribute + "&minx=-5&miny=-5&maxx=5&maxy=5"},
+		{"choropleth", "/choropleth?scenario=current&attribute=" + gpkgtest.Attribute + "&minx=-5&miny=-5&maxx=5&maxy=5"},
+		{"catchments bounds", "/catchments/bounds"},
+		{"catchment geometry", "/catchments/geometry/1000000001"},
+		{"aggregate", "/aggregate?scenario=current&attributes=" + gpkgtest.Attribute},
+	}
+
+	for _, tc := range targets {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := newCancelTestHandler(t)
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, cancelledRequest(tc.target))
+
+			if w.Code != StatusClientClosedRequest {
+				t.Fatalf("status %d, want %d (body %s)", w.Code, StatusClientClosedRequest, w.Body.String())
+			}
+			if w.Body.Len() != 0 {
+				t.Errorf("a response body was written for a client that is no longer there: %s", w.Body.String())
+			}
+
+			// The same request with a live client is still served normally -
+			// otherwise the assertion above would pass for a broken endpoint.
+			w = httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest("GET", tc.target, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("with a live client: status %d, want 200 (body %s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// GetCatchmentAttributes has no error return, so an abandoned request comes
+// back from it indistinguishable from a catchment that does not exist. Telling
+// the client its catchment is missing would be a lie, and would show up as a
+// 404 rate spike whenever users click around quickly.
+func TestAbandonedIdentifyIsNotReportedAsNotFound(t *testing.T) {
+	r, _ := newCancelTestHandler(t)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, cancelledRequest("/catchment/1000000001"))
+
+	if w.Code == http.StatusNotFound {
+		t.Fatal("an abandoned identify was reported as a missing catchment")
+	}
+	if w.Code != StatusClientClosedRequest {
+		t.Fatalf("status %d, want %d (body %s)", w.Code, StatusClientClosedRequest, w.Body.String())
+	}
+}
+
+// The full-domain precalculation is the opposite judgement: it is computed once
+// and cached for the life of the process, and every pane of every later
+// quad-view load is served from that cache. It must therefore survive the
+// request that happened to trigger it - otherwise one user reloading impatiently
+// throws the work away and the next arrival starts from nothing.
+func TestPrecalculateFullSurvivesTheRequestThatTriggeredIt(t *testing.T) {
+	r, handler := newCancelTestHandler(t)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, cancelledRequest("/precalculate/full"))
+
+	handler.fullDomainMu.Lock()
+	cached := handler.fullDomainCache
+	handler.fullDomainMu.Unlock()
+
+	if cached == nil {
+		t.Fatal("the shared full-domain cache was discarded because one client disconnected")
+	}
+	if len(cached.Current) == 0 || len(cached.Reference) == 0 {
+		t.Fatalf("cached averages are empty: %+v", cached)
+	}
+
+	// And the next request is served from it.
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/precalculate/full", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	var got FullDomainData
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	if got.Current[gpkgtest.Attribute] != cached.Current[gpkgtest.Attribute] {
+		t.Errorf("served %v, cached %v", got.Current, cached.Current)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -431,9 +432,9 @@ func (h *Handler) handleScenarioData(w http.ResponseWriter, r *http.Request) {
 	scenario := vars["scenario"]
 	attribute := vars["attribute"]
 
-	data, err := h.gpkgStore.GetScenarioData(scenario, attribute)
+	data, err := h.gpkgStore.GetScenarioData(r.Context(), scenario, attribute)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondStoreError(w, r, http.StatusNotFound, err)
 		return
 	}
 
@@ -524,13 +525,13 @@ func (h *Handler) handleAggregateData(w http.ResponseWriter, r *http.Request) {
 	var agg map[string]float64
 	var err error
 	if bound == "" {
-		agg, err = h.gpkgStore.GetScenarioAverages(scenario, attributes, bbox)
+		agg, err = h.gpkgStore.GetScenarioAverages(r.Context(), scenario, attributes, bbox)
 	} else {
-		agg, err = h.gpkgStore.GetScenarioBoundAverages(scenario, bound, attributes, bbox)
+		agg, err = h.gpkgStore.GetScenarioBoundAverages(r.Context(), scenario, bound, attributes, bbox)
 	}
 	log.Printf("[perf] handleAggregateData scenario=%s bound=%q attributes=%d hasBbox=%v duration_ms=%d", scenario, bound, len(attributes), bbox != nil, time.Since(aggStart).Milliseconds())
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err.Error())
+		respondStoreError(w, r, http.StatusBadRequest, err)
 		return
 	}
 
@@ -565,13 +566,31 @@ func (h *Handler) handlePrecalculateFull(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Deliberately detached from the request's cancellation. This computes the
+	// full-domain averages for every column across the whole dataset - seconds
+	// of work - and the result is cached for the life of the process and
+	// served to every pane of every subsequent quad-view load. It is shared
+	// work that one request merely happens to trigger, so one impatient user
+	// reloading must not discard it and leave the next arrival to start over.
+	//
+	// The request itself is still cancellable in the sense that matters: if
+	// the client has gone by the time this finishes, the response write is
+	// discarded by net/http. Only the computation is protected.
+	//
+	// context.WithoutCancel keeps the request context's values but drops both
+	// its cancellation and its deadline, so this computation has no time limit
+	// of its own. That is acceptable here only because it is bounded work over
+	// a fixed dataset that the process is going to have to do exactly once;
+	// anything unbounded would need its own deadline instead.
+	computeCtx := context.WithoutCancel(r.Context())
+
 	start := time.Now()
-	refAgg, err := h.gpkgStore.GetScenarioAverages("reference", columns, nil)
+	refAgg, err := h.gpkgStore.GetScenarioAverages(computeCtx, "reference", columns, nil)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to compute reference averages: %v", err))
 		return
 	}
-	curAgg, err := h.gpkgStore.GetScenarioAverages("current", columns, nil)
+	curAgg, err := h.gpkgStore.GetScenarioAverages(computeCtx, "current", columns, nil)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to compute current averages: %v", err))
 		return
@@ -608,9 +627,9 @@ func (h *Handler) handleComparisonData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := h.gpkgStore.GetComparisonData(left, right, attribute)
+	data, err := h.gpkgStore.GetComparisonData(r.Context(), left, right, attribute)
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondStoreError(w, r, http.StatusNotFound, err)
 		return
 	}
 
@@ -626,8 +645,15 @@ func (h *Handler) handleCatchmentIdentify(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	data := h.gpkgStore.GetCatchmentAttributes(catchmentID)
+	data := h.gpkgStore.GetCatchmentAttributes(r.Context(), catchmentID)
 	if len(data) == 0 {
+		// An abandoned request also comes back empty here, and telling the
+		// client its catchment does not exist would be a lie - and would show
+		// up as a 404 rate spike whenever users click around quickly.
+		if clientGone(r) {
+			respondCancelled(w, r)
+			return
+		}
 		respondError(w, http.StatusNotFound, "catchment not found")
 		return
 	}
@@ -700,9 +726,9 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 	queryStart := time.Now()
 	var fc *geodata.FeatureCollection
 	if q.Get("valuesOnly") == "1" {
-		fc, err = h.gpkgStore.QueryCatchmentValues(queryScenario, attribute, minx, miny, maxx, maxy)
+		fc, err = h.gpkgStore.QueryCatchmentValues(r.Context(), queryScenario, attribute, minx, miny, maxx, maxy)
 	} else {
-		fc, err = h.gpkgStore.QueryCatchments(queryScenario, attribute, minx, miny, maxx, maxy, zoom)
+		fc, err = h.gpkgStore.QueryCatchments(r.Context(), queryScenario, attribute, minx, miny, maxx, maxy, zoom)
 	}
 	log.Printf("[perf] handleChoropleth step=queryCatchments scenario=%s attribute=%s features=%d duration_ms=%d", queryScenario, attribute, func() int {
 		if fc != nil {
@@ -711,7 +737,7 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 		return 0
 	}(), time.Since(queryStart).Milliseconds())
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -727,7 +753,7 @@ func (h *Handler) handleChoropleth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get domain range for consistent color scaling across scenarios
-	domainMin, domainMax := h.domainRangeFor(scenario, attribute)
+	domainMin, domainMax := h.domainRangeFor(r.Context(), scenario, attribute)
 
 	// Build response with domain range
 	response := ChoroplethResponse{
@@ -797,13 +823,17 @@ func (h *Handler) siteIdealOverrides(scenario, siteID, attribute string) map[int
 //
 // Both the GeoJSON and the vector-tile choropleth paths call this: the colours
 // must not shift depending on which transport delivered the geometry.
-func (h *Handler) domainRangeFor(scenario, attribute string) (min, max float64) {
+func (h *Handler) domainRangeFor(ctx context.Context, scenario, attribute string) (min, max float64) {
 	start := time.Now()
-	domainRange, err := h.gpkgStore.GetDomainRange(attribute)
+	domainRange, err := h.gpkgStore.GetDomainRange(ctx, attribute)
 	log.Printf("[perf] domainRangeFor attribute=%s duration_ms=%d", attribute, time.Since(start).Milliseconds())
 	if err != nil {
-		// If domain tables don't exist, fall back to no domain range.
-		log.Printf("Warning: could not get domain range for %s: %v", attribute, err)
+		// If domain tables don't exist, fall back to no domain range. A
+		// cancelled request lands here too, and must not be logged as a
+		// datapack problem; its caller abandons the response anyway.
+		if !geodata.IsCancellation(ctx, err) {
+			log.Printf("Warning: could not get domain range for %s: %v", attribute, err)
+		}
 		domainRange = &geodata.DomainRange{Min: 0, Max: 0}
 	}
 
@@ -878,9 +908,9 @@ func (h *Handler) handleCatchmentValues(w http.ResponseWriter, r *http.Request) 
 		queryScenario = "reference"
 	}
 
-	values, err := h.gpkgStore.QueryCatchmentValueArrays(queryScenario, attribute, bbox[0], bbox[1], bbox[2], bbox[3])
+	values, err := h.gpkgStore.QueryCatchmentValueArrays(r.Context(), queryScenario, attribute, bbox[0], bbox[1], bbox[2], bbox[3])
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -893,7 +923,7 @@ func (h *Handler) handleCatchmentValues(w http.ResponseWriter, r *http.Request) 
 	}
 	count = len(values.IDs)
 
-	domainMin, domainMax := h.domainRangeFor(scenario, attribute)
+	domainMin, domainMax := h.domainRangeFor(r.Context(), scenario, attribute)
 
 	// Same cache policy as /choropleth: the values for a given
 	// scenario+attribute+bbox are static for the life of the datapack, and the
@@ -974,7 +1004,7 @@ func (h *Handler) waitForPendingCatchments(site *sites.Site, timeout time.Durati
 	return site
 }
 
-func (h *Handler) populateSiteCatchmentDetails(site *sites.Site) error {
+func (h *Handler) populateSiteCatchmentDetails(ctx context.Context, site *sites.Site) error {
 	start := time.Now()
 	defer func() {
 		catchmentCount := 0
@@ -998,7 +1028,7 @@ func (h *Handler) populateSiteCatchmentDetails(site *sites.Site) error {
 	}
 
 	indicatorsStart := time.Now()
-	catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(site.CatchmentIDs)
+	catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(ctx, site.CatchmentIDs)
 	if err != nil {
 		return err
 	}
@@ -1008,7 +1038,7 @@ func (h *Handler) populateSiteCatchmentDetails(site *sites.Site) error {
 	// Skip the expensive geometry fetch + polyclip intersection in that case.
 	if len(site.Geometry) > 0 && site.CreationMethod != "catchments" {
 		aoiStart := time.Now()
-		if err := h.gpkgStore.ApplyAOIFractions(catchmentData, site.Geometry); err != nil {
+		if err := h.gpkgStore.ApplyAOIFractions(ctx, catchmentData, site.Geometry); err != nil {
 			return err
 		}
 		log.Printf("[perf] populateSiteCatchmentDetails step=applyAOIFractions site_id=%s catchments=%d duration_ms=%d", site.ID, len(site.CatchmentIDs), time.Since(aoiStart).Milliseconds())
@@ -1052,7 +1082,14 @@ func (h *Handler) populateSiteCatchmentDetailsDeferred(siteID string, catchmentI
 		CatchmentIDs: append([]string(nil), catchmentIDs...),
 		Geometry:     append(json.RawMessage(nil), geometry...),
 	}
-	if err := h.populateSiteCatchmentDetails(transientSite); err != nil {
+	// Deliberately context.Background(). The handler that started this
+	// goroutine has already responded and returned, so its request context is
+	// cancelled the moment it does - threading it here would abort the
+	// enrichment every time rather than only when a client disconnects. The
+	// work belongs to the site, not to the request that happened to create
+	// it, and other requests (GET /sites/{id}/catchments, indicator
+	// extraction) wait on its completion channel.
+	if err := h.populateSiteCatchmentDetails(context.Background(), transientSite); err != nil {
 		log.Printf("Warning: deferred site catchment enrichment failed site_id=%s err=%v", siteID, err)
 		return
 	}
@@ -1143,8 +1180,8 @@ func (h *Handler) handleUpdateSite(w http.ResponseWriter, r *http.Request) {
 			updates.Geometry = existing.Geometry
 		}
 	}
-	if err := h.populateSiteCatchmentDetails(&updates); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to build catchment details: "+err.Error())
+	if err := h.populateSiteCatchmentDetails(r.Context(), &updates); err != nil {
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1220,9 +1257,9 @@ func (h *Handler) handleDissolveCatchments(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Get dissolved geometry from gpkg store
-	geometry, area, err := h.gpkgStore.DissolveCatchments(req.CatchmentIDs)
+	geometry, area, err := h.gpkgStore.DissolveCatchments(r.Context(), req.CatchmentIDs)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1327,9 +1364,9 @@ func (h *Handler) handleCatchmentGeometry(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	features, err := h.gpkgStore.GetCatchmentsByIDs([]string{catchmentID})
+	features, err := h.gpkgStore.GetCatchmentsByIDs(r.Context(), []string{catchmentID})
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1348,9 +1385,9 @@ func (h *Handler) handleCatchmentsBounds(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	bounds, err := h.gpkgStore.GetCatchmentsBounds()
+	bounds, err := h.gpkgStore.GetCatchmentsBounds(r.Context())
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1396,9 +1433,9 @@ func (h *Handler) handleCatchmentsInBBox(w http.ResponseWriter, r *http.Request)
 	}
 
 	if !includeGeometry {
-		ids, err := h.gpkgStore.GetCatchmentIDsByBBox(req.MinX, req.MinY, req.MaxX, req.MaxY, limit)
+		ids, err := h.gpkgStore.GetCatchmentIDsByBBox(r.Context(), req.MinX, req.MinY, req.MaxX, req.MaxY, limit)
 		if err != nil {
-			respondError(w, http.StatusInternalServerError, err.Error())
+			respondStoreError(w, r, http.StatusInternalServerError, err)
 			return
 		}
 
@@ -1413,9 +1450,9 @@ func (h *Handler) handleCatchmentsInBBox(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	features, err := h.gpkgStore.GetCatchmentsByBBox(req.MinX, req.MinY, req.MaxX, req.MaxY, limit)
+	features, err := h.gpkgStore.GetCatchmentsByBBox(r.Context(), req.MinX, req.MinY, req.MaxX, req.MaxY, limit)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1446,7 +1483,7 @@ type ExtractIndicatorsRequest struct {
 
 // doSiteExtraction performs the full indicator extraction for a site and saves to disk.
 // Called from a background goroutine for webview runtime.
-func (h *Handler) doSiteExtraction(id string) error {
+func (h *Handler) doSiteExtraction(ctx context.Context, id string) error {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] doSiteExtraction site_id=%s duration_ms=%d", id, time.Since(start).Milliseconds())
@@ -1473,12 +1510,12 @@ func (h *Handler) doSiteExtraction(id string) error {
 		catchmentData = siteCatchmentsToIndicators(site.Catchments)
 		log.Printf("[perf] doSiteExtraction step=useCachedCatchments site_id=%s catchments=%d", id, len(catchmentData))
 	} else {
-		catchmentData, err = h.gpkgStore.GetCatchmentIndicatorsByIDs(catchmentIDs)
+		catchmentData, err = h.gpkgStore.GetCatchmentIndicatorsByIDs(ctx, catchmentIDs)
 		if err != nil {
 			return fmt.Errorf("get catchment data: %w", err)
 		}
 		if len(site.Geometry) > 0 && site.CreationMethod != "catchments" {
-			if aoiErr := h.gpkgStore.ApplyAOIFractions(catchmentData, site.Geometry); aoiErr != nil {
+			if aoiErr := h.gpkgStore.ApplyAOIFractions(ctx, catchmentData, site.Geometry); aoiErr != nil {
 				log.Printf("Warning: ApplyAOIFractions for %s: %v", id, aoiErr)
 			}
 		}
@@ -1588,13 +1625,17 @@ func (h *Handler) handleExtractIndicators(w http.ResponseWriter, r *http.Request
 			respondError(w, http.StatusBadRequest, "site has no associated catchments")
 			return
 		}
-		catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(catchmentIDs)
+		catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(r.Context(), catchmentIDs)
 		if err != nil {
-			respondError(w, http.StatusInternalServerError, "failed to get catchment data: "+err.Error())
+			respondStoreError(w, r, http.StatusInternalServerError, err)
 			return
 		}
 		if len(site.Geometry) > 0 && site.CreationMethod != "catchments" {
-			if aoiErr := h.gpkgStore.ApplyAOIFractions(catchmentData, site.Geometry); aoiErr != nil {
+			if aoiErr := h.gpkgStore.ApplyAOIFractions(r.Context(), catchmentData, site.Geometry); aoiErr != nil {
+				if geodata.IsCancellation(r.Context(), aoiErr) {
+					respondCancelled(w, r)
+					return
+				}
 				log.Printf("Warning: ApplyAOIFractions for browser site: %v", aoiErr)
 			}
 		}
@@ -1633,7 +1674,12 @@ func (h *Handler) handleExtractIndicators(w http.ResponseWriter, r *http.Request
 	h.pendingExtractions.Store(id, struct{}{})
 	go func() {
 		defer h.pendingExtractions.Delete(id)
-		if err := h.doSiteExtraction(id); err != nil {
+		// Deliberately context.Background(): this handler responds 202 and
+		// returns immediately, so the request context is already cancelled by
+		// the time the extraction gets going. The client polls
+		// GET /sites/{id}/indicators for the result, which means the work has
+		// to outlive the request that asked for it.
+		if err := h.doSiteExtraction(context.Background(), id); err != nil {
 			log.Printf("Async extraction failed for site %s: %v", id, err)
 		}
 	}()
@@ -1909,7 +1955,7 @@ func (h *Handler) handleUpdateIndicators(w http.ResponseWriter, r *http.Request)
 		// Populate catchments before building lookup data so AOIFraction and
 		// catchment IDs are available for site-level NPP/SOC aggregation.
 		if len(site.Catchments) == 0 && h.gpkgStore != nil && len(site.CatchmentIDs) > 0 {
-			if popErr := h.populateSiteCatchmentDetails(site); popErr != nil {
+			if popErr := h.populateSiteCatchmentDetails(r.Context(), site); popErr != nil {
 				log.Printf("Warning: could not populate catchments for ideal propagation site_id=%s: %v", id, popErr)
 			}
 		}
@@ -2099,13 +2145,17 @@ func (h *Handler) handleSiteCatchments(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get indicator data for all catchments
-	catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(site.CatchmentIDs)
+	catchmentData, err := h.gpkgStore.GetCatchmentIndicatorsByIDs(r.Context(), site.CatchmentIDs)
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to get catchment data: "+err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 	if len(site.Geometry) > 0 && site.CreationMethod != "catchments" {
-		if err := h.gpkgStore.ApplyAOIFractions(catchmentData, site.Geometry); err != nil {
+		if err := h.gpkgStore.ApplyAOIFractions(r.Context(), catchmentData, site.Geometry); err != nil {
+			if geodata.IsCancellation(r.Context(), err) {
+				respondCancelled(w, r)
+				return
+			}
 			log.Printf("Warning: failed to compute AOI fractions for site %s: %v", id, err)
 		}
 	}
@@ -2213,19 +2263,31 @@ func (h *Handler) handleSiteWhiskers(w http.ResponseWriter, r *http.Request) {
 	if len(site.Catchments) > 0 && (len(site.CatchmentIDs) == 0 || len(site.Catchments) == len(site.CatchmentIDs)) {
 		catchmentData = siteCatchmentsToIndicators(site.Catchments)
 	} else {
-		catchmentData, err = h.gpkgStore.GetCatchmentIndicatorsByIDs(site.CatchmentIDs)
+		catchmentData, err = h.gpkgStore.GetCatchmentIndicatorsByIDs(r.Context(), site.CatchmentIDs)
 		if err != nil {
-			respondError(w, http.StatusInternalServerError, "failed to get catchment data: "+err.Error())
+			respondStoreError(w, r, http.StatusInternalServerError, err)
 			return
 		}
 		if len(site.Geometry) > 0 && site.CreationMethod != "catchments" {
-			if err := h.gpkgStore.ApplyAOIFractions(catchmentData, site.Geometry); err != nil {
+			if err := h.gpkgStore.ApplyAOIFractions(r.Context(), catchmentData, site.Geometry); err != nil {
+				if geodata.IsCancellation(r.Context(), err) {
+					respondCancelled(w, r)
+					return
+				}
 				log.Printf("Warning: failed to compute AOI fractions for site %s: %v", id, err)
 			}
 		}
 	}
 
-	bounds := h.gpkgStore.ComputeWhiskerBounds(catchmentData)
+	bounds := h.gpkgStore.ComputeWhiskerBounds(r.Context(), catchmentData)
+	// ComputeWhiskerBounds has no error return, so a cancelled request comes
+	// back as empty bounds. Persisting those would poison the site's cached
+	// whiskers for every later reader, and returning them would show a chart
+	// with no uncertainty range at all rather than no chart.
+	if clientGone(r) {
+		respondCancelled(w, r)
+		return
+	}
 
 	// Persist computed bounds into site indicators so subsequent requests are instant.
 	if h.siteStore != nil && r.Method != http.MethodPost {
@@ -2343,9 +2405,9 @@ func (h *Handler) handleBoundaryUnion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get catchment geometry
-	features, err := h.gpkgStore.GetCatchmentsByIDs([]string{catchmentID})
+	features, err := h.gpkgStore.GetCatchmentsByIDs(r.Context(), []string{catchmentID})
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 	if len(features) == 0 {
@@ -2389,8 +2451,8 @@ func (h *Handler) handleBoundaryUnion(w http.ResponseWriter, r *http.Request) {
 	site.Geometry = newGeometry
 	site.BoundingBox = bbox
 	site.Area = newArea
-	if err := h.populateSiteCatchmentDetails(site); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to build catchment details: "+err.Error())
+	if err := h.populateSiteCatchmentDetails(r.Context(), site); err != nil {
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -2435,9 +2497,9 @@ func (h *Handler) handleBoundaryDifference(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Get catchment geometry
-	features, err := h.gpkgStore.GetCatchmentsByIDs([]string{catchmentID})
+	features, err := h.gpkgStore.GetCatchmentsByIDs(r.Context(), []string{catchmentID})
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 	if len(features) == 0 {
@@ -2476,8 +2538,8 @@ func (h *Handler) handleBoundaryDifference(w http.ResponseWriter, r *http.Reques
 	site.Geometry = newGeometry
 	site.BoundingBox = bbox
 	site.Area = newArea
-	if err := h.populateSiteCatchmentDetails(site); err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to build catchment details: "+err.Error())
+	if err := h.populateSiteCatchmentDetails(r.Context(), site); err != nil {
+		respondStoreError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/internal/geodata/cancel.go
+++ b/internal/geodata/cancel.go
@@ -1,0 +1,39 @@
+package geodata
+
+import (
+	"context"
+	"errors"
+)
+
+// IsCancellation reports whether err is the caller abandoning the work rather
+// than something going wrong.
+//
+// Every query in this package is reachable from an HTTP handler, and the map
+// issues one on every pan and zoom. A user who pans again, closes the tab, or
+// hits Escape cancels a request that was already in flight; that is the normal
+// operation of the application, not a fault. Work started on its behalf must
+// stop, but nothing about it should be logged as an error or counted as one.
+//
+// Two error shapes have to be recognised, which is why the context is a
+// parameter rather than this being a bare errors.Is:
+//
+//   - database/sql returns context.Canceled directly when the context is
+//     already done, and Rows.Err reports it in preference to whatever the
+//     driver said when a scan is interrupted part-way.
+//   - When SQLite is interrupted mid-statement, go-sqlite3 reports its own
+//     "interrupted" error (SQLITE_INTERRUPT), which has no relation to
+//     context.Canceled at all. Consulting the context alongside the error
+//     covers that case without importing the driver's error type here.
+//
+// context.DeadlineExceeded is deliberately not treated as a cancellation: a
+// query that blew a timeout is a genuine failure worth reporting, whereas a
+// user changing their mind is not.
+func IsCancellation(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return ctx != nil && errors.Is(ctx.Err(), context.Canceled)
+}

--- a/internal/geodata/cancellation_test.go
+++ b/internal/geodata/cancellation_test.go
@@ -1,0 +1,274 @@
+package geodata
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kartoza/decision-theatre/internal/gpkgtest"
+)
+
+// This file is an internal test (package geodata, not geodata_test) because
+// proving that a cancellation actually stops work requires reaching the
+// connection pool: the only way to make a synthetic datapack's queries take
+// long enough to abandon is to make them queue for a connection, which is
+// exactly what happens on the real server when the map is being panned.
+
+// newCancelTestStore opens a store over a synthetic datapack and waits for the
+// background grid geometry cache to finish, so that build is not still holding
+// a pooled connection when a test starts counting them.
+func newCancelTestStore(t *testing.T) *GpkgStore {
+	t.Helper()
+
+	dir := gpkgtest.Build(t, t.TempDir(), []gpkgtest.Catchment{
+		{ID: 1000000001, Lat: 0, Long: 0, SizeDeg: 0.5, Current: gpkgtest.Float(10), Reference: gpkgtest.Float(1)},
+		{ID: 1000000002, Lat: 0, Long: 1, SizeDeg: 0.5, Current: gpkgtest.Float(20), Reference: gpkgtest.Float(2)},
+	}, 0, 100)
+
+	store, err := NewGpkgStore(dir)
+	if err != nil {
+		t.Fatalf("NewGpkgStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+
+	for _, tier := range gridTiersDegrees {
+		select {
+		case <-store.gridGeometryReady[tier]:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("grid geometry cache tier %v never became ready", tier)
+		}
+	}
+	return store
+}
+
+// TestCancelledRequestStopsQueuedQuery is the test this whole change exists
+// for. A query that is waiting its turn for a database connection - the state
+// every extra request lands in once the pool is busy, which is precisely when
+// abandoned work is most expensive - must give up the moment its client goes
+// away, rather than running to completion for an answer nobody will read.
+//
+// Before contexts were threaded through, the store called db.Query, which waits
+// on the pool forever: this test would sit here until it timed out.
+func TestCancelledRequestStopsQueuedQuery(t *testing.T) {
+	store := newCancelTestStore(t)
+
+	// Occupy every connection in the pool so the query below has to queue.
+	maxConns := store.db.Stats().MaxOpenConnections
+	if maxConns <= 0 {
+		t.Fatalf("expected a bounded connection pool, got MaxOpenConnections=%d", maxConns)
+	}
+	held := make([]*sql.Conn, 0, maxConns)
+	for i := 0; i < maxConns; i++ {
+		conn, err := store.db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("holding connection %d: %v", i, err)
+		}
+		held = append(held, conn)
+	}
+	t.Cleanup(func() {
+		for _, conn := range held {
+			_ = conn.Close()
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.QueryCatchmentValueArrays(ctx, "current", gpkgtest.Attribute, -5, -5, 5, 5)
+		done <- err
+	}()
+
+	// Let the query settle into the queue, then abandon it the way a user
+	// panning the map again does.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled query returned success; the cancellation never reached the database call")
+		}
+		if !IsCancellation(ctx, err) {
+			t.Fatalf("cancelled query failed with %v, want a cancellation", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("query was still queued 10s after the client disconnected: cancellation is not reaching the connection pool")
+	}
+}
+
+// storeCall is one entry point of the store, exercised with both a live and a
+// cancelled context.
+type storeCall struct {
+	name string
+	call func(context.Context, *GpkgStore) error
+}
+
+// TestEveryQueryHonoursCancellation walks the store's query surface and checks
+// each entry point twice: once with a live context, where it must succeed
+// (otherwise the cancelled case would pass for the wrong reason), and once with
+// a context cancelled before the call, where it must report a cancellation
+// rather than quietly returning whatever it managed to read.
+//
+// It is written as a table on purpose: a query added later without a context
+// parameter cannot be added to this list, and one added with a context it then
+// ignores fails here.
+func TestEveryQueryHonoursCancellation(t *testing.T) {
+	calls := []storeCall{
+		{"QueryCatchments", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.QueryCatchments(ctx, "current", gpkgtest.Attribute, -5, -5, 5, 5, 8)
+			return err
+		}},
+		{"QueryCatchmentValues", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.QueryCatchmentValues(ctx, "current", gpkgtest.Attribute, -5, -5, 5, 5)
+			return err
+		}},
+		{"QueryCatchmentValueArrays", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.QueryCatchmentValueArrays(ctx, "current", gpkgtest.Attribute, -5, -5, 5, 5)
+			return err
+		}},
+		{"GetScenarioAverages", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetScenarioAverages(ctx, "current", []string{gpkgtest.Attribute}, nil)
+			return err
+		}},
+		{"GetDomainRange", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetDomainRange(ctx, gpkgtest.Attribute)
+			return err
+		}},
+		{"GetCatchmentsBounds", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentsBounds(ctx)
+			return err
+		}},
+		{"GetCatchmentsByBBox", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentsByBBox(ctx, -5, -5, 5, 5, 100)
+			return err
+		}},
+		{"GetCatchmentIDsByBBox", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentIDsByBBox(ctx, -5, -5, 5, 5, 100)
+			return err
+		}},
+		{"GetCatchmentsByIDs", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentsByIDs(ctx, []string{"1000000001"})
+			return err
+		}},
+		{"GetCatchmentIndicatorsByIDs", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentIndicatorsByIDs(ctx, []string{"1000000001"})
+			return err
+		}},
+		{"DissolveCatchments", func(ctx context.Context, s *GpkgStore) error {
+			_, _, err := s.DissolveCatchments(ctx, []string{"1000000001"})
+			return err
+		}},
+		{"GetCatchmentAOIFractions", func(ctx context.Context, s *GpkgStore) error {
+			_, err := s.GetCatchmentAOIFractions(ctx, []string{"1000000001"},
+				json.RawMessage(`{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}`))
+			return err
+		}},
+	}
+
+	for _, tc := range calls {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newCancelTestStore(t)
+
+			if err := tc.call(context.Background(), store); err != nil {
+				t.Fatalf("with a live context the call must succeed, got %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := tc.call(ctx, store)
+			if err == nil {
+				t.Fatal("returned success for an abandoned request; the context is not reaching the database call")
+			}
+			if !IsCancellation(ctx, err) {
+				t.Fatalf("returned %v, want a cancellation", err)
+			}
+		})
+	}
+}
+
+// The grid geometry cache is shared: it is built once and then serves every
+// aggregated choropleth for the life of the process. A request that gives up
+// waiting for it must take only itself out of the picture - if it tore the
+// build down, one impatient user would leave the aggregated path broken for
+// everyone, permanently, because the sync.Once never fires again.
+func TestGivingUpOnTheGridCacheDoesNotCancelTheBuild(t *testing.T) {
+	// A store whose tiers are all still building: the ready channels are open.
+	ready := make(map[float64]chan struct{}, len(gridTiersDegrees))
+	for _, tier := range gridTiersDegrees {
+		ready[tier] = make(chan struct{})
+	}
+	// The build is already marked as started so the wait below does not kick
+	// one off against a nil database.
+	store := &GpkgStore{gridGeometryReady: ready}
+	store.gridGeometryOnce.Do(func() {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rows := []gridRow{{lat: 0, long: 0, area: 1, value: sql.NullFloat64{Float64: 5, Valid: true}}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.queryCatchmentsGridAggregated(ctx, gpkgtest.Attribute, rows)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting request returned %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a cancelled request is still waiting for the grid cache")
+	}
+
+	// The build's own signal is untouched: nothing closed the channels, and
+	// nothing else observed a cancellation.
+	for _, tier := range gridTiersDegrees {
+		select {
+		case <-ready[tier]:
+			t.Fatalf("tier %v was marked ready by an abandoned request; the shared build was torn down", tier)
+		default:
+		}
+	}
+}
+
+func TestIsCancellation(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	expired, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"no error", cancelled, nil, false},
+		{"context.Canceled", context.Background(), context.Canceled, true},
+		{"wrapped context.Canceled", context.Background(), errors.New("query failed: " + context.Canceled.Error()), false},
+		// SQLite reports its own error when interrupted mid-statement, with no
+		// relation to context.Canceled; the context is what identifies it.
+		{"driver interrupt under a cancelled context", cancelled, errors.New("interrupted"), true},
+		{"genuine failure under a live context", context.Background(), errors.New("no such table: catchments_lev12"), false},
+		// A blown deadline is a real failure worth reporting, not a user
+		// changing their mind.
+		{"deadline exceeded", expired, context.DeadlineExceeded, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsCancellation(tc.ctx, tc.err); got != tc.want {
+				t.Errorf("IsCancellation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/geodata/catchment_values_test.go
+++ b/internal/geodata/catchment_values_test.go
@@ -1,6 +1,7 @@
 package geodata_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kartoza/decision-theatre/internal/geodata"
@@ -33,7 +34,7 @@ func TestQueryCatchmentValueArraysReturnsIDsAndValuesInBBox(t *testing.T) {
 	store := newStore(t)
 
 	// A bbox covering the first two catchments only.
-	values, err := store.QueryCatchmentValueArrays("current", gpkgtest.Attribute, -0.5, -0.5, 1.5, 0.5)
+	values, err := store.QueryCatchmentValueArrays(context.Background(), "current", gpkgtest.Attribute, -0.5, -0.5, 1.5, 0.5)
 	if err != nil {
 		t.Fatalf("QueryCatchmentValueArrays: %v", err)
 	}
@@ -60,7 +61,7 @@ func TestQueryCatchmentValueArraysReturnsIDsAndValuesInBBox(t *testing.T) {
 func TestQueryCatchmentValueArraysSkipsNullValues(t *testing.T) {
 	store := newStore(t)
 
-	values, err := store.QueryCatchmentValueArrays("current", gpkgtest.Attribute, -5, -5, 5, 5)
+	values, err := store.QueryCatchmentValueArrays(context.Background(), "current", gpkgtest.Attribute, -5, -5, 5, 5)
 	if err != nil {
 		t.Fatalf("QueryCatchmentValueArrays: %v", err)
 	}
@@ -82,11 +83,11 @@ func TestQueryCatchmentValueArraysSkipsNullValues(t *testing.T) {
 func TestQueryCatchmentValuesAgreesWithValueArrays(t *testing.T) {
 	store := newStore(t)
 
-	arrays, err := store.QueryCatchmentValueArrays("reference", gpkgtest.Attribute, -5, -5, 5, 5)
+	arrays, err := store.QueryCatchmentValueArrays(context.Background(), "reference", gpkgtest.Attribute, -5, -5, 5, 5)
 	if err != nil {
 		t.Fatalf("QueryCatchmentValueArrays: %v", err)
 	}
-	fc, err := store.QueryCatchmentValues("reference", gpkgtest.Attribute, -5, -5, 5, 5)
+	fc, err := store.QueryCatchmentValues(context.Background(), "reference", gpkgtest.Attribute, -5, -5, 5, 5)
 	if err != nil {
 		t.Fatalf("QueryCatchmentValues: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestQueryCatchmentValueArraysRejectsUnknownAttribute(t *testing.T) {
 
 	// The attribute name is interpolated into SQL, so an unvalidated one is an
 	// injection point; the allow-list is loaded from scenario_current's columns.
-	if _, err := store.QueryCatchmentValueArrays("current", `x" FROM sqlite_master; --`, -5, -5, 5, 5); err == nil {
+	if _, err := store.QueryCatchmentValueArrays(context.Background(), "current", `x" FROM sqlite_master; --`, -5, -5, 5, 5); err == nil {
 		t.Fatal("expected an error for an attribute that is not a known column")
 	}
 }

--- a/internal/geodata/gpkg_store.go
+++ b/internal/geodata/gpkg_store.go
@@ -1,6 +1,7 @@
 package geodata
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -103,8 +104,16 @@ func NewGpkgStore(dataDir string) (*GpkgStore, error) {
 	db.SetMaxOpenConns(maxConns)
 	db.SetMaxIdleConns(maxConns)
 
+	// Opening the store is startup work, not request work. It runs once when
+	// the process boots, and again on a background goroutine when a datapack
+	// is installed - there is no HTTP request whose cancellation should
+	// abandon it, so context.Background() is the honest context here rather
+	// than context.TODO(). See IsCancellation for the package's policy on
+	// which work is request-scoped.
+	ctx := context.Background()
+
 	// Test connection
-	if err := db.Ping(); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("failed to connect to geopackage: %w", err)
 	}
 
@@ -120,7 +129,7 @@ func NewGpkgStore(dataDir string) (*GpkgStore, error) {
 	}
 
 	// Load column names from scenario_current
-	if err := store.loadColumns(); err != nil {
+	if err := store.loadColumns(ctx); err != nil {
 		log.Printf("Warning: could not load columns: %v", err)
 	}
 
@@ -133,8 +142,8 @@ func NewGpkgStore(dataDir string) (*GpkgStore, error) {
 }
 
 // loadColumns reads the column names from the scenario tables
-func (s *GpkgStore) loadColumns() error {
-	rows, err := s.db.Query("PRAGMA table_info(scenario_current)")
+func (s *GpkgStore) loadColumns(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, "PRAGMA table_info(scenario_current)")
 	if err != nil {
 		return err
 	}
@@ -155,6 +164,9 @@ func (s *GpkgStore) loadColumns() error {
 			continue
 		}
 		columns = append(columns, name)
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	s.mu.Lock()
@@ -232,12 +244,12 @@ func parseNumericIDs(ids []string) ([]interface{}, bool) {
 	return args, true
 }
 
-func (s *GpkgStore) resolveScenarioIDColumn(tableName string) (string, error) {
+func (s *GpkgStore) resolveScenarioIDColumn(ctx context.Context, tableName string) (string, error) {
 	if cached, ok := s.idColCache.Load(tableName); ok {
 		return cached.(string), nil
 	}
 
-	rows, err := s.db.Query(fmt.Sprintf("PRAGMA table_info(%s)", tableName))
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", tableName))
 	if err != nil {
 		return "", err
 	}
@@ -254,6 +266,11 @@ func (s *GpkgStore) resolveScenarioIDColumn(tableName string) (string, error) {
 		}
 		columns[name] = struct{}{}
 	}
+	// Without this, a cancelled request would look identical to a table with
+	// no id column at all and be reported as a datapack problem.
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
 
 	// Prefer indexed columns first.  All scenario tables have catchment_id_int
 	// with an index; falling back to catchID causes a full-table scan.
@@ -269,7 +286,7 @@ func (s *GpkgStore) resolveScenarioIDColumn(tableName string) (string, error) {
 }
 
 // GetScenarioData returns data for a scenario and attribute as a map of catchment ID to value
-func (s *GpkgStore) GetScenarioData(scenario, attribute string) (map[string]float64, error) {
+func (s *GpkgStore) GetScenarioData(ctx context.Context, scenario, attribute string) (map[string]float64, error) {
 	tableName := resolveScenarioTable(scenario)
 
 	if !s.isValidColumn(attribute) {
@@ -279,7 +296,7 @@ func (s *GpkgStore) GetScenarioData(scenario, attribute string) (map[string]floa
 	query := fmt.Sprintf(`SELECT catchment_id, "%s" FROM %s WHERE "%s" IS NOT NULL`,
 		attribute, tableName, attribute)
 
-	rows, err := s.db.Query(query)
+	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query scenario data: %w", err)
 	}
@@ -294,29 +311,32 @@ func (s *GpkgStore) GetScenarioData(scenario, attribute string) (map[string]floa
 		}
 		result[catchmentID] = value
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read scenario data: %w", err)
+	}
 
 	return result, nil
 }
 
 // GetScenarioAverages returns area-weighted means for one scenario across multiple attributes.
 // When bbox is provided, the aggregation is restricted to catchments intersecting that bbox.
-func (s *GpkgStore) GetScenarioAverages(scenario string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
-	return s.getAveragesForTable(resolveScenarioTable(scenario), attributes, bbox)
+func (s *GpkgStore) GetScenarioAverages(ctx context.Context, scenario string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
+	return s.getAveragesForTable(ctx, resolveScenarioTable(scenario), attributes, bbox)
 }
 
 // GetScenarioBoundAverages returns area-weighted means of the lower/upper
 // uncertainty bound columns for one scenario across multiple attributes.
 // These power whisker/box-plot ranges outside "site" zone range, where the
 // per-catchment whisker computation (ComputeWhiskerBounds) doesn't apply.
-func (s *GpkgStore) GetScenarioBoundAverages(scenario, bound string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
+func (s *GpkgStore) GetScenarioBoundAverages(ctx context.Context, scenario, bound string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
 	tableName, err := resolveScenarioBoundTable(scenario, bound)
 	if err != nil {
 		return nil, err
 	}
-	return s.getAveragesForTable(tableName, attributes, bbox)
+	return s.getAveragesForTable(ctx, tableName, attributes, bbox)
 }
 
-func (s *GpkgStore) getAveragesForTable(tableName string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
+func (s *GpkgStore) getAveragesForTable(ctx context.Context, tableName string, attributes []string, bbox *[4]float64) (map[string]float64, error) {
 	if len(attributes) == 0 {
 		return nil, fmt.Errorf("no attributes provided")
 	}
@@ -353,7 +373,7 @@ func (s *GpkgStore) getAveragesForTable(tableName string, attributes []string, b
 		args = append(args, maxx, minx, maxy, miny)
 	}
 
-	row := s.db.QueryRow(query, args...)
+	row := s.db.QueryRowContext(ctx, query, args...)
 	vals := make([]sql.NullFloat64, len(attributes))
 	scanArgs := make([]interface{}, len(attributes))
 	for i := range vals {
@@ -375,7 +395,7 @@ func (s *GpkgStore) getAveragesForTable(tableName string, attributes []string, b
 }
 
 // GetComparisonData returns comparison data for two scenarios for a given attribute
-func (s *GpkgStore) GetComparisonData(left, right, attribute string) (map[string][2]float64, error) {
+func (s *GpkgStore) GetComparisonData(ctx context.Context, left, right, attribute string) (map[string][2]float64, error) {
 	if !s.isValidColumn(attribute) {
 		return nil, fmt.Errorf("invalid attribute: %s", attribute)
 	}
@@ -390,7 +410,7 @@ func (s *GpkgStore) GetComparisonData(left, right, attribute string) (map[string
 		WHERE l."%s" IS NOT NULL AND r."%s" IS NOT NULL`,
 		attribute, attribute, leftTable, rightTable, attribute, attribute)
 
-	rows, err := s.db.Query(query)
+	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query comparison data: %w", err)
 	}
@@ -404,6 +424,9 @@ func (s *GpkgStore) GetComparisonData(left, right, attribute string) (map[string
 			continue
 		}
 		result[catchmentID] = [2]float64{leftVal, rightVal}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read comparison data: %w", err)
 	}
 
 	return result, nil
@@ -453,7 +476,7 @@ const gridRenderBudget = 8000
 // returns full per-catchment geometry; otherwise it falls back to a
 // grid-aggregated choropleth (see gridCellSizeDegrees) so a densely-catchmented
 // area never gets silently truncated into a gappy render.
-func (s *GpkgStore) QueryCatchments(scenario, attribute string, minx, miny, maxx, maxy, zoom float64) (*FeatureCollection, error) {
+func (s *GpkgStore) QueryCatchments(ctx context.Context, scenario, attribute string, minx, miny, maxx, maxy, zoom float64) (*FeatureCollection, error) {
 	start := time.Now()
 	var path string
 	var matched int
@@ -478,7 +501,7 @@ func (s *GpkgStore) QueryCatchments(scenario, attribute string, minx, miny, maxx
 	// catchments) that duplicated scan cost ~400ms on its own; merging them
 	// removes it entirely for the aggregated path, which is the one this
 	// budget check exists for in the first place.
-	catchmentRows, err := s.fetchCatchmentGridRows(tableName, attribute, minx, miny, maxx, maxy)
+	catchmentRows, err := s.fetchCatchmentGridRows(ctx, tableName, attribute, minx, miny, maxx, maxy)
 	if err != nil {
 		return nil, err
 	}
@@ -486,10 +509,10 @@ func (s *GpkgStore) QueryCatchments(scenario, attribute string, minx, miny, maxx
 
 	if matched <= maxDetailedFeatures {
 		path = "detailed"
-		return s.queryCatchmentsDetailed(tableName, attribute, minx, miny, maxx, maxy)
+		return s.queryCatchmentsDetailed(ctx, tableName, attribute, minx, miny, maxx, maxy)
 	}
 	path = "aggregated"
-	return s.queryCatchmentsGridAggregated(attribute, catchmentRows)
+	return s.queryCatchmentsGridAggregated(ctx, attribute, catchmentRows)
 }
 
 // coordinateRe matches a JSON floating-point coordinate value (GeoJSON never
@@ -525,7 +548,7 @@ func truncateCoordinatePrecision(geojsonStr string) string {
 }
 
 // queryCatchmentsDetailed returns one feature per catchment with full-detail geometry.
-func (s *GpkgStore) queryCatchmentsDetailed(tableName, attribute string, minx, miny, maxx, maxy float64) (*FeatureCollection, error) {
+func (s *GpkgStore) queryCatchmentsDetailed(ctx context.Context, tableName, attribute string, minx, miny, maxx, maxy float64) (*FeatureCollection, error) {
 	// Use pre-computed geojson column - much faster than WKB conversion
 	// Only select the fields we need (no geometry blob)
 	// Use integer columns for faster index-based joins
@@ -547,7 +570,7 @@ func (s *GpkgStore) queryCatchmentsDetailed(tableName, attribute string, minx, m
 		LIMIT ?
 	`, attribute, tableName)
 
-	rows, err := s.db.Query(query, maxx, minx, maxy, miny, maxDetailedFeatures)
+	rows, err := s.db.QueryContext(ctx, query, maxx, minx, maxy, miny, maxDetailedFeatures)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
@@ -583,6 +606,12 @@ func (s *GpkgStore) queryCatchmentsDetailed(tableName, attribute string, minx, m
 			Properties: props,
 		})
 	}
+	// A cancelled query stops mid-scan, so without this the caller would get a
+	// partial feature collection reported as a complete one - a map with holes
+	// in it and no indication anything went wrong.
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
 
 	return &FeatureCollection{
 		Type:     "FeatureCollection",
@@ -616,8 +645,8 @@ type CatchmentValues struct {
 // Callers never hand this to a map source, so shipping one feature per catchment
 // (with a null geometry) doesn't carry the rendering cost that motivated those
 // other paths.
-func (s *GpkgStore) QueryCatchmentValues(scenario, attribute string, minx, miny, maxx, maxy float64) (*FeatureCollection, error) {
-	values, err := s.QueryCatchmentValueArrays(scenario, attribute, minx, miny, maxx, maxy)
+func (s *GpkgStore) QueryCatchmentValues(ctx context.Context, scenario, attribute string, minx, miny, maxx, maxy float64) (*FeatureCollection, error) {
+	values, err := s.QueryCatchmentValueArrays(ctx, scenario, attribute, minx, miny, maxx, maxy)
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +675,7 @@ func (s *GpkgStore) QueryCatchmentValues(scenario, attribute string, minx, miny,
 // the statistics path, and the /catchment-values endpoint serves it directly to
 // the vector-tile choropleth. Keeping one query means the two can never drift
 // on which catchments they consider in view.
-func (s *GpkgStore) QueryCatchmentValueArrays(scenario, attribute string, minx, miny, maxx, maxy float64) (*CatchmentValues, error) {
+func (s *GpkgStore) QueryCatchmentValueArrays(ctx context.Context, scenario, attribute string, minx, miny, maxx, maxy float64) (*CatchmentValues, error) {
 	start := time.Now()
 	count := 0
 	defer func() {
@@ -669,7 +698,7 @@ func (s *GpkgStore) QueryCatchmentValueArrays(scenario, attribute string, minx, 
 		  )
 	`, attribute, tableName, attribute)
 
-	rows, err := s.db.Query(query, maxx, minx, maxy, miny)
+	rows, err := s.db.QueryContext(ctx, query, maxx, minx, maxy, miny)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
@@ -691,6 +720,12 @@ func (s *GpkgStore) QueryCatchmentValueArrays(scenario, attribute string, minx, 
 		result.IDs = append(result.IDs, int64(id))
 		result.Values = append(result.Values, value)
 	}
+	// See queryCatchmentsDetailed: a truncated scan must not be reported as a
+	// complete viewport, or the statistics panel would quietly summarise a
+	// subset of the data.
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
 	count = len(result.IDs)
 
 	return result, nil
@@ -700,7 +735,19 @@ func (s *GpkgStore) QueryCatchmentValueArrays(scenario, attribute string, minx, 
 // to call from every request; only the first call actually starts the build.
 func (s *GpkgStore) ensureGridGeometryCache() {
 	s.gridGeometryOnce.Do(func() {
-		go s.buildGridGeometryCache()
+		// Deliberately context.Background(), not the context of whichever
+		// request happened to need the grid first. This cache is built once
+		// and then serves every aggregated choropleth for the life of the
+		// process, so it is shared work that merely happens to be triggered
+		// by one request. Tying it to that request's lifetime would let a
+		// single user panning away tear down a build the rest are waiting
+		// on, and the sync.Once means nothing would ever restart it - the
+		// aggregated path would be broken for the remaining uptime.
+		//
+		// Requests still stop *waiting* on it the moment their own context is
+		// cancelled; only the build is decoupled. See
+		// queryCatchmentsGridAggregated.
+		go s.buildGridGeometryCache(context.Background())
 	})
 }
 
@@ -732,10 +779,10 @@ func gridCellKeyFor(lat, long, cellSizeDegrees float64) gridCellKey {
 // boundary coordinates, so those edges cancel out perfectly in the union;
 // the result is simplified once, as a whole, after dissolving (see the
 // simplifyPolygonsForComputation call below).
-func (s *GpkgStore) buildGridGeometryCache() {
+func (s *GpkgStore) buildGridGeometryCache(ctx context.Context) {
 	start := time.Now()
 
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT lat, long, geojson
 		FROM catchments_lev12
 		WHERE lat IS NOT NULL AND long IS NOT NULL AND geojson IS NOT NULL
@@ -916,7 +963,7 @@ type gridRow struct {
 // for a continent-scale match set. QueryCatchments uses the row count alone
 // to pick detailed vs. aggregated, and reuses the rows themselves if
 // aggregated is chosen, rather than re-querying (see QueryCatchments).
-func (s *GpkgStore) fetchCatchmentGridRows(tableName, attribute string, minx, miny, maxx, maxy float64) ([]gridRow, error) {
+func (s *GpkgStore) fetchCatchmentGridRows(ctx context.Context, tableName, attribute string, minx, miny, maxx, maxy float64) ([]gridRow, error) {
 	// Every catchment in the bbox is included here, even ones with a null
 	// value for attribute - a cell whose catchments simply lack data for this
 	// particular indicator should still render (falling back to the domain
@@ -934,7 +981,7 @@ func (s *GpkgStore) fetchCatchmentGridRows(tableName, attribute string, minx, mi
 		  )
 	`, attribute, tableName)
 
-	rows, err := s.db.Query(query, maxx, minx, maxy, miny)
+	rows, err := s.db.QueryContext(ctx, query, maxx, minx, maxy, miny)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
@@ -949,6 +996,12 @@ func (s *GpkgStore) fetchCatchmentGridRows(tableName, attribute string, minx, mi
 		}
 		catchmentRows = append(catchmentRows, r)
 	}
+	// The row count decides detailed vs. aggregated rendering in
+	// QueryCatchments, so a truncated scan would not just lose rows - it would
+	// pick the wrong render path and present the result as complete.
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
 	return catchmentRows, nil
 }
 
@@ -962,7 +1015,7 @@ func (s *GpkgStore) fetchCatchmentGridRows(tableName, attribute string, minx, mi
 // picking the finest affordable tier keeps the choropleth as close to the true
 // catchment texture as the feature budget allows - only a genuinely
 // continent-scale view is forced down to the coarsest tier.
-func (s *GpkgStore) queryCatchmentsGridAggregated(attribute string, catchmentRows []gridRow) (*FeatureCollection, error) {
+func (s *GpkgStore) queryCatchmentsGridAggregated(ctx context.Context, attribute string, catchmentRows []gridRow) (*FeatureCollection, error) {
 	s.ensureGridGeometryCache()
 
 	type cellAccumulator struct {
@@ -1019,7 +1072,18 @@ func (s *GpkgStore) queryCatchmentsGridAggregated(attribute string, catchmentRow
 
 	// Only block on the tier this request actually needs, not the slowest
 	// tier in the set (see buildGridGeometryCache's per-tier readiness).
-	<-s.gridGeometryReady[chosenTier]
+	//
+	// The wait is abandoned as soon as this request's context is cancelled -
+	// on a cold start that wait is the longest thing this handler does, and a
+	// user who has already panned away should not hold a connection and a
+	// goroutine until the whole cache lands. The build itself is untouched by
+	// giving up here: it runs on a background context precisely so it
+	// survives (see ensureGridGeometryCache).
+	select {
+	case <-s.gridGeometryReady[chosenTier]:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 
 	s.mu.RLock()
 	tierCache := s.gridGeometryCache[chosenTier]
@@ -1075,7 +1139,7 @@ func (s *GpkgStore) isValidColumn(attribute string) bool {
 }
 
 // GetDomainRange returns the min and max values for an attribute across all scenarios
-func (s *GpkgStore) GetDomainRange(attribute string) (*DomainRange, error) {
+func (s *GpkgStore) GetDomainRange(ctx context.Context, attribute string) (*DomainRange, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetDomainRange attribute=%s duration_ms=%d", attribute, time.Since(start).Milliseconds())
@@ -1090,14 +1154,14 @@ func (s *GpkgStore) GetDomainRange(attribute string) (*DomainRange, error) {
 
 	// Query domain_minima table
 	query := fmt.Sprintf(`SELECT "%s" FROM domain_minima LIMIT 1`, attribute)
-	err := s.db.QueryRow(query).Scan(&minVal)
+	err := s.db.QueryRowContext(ctx, query).Scan(&minVal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get domain minimum for %s: %w", attribute, err)
 	}
 
 	// Query domain_maxima table
 	query = fmt.Sprintf(`SELECT "%s" FROM domain_maxima LIMIT 1`, attribute)
-	err = s.db.QueryRow(query).Scan(&maxVal)
+	err = s.db.QueryRowContext(ctx, query).Scan(&maxVal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get domain maximum for %s: %w", attribute, err)
 	}
@@ -1117,7 +1181,7 @@ func (s *GpkgStore) Close() {
 
 // DissolveCatchments returns a dissolved/unioned geometry from multiple catchments
 // Returns the geometry as GeoJSON (single outer boundary) and the total area in square kilometers
-func (s *GpkgStore) DissolveCatchments(catchmentIDs []string) (json.RawMessage, float64, error) {
+func (s *GpkgStore) DissolveCatchments(ctx context.Context, catchmentIDs []string) (json.RawMessage, float64, error) {
 	if len(catchmentIDs) == 0 {
 		return nil, 0, fmt.Errorf("no catchment IDs provided")
 	}
@@ -1136,7 +1200,7 @@ func (s *GpkgStore) DissolveCatchments(catchmentIDs []string) (json.RawMessage, 
 		WHERE HYBAS_ID IN (%s) AND geojson IS NOT NULL
 	`, strings.Join(placeholders, ","))
 
-	rows, err := s.db.Query(query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to query catchments: %w", err)
 	}
@@ -1182,6 +1246,13 @@ func (s *GpkgStore) DissolveCatchments(catchmentIDs []string) (json.RawMessage, 
 				}
 			}
 		}
+	}
+
+	// Checked before the emptiness test below so that a cancelled scan is
+	// reported as a cancellation rather than as a set of catchments that
+	// turned out to have no geometry.
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("failed to read catchments: %w", err)
 	}
 
 	if len(polyPolygons) == 0 {
@@ -1432,7 +1503,7 @@ func ringContainedIn(inner, outer [][2]float64) bool {
 
 // GetCatchmentAttributes returns all attributes for a specific catchment across both scenarios
 // Returns a map: scenario -> attribute -> value
-func (s *GpkgStore) GetCatchmentAttributes(catchmentID string) map[string]map[string]float64 {
+func (s *GpkgStore) GetCatchmentAttributes(ctx context.Context, catchmentID string) map[string]map[string]float64 {
 	result := make(map[string]map[string]float64)
 
 	// Query both scenario tables
@@ -1459,7 +1530,7 @@ func (s *GpkgStore) GetCatchmentAttributes(catchmentID string) map[string]map[st
 		query := fmt.Sprintf(`SELECT %s FROM %s WHERE catchment_id = ?`,
 			strings.Join(quotedCols, ", "), tableName)
 
-		row := s.db.QueryRow(query, catchmentID)
+		row := s.db.QueryRowContext(ctx, query, catchmentID)
 
 		// Create a slice of interface{} for scanning
 		values := make([]sql.NullFloat64, len(columns))
@@ -1474,7 +1545,7 @@ func (s *GpkgStore) GetCatchmentAttributes(catchmentID string) map[string]map[st
 			// Remove leading zeros or non-numeric chars if needed
 			query = fmt.Sprintf(`SELECT %s FROM %s WHERE catchment_id_int = ?`,
 				strings.Join(quotedCols, ", "), tableName)
-			row = s.db.QueryRow(query, intID)
+			row = s.db.QueryRowContext(ctx, query, intID)
 			if err := row.Scan(scanArgs...); err != nil {
 				continue
 			}
@@ -1507,7 +1578,7 @@ type CatchmentIndicators struct {
 
 // GetCatchmentIndicatorsByIDs returns indicator values for multiple catchments
 // Used for area-weighted aggregation in site calculations
-func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ids []string) ([]CatchmentIndicators, error) {
+func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ctx context.Context, ids []string) ([]CatchmentIndicators, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetCatchmentIndicatorsByIDs ids=%d duration_ms=%d", len(ids), time.Since(start).Milliseconds())
@@ -1550,9 +1621,11 @@ func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ids []string) ([]CatchmentIndica
 	queryScenario := func(scenario string) {
 		scenarioStart := time.Now()
 		tableName := "scenario_" + scenario
-		idColumn, err := s.resolveScenarioIDColumn(tableName)
+		idColumn, err := s.resolveScenarioIDColumn(ctx, tableName)
 		if err != nil {
-			log.Printf("Failed to resolve ID column for %s: %v", tableName, err)
+			if !IsCancellation(ctx, err) {
+				log.Printf("Failed to resolve ID column for %s: %v", tableName, err)
+			}
 			scenarioCh <- scenarioResult{scenario: scenario, data: nil}
 			return
 		}
@@ -1568,8 +1641,16 @@ func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ids []string) ([]CatchmentIndica
 			WHERE %s IN (%s)
 		`, idColumn, strings.Join(quotedCols, ", "), tableName, idColumn, strings.Join(placeholders, ","))
 
-		rows, err := s.db.Query(query, queryArgs...)
+		rows, err := s.db.QueryContext(ctx, query, queryArgs...)
 		if err != nil {
+			// A cancelled request is not a failure, so it must not be logged
+			// as one; it is still reported to the caller, which is what makes
+			// it distinguishable from the pre-existing "log and return empty"
+			// path this sits next to.
+			if IsCancellation(ctx, err) {
+				scenarioCh <- scenarioResult{scenario: scenario, err: err}
+				return
+			}
 			log.Printf("Failed to query %s: %v", tableName, err)
 			scenarioCh <- scenarioResult{scenario: scenario, data: nil}
 			return
@@ -1639,8 +1720,11 @@ func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ids []string) ([]CatchmentIndica
 		WHERE %s IN (%s)
 	`, areaColumn, areaColumn, strings.Join(placeholders, ","))
 
-	areaRows, err := s.db.Query(areaQuery, areaArgs...)
+	areaRows, err := s.db.QueryContext(ctx, areaQuery, areaArgs...)
 	if err != nil {
+		if IsCancellation(ctx, err) {
+			return nil, err
+		}
 		log.Printf("Failed to query areas: %v", err)
 	} else {
 		defer areaRows.Close()
@@ -1680,7 +1764,7 @@ func (s *GpkgStore) GetCatchmentIndicatorsByIDs(ids []string) ([]CatchmentIndica
 
 // ApplyAOIFractions computes overlap fractions between site geometry and catchments.
 // Fractions are written in-place to catchments as values in [0, 1].
-func (s *GpkgStore) ApplyAOIFractions(catchments []CatchmentIndicators, siteGeometry json.RawMessage) error {
+func (s *GpkgStore) ApplyAOIFractions(ctx context.Context, catchments []CatchmentIndicators, siteGeometry json.RawMessage) error {
 	if len(catchments) == 0 || len(siteGeometry) == 0 {
 		return nil
 	}
@@ -1697,7 +1781,7 @@ func (s *GpkgStore) ApplyAOIFractions(catchments []CatchmentIndicators, siteGeom
 		return nil
 	}
 
-	fractions, err := s.GetCatchmentAOIFractions(ids, siteGeometry)
+	fractions, err := s.GetCatchmentAOIFractions(ctx, ids, siteGeometry)
 	if err != nil {
 		return err
 	}
@@ -1713,7 +1797,7 @@ func (s *GpkgStore) ApplyAOIFractions(catchments []CatchmentIndicators, siteGeom
 }
 
 // GetCatchmentAOIFractions returns site-overlap fractions for catchments by ID.
-func (s *GpkgStore) GetCatchmentAOIFractions(ids []string, siteGeometry json.RawMessage) (map[string]float64, error) {
+func (s *GpkgStore) GetCatchmentAOIFractions(ctx context.Context, ids []string, siteGeometry json.RawMessage) (map[string]float64, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetCatchmentAOIFractions ids=%d duration_ms=%d", len(ids), time.Since(start).Milliseconds())
@@ -1736,7 +1820,7 @@ func (s *GpkgStore) GetCatchmentAOIFractions(ids []string, siteGeometry json.Raw
 	log.Printf("[perf] GetCatchmentAOIFractions step=parseSiteGeometry polygons=%d duration_ms=%d", len(sitePolygons), time.Since(parseStart).Milliseconds())
 
 	fetchStart := time.Now()
-	features, err := s.GetCatchmentsByIDs(ids)
+	features, err := s.GetCatchmentsByIDs(ctx, ids)
 	if err != nil {
 		return result, err
 	}
@@ -2017,7 +2101,7 @@ func isFinitePositive(v float64) bool {
 }
 
 // GetCatchmentsByIDs returns catchment geometries for the given IDs
-func (s *GpkgStore) GetCatchmentsByIDs(ids []string) ([]GeoJSONFeature, error) {
+func (s *GpkgStore) GetCatchmentsByIDs(ctx context.Context, ids []string) ([]GeoJSONFeature, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetCatchmentsByIDs ids=%d duration_ms=%d", len(ids), time.Since(start).Milliseconds())
@@ -2048,7 +2132,7 @@ func (s *GpkgStore) GetCatchmentsByIDs(ids []string) ([]GeoJSONFeature, error) {
 		WHERE %s IN (%s) AND geojson IS NOT NULL
 	`, idColumn, idColumn, strings.Join(placeholders, ","))
 
-	rows, err := s.db.Query(query, queryArgs...)
+	rows, err := s.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query catchments: %w", err)
 	}
@@ -2089,7 +2173,7 @@ func (s *GpkgStore) GetCatchmentsByIDs(ids []string) ([]GeoJSONFeature, error) {
 
 // GetCatchmentsByBBox returns catchment geometries intersecting the provided bounding box.
 // The limit is capped by the caller to avoid very large responses.
-func (s *GpkgStore) GetCatchmentsByBBox(minx, miny, maxx, maxy float64, limit int) ([]GeoJSONFeature, error) {
+func (s *GpkgStore) GetCatchmentsByBBox(ctx context.Context, minx, miny, maxx, maxy float64, limit int) ([]GeoJSONFeature, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetCatchmentsByBBox limit=%d duration_ms=%d", limit, time.Since(start).Milliseconds())
@@ -2111,7 +2195,7 @@ func (s *GpkgStore) GetCatchmentsByBBox(minx, miny, maxx, maxy float64, limit in
 		LIMIT ?
 	`
 
-	rows, err := s.db.Query(query, maxx, minx, maxy, miny, limit)
+	rows, err := s.db.QueryContext(ctx, query, maxx, minx, maxy, miny, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query catchments by bbox: %w", err)
 	}
@@ -2134,12 +2218,15 @@ func (s *GpkgStore) GetCatchmentsByBBox(minx, miny, maxx, maxy float64, limit in
 			},
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to query catchments by bbox: %w", err)
+	}
 
 	return features, nil
 }
 
 // GetCatchmentIDsByBBox returns catchment IDs intersecting the provided bounding box.
-func (s *GpkgStore) GetCatchmentIDsByBBox(minx, miny, maxx, maxy float64, limit int) ([]string, error) {
+func (s *GpkgStore) GetCatchmentIDsByBBox(ctx context.Context, minx, miny, maxx, maxy float64, limit int) ([]string, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("[perf] GetCatchmentIDsByBBox limit=%d duration_ms=%d", limit, time.Since(start).Milliseconds())
@@ -2158,7 +2245,7 @@ func (s *GpkgStore) GetCatchmentIDsByBBox(minx, miny, maxx, maxy float64, limit 
 		LIMIT ?
 	`
 
-	rows, err := s.db.Query(query, maxx, minx, maxy, miny, limit)
+	rows, err := s.db.QueryContext(ctx, query, maxx, minx, maxy, miny, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query catchment IDs by bbox: %w", err)
 	}
@@ -2172,12 +2259,15 @@ func (s *GpkgStore) GetCatchmentIDsByBBox(minx, miny, maxx, maxy float64, limit 
 		}
 		ids = append(ids, normalizeCatchmentID(id))
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to query catchment IDs by bbox: %w", err)
+	}
 
 	return ids, nil
 }
 
 // GetCatchmentsBounds returns the envelope of all catchment geometries.
-func (s *GpkgStore) GetCatchmentsBounds() ([4]float64, error) {
+func (s *GpkgStore) GetCatchmentsBounds(ctx context.Context) ([4]float64, error) {
 	var bounds [4]float64
 
 	const query = `
@@ -2185,7 +2275,7 @@ func (s *GpkgStore) GetCatchmentsBounds() ([4]float64, error) {
 		FROM rtree_catchments_lev12_geom
 	`
 
-	if err := s.db.QueryRow(query).Scan(&bounds[0], &bounds[1], &bounds[2], &bounds[3]); err != nil {
+	if err := s.db.QueryRowContext(ctx, query).Scan(&bounds[0], &bounds[1], &bounds[2], &bounds[3]); err != nil {
 		return bounds, fmt.Errorf("failed to query catchments bounds: %w", err)
 	}
 
@@ -2374,7 +2464,7 @@ func calculatePolygonArea(poly polyclip.Polygon) float64 {
 // by querying the four whisker scenario tables directly from the GeoPackage.
 // This replaces the CSV-based WhiskerStore approach which required loading 200-400 MB
 // files into memory at startup.
-func (s *GpkgStore) ComputeWhiskerBounds(catchments []CatchmentIndicators) WhiskerBounds {
+func (s *GpkgStore) ComputeWhiskerBounds(ctx context.Context, catchments []CatchmentIndicators) WhiskerBounds {
 	if len(catchments) == 0 {
 		return WhiskerBounds{}
 	}
@@ -2430,9 +2520,11 @@ func (s *GpkgStore) ComputeWhiskerBounds(catchments []CatchmentIndicators) Whisk
 	colStr := strings.Join(quotedCols, ", ")
 
 	queryTable := func(tableName string) map[string]float64 {
-		idColumn, err := s.resolveScenarioIDColumn(tableName)
+		idColumn, err := s.resolveScenarioIDColumn(ctx, tableName)
 		if err != nil {
-			log.Printf("ComputeWhiskerBounds: failed to resolve ID column for %s: %v", tableName, err)
+			if !IsCancellation(ctx, err) {
+				log.Printf("ComputeWhiskerBounds: failed to resolve ID column for %s: %v", tableName, err)
+			}
 			return nil
 		}
 		queryArgs := textArgs
@@ -2442,9 +2534,15 @@ func (s *GpkgStore) ComputeWhiskerBounds(catchments []CatchmentIndicators) Whisk
 		query := fmt.Sprintf(`SELECT %s, %s FROM %s WHERE %s IN (%s)`,
 			idColumn, colStr, tableName, idColumn, phStr)
 
-		rows, err := s.db.Query(query, queryArgs...)
+		rows, err := s.db.QueryContext(ctx, query, queryArgs...)
 		if err != nil {
-			log.Printf("ComputeWhiskerBounds: failed to query %s: %v", tableName, err)
+			// A client that went away is not a query failure. The caller can
+			// still tell the two apart: it checks ctx.Err() itself, because
+			// this function's signature has no error to return (tracked
+			// separately - see the swallowed-error issue).
+			if !IsCancellation(ctx, err) {
+				log.Printf("ComputeWhiskerBounds: failed to query %s: %v", tableName, err)
+			}
 			return nil
 		}
 		defer rows.Close()


### PR DESCRIPTION
Fixes #38

A client that gave up did not stop the work it had started.

No database call took a `context.Context`. When a user closed a tab, panned the
map again, or a proxy timed out, the query ran to completion against SQLite —
holding a connection and CPU for an answer nobody would read. The most expensive
query in this application takes over four seconds and the map issues one on every
pan, so abandoned work accumulated exactly when the server was already busy.

## What changed

- **`internal/geodata/gpkg_store.go`** — every SQLite-touching method now takes a
  context and uses `QueryContext` / `QueryRowContext`. Fifteen `Query` and six
  `QueryRow` call sites. The geopackage is opened `mode=ro`, so there is no
  `ExecContext` to convert.
- **`internal/geodata/cancel.go`** (new) — `IsCancellation(ctx, err)`. It takes
  the context as well as the error deliberately: `database/sql` reports
  `context.Canceled`, but go-sqlite3 reports its own `SQLITE_INTERRUPT`
  ("interrupted") when SQLite is stopped mid-statement, and that has no relation
  to `context.Canceled`. A blown **deadline** is deliberately not treated as a
  cancellation — that is a real failure and should read as one.
- **`internal/api/cancel.go`** (new) — a cancelled request logs as cancelled,
  never as an error, and writes no body (499).
- **`internal/api/handler.go`** — `r.Context()` threaded to every store call.

## Ten `rows.Err()` checks, which were required rather than tidy

A cancelled scan ends `rows.Next()` early. Without checking `rows.Err()`, a
caller would receive a **partial choropleth or a partial statistics set and
believe it was complete** — so threading a context would have opened a new
silent-failure path while closing another.

This also surfaces genuine mid-scan database errors that previously truncated
results in silence. That is a behaviour change slightly beyond the issue, and it
is called out here rather than buried.

## Deliberately not cancellable

Some work is started on behalf of one request and serves all of them. Cancelling
it would let one impatient user degrade the service for everyone.

- **The grid geometry cache build** is guarded by a `sync.Once`. If a
  cancellation tore it down, nothing would restart it and the aggregated map path
  would stay broken for the life of the process. What is now cancellable there is
  the *wait*: `queryCatchmentsGridAggregated` selects on `ctx.Done()` alongside
  the ready channel.
- **`handlePrecalculateFull`** uses `context.WithoutCancel` — it is cached for the
  process lifetime and served to every later pane.
- **`populateSiteCatchmentDetailsDeferred`** and **`doSiteExtraction`** run in
  goroutines started by handlers that have already responded and returned, so
  their request context is *already* cancelled; threading it would have aborted
  the work on every request rather than only on a disconnect.

No `context.TODO()` anywhere.

## Tests

`go build ./...`, `go vet ./...`, `gofmt` and `go test ./...` clean before and
after, and `-race` clean on both changed packages. No module dependency added, so
`go.mod`, `go.sum` and the flake's `vendorHash` are untouched.

The load-bearing test is `TestCancelledRequestStopsQueuedQuery`. It holds every
connection in the pool — the state every additional request lands in once the
server is busy, which is precisely when abandoned work is most expensive — then
cancels a queued query and requires it to return promptly. **It was verified to
fail before the change**: with `db.Query` it waits on the pool indefinitely and
times out. A twelve-entry-point table test covers the rest.

## Found, not fixed

- **`internal/tiles/mbtiles.go` has the identical problem**, and is hit far more
  often than the geopackage — several tile queries per pan, per pane. Outside the
  scope of this issue, but the obvious companion fix.
- `buildGridGeometryCache` does not check `rows.Err()`, so a genuine database
  error would publish a **partial geometry cache and mark every tier ready** for
  the life of the process. That is an instance of the log-and-return-empty pattern
  tracked separately; it is the most consequential one visible.
- `handlePrecalculateFull` has no singleflight, so four quad-view panes on a cold
  start each run the whole computation. Detaching it from cancellation slightly
  increases that exposure.

## Not vouched for

The exact error shape a real mid-flight SQLite interrupt produces.
`IsCancellation` covers both shapes and is unit-tested, but a genuine
mid-statement interrupt could not be exercised — the synthetic datapack has two
catchments. Behaviour against a real multi-gigabyte datapack is covered by
compilation and signature threading rather than by execution.
