### PR TITLE
perf(frontend): make a save cost what changed, not what is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Saving one site cost as much as saving all of them.** The three bulk callers
+  loaded every stored site, changed one, and wrote them all back, so `JSON.parse`
+  and `JSON.stringify` ran across the whole store on the main thread for every
+  edit — and the cost grew with everything a user had ever saved rather than with
+  what changed.
+
+  A record cache now keeps, per site, the object last handed out and the exact
+  string it serialises to. Reads re-parse only when the stored string differs, an
+  untouched site is recognised by reference and never re-serialised, and the index
+  is rewritten only when membership or order actually changed.
+
+  Measured in jsdom, editing one site out of 200 with the store at 4,091,627
+  characters — 78% of this machine's measured 5,241,856-character localStorage
+  ceiling — **saving fell from 24.94 ms to 0.28 ms and reloading from 17.90 ms to
+  0.60 ms**. The figure that matters is that the new cost barely moves between a
+  807,000-character store (0.21 ms) and a 4.1-million one (0.28 ms): it is now
+  proportional to the edit, not to the store.
+
+  Nothing is deferred, debounced or batched, so no durability window is
+  introduced — these records are the user's only copy of their work. A cache entry
+  is written only when the underlying write succeeded and is dropped when it
+  failed, so a quota exception can never leave the application believing a site is
+  stored.
+
 - **The application held twelve WebGL contexts in grid view and never gave one
   back.** Each `MapView` built two MapLibre instances — left and right — whether or
   not the user was comparing anything, and a pane latched "has shown a map" on first

--- a/NOTES-sitestore.md
+++ b/NOTES-sitestore.md
@@ -1,0 +1,159 @@
+# Notes — issue #70, site store save cost
+
+Branch `perf/site-store-off-main-thread`. Touches `frontend/src/lib/siteStore.ts`
+and `frontend/src/test/siteStore.test.ts` only.
+
+## What the state was
+
+The per-record split had already landed (commit `2dfe378`): sites live at
+`dt-site:{id}` with a `dt-site-index`, and the per-catchment breakdown is no
+longer persisted. That fixed the *write*.
+
+It did not fix the work around the write. The three bulk callers in
+`hooks/useApi.ts` — `createSite`, `updateSite`, `deleteSite` — still do
+load-everything, change one entry, hand the whole list back. Against per-site
+records that meant `loadSites` parsed all N records on the way in, and
+`saveSites` re-serialised all N on the way out and read all N back from storage
+to work out which one differed. Same O(store) main-thread cost as the old single
+blob, just spread over more keys.
+
+## What changed
+
+A module-level **record cache** in `siteStore.ts`: for each id, the object the
+module last handed out or wrote, and the exact string that object serialises to.
+
+- `readRecord` re-parses only when the stored string differs from the one it
+  already parsed, and returns the cached object rather than a fresh copy.
+- `saveSites` recognises an unchanged site by **reference identity** — it is the
+  very object the cache handed out — and skips serialising it entirely. A site
+  it does not recognise is serialised and compared against the string the cache
+  knows is on disk, so an unfamiliar-but-identical object still does not reach
+  storage.
+- The index is cached too, and rewritten only when membership or order actually
+  changed. It used to be rewritten on every bulk save.
+- The removed-records sweep in `saveSites` used `Array.includes` inside a loop
+  over the index; it is a `Set` now.
+- A `storage` event listener drops cached entries another tab replaced. Without
+  it a second tab would serve its own stale copy, and — worse — the identity
+  shortcut would decide a record needed no write when the other tab had already
+  replaced it.
+- `getSiteStoreStats` / `resetSiteStoreStats` count serialisations, parses,
+  record reads and writes, and index writes, so the tests can assert the *amount*
+  of work rather than the outcome.
+- `invalidateSiteCache(id?)` is the documented escape hatch.
+
+## Measured
+
+jsdom, this machine, one site edited out of a store of 200:
+
+| store | operation | before | after |
+| --- | --- | --- | --- |
+| 4,091,627 chars (78% of the 5,241,856 ceiling) | bulk save | 24.94 ms | 0.28 ms |
+| same | reload for the next save | 17.90 ms | 0.60 ms |
+| 806,903 chars, 40 sites | bulk save | 3.95 ms | 0.21 ms |
+
+The point is not the ratio, it is that the "after" column barely moves between
+807 k chars and 4.1 M: 0.21 ms → 0.28 ms. The cost is now proportional to the
+edit, not to the store. (The benchmark was a throwaway; it is not committed.)
+
+## Durability
+
+**No durability window was introduced.** Nothing is debounced, batched, deferred
+or queued. Writes are still synchronous `setItem` calls made during the save. If
+`saveSite`/`saveSites` returns true, the bytes are in localStorage; close the tab
+on the next tick and the work is there. Making saves *cheaper* was the fix;
+making them *later* would have traded the user's only copy for smoothness.
+
+Quota failures still surface, and the cache is built so it cannot hide one:
+
+- `writeRecord` sets the cache entry only when `safeSetItem` returned true, and
+  **deletes** it when it returned false. A failed write can therefore never leave
+  the module believing a site is stored, and the next attempt with the same
+  object really writes. There is a test for exactly this.
+- `writeIndex` nulls the index cache on failure.
+- `saveSites` still returns false if any record or the index failed, and the
+  callers in `useApi.ts` still turn that into "Browser storage is full".
+
+## Deliberately not done
+
+- **No IndexedDB.** That is issue #72.
+- **No Web Worker.** Web Storage is not exposed to workers, so the branch name is
+  aspirational: this reduces main-thread work rather than moving it off-thread.
+  Genuinely off-thread requires #72.
+- **No npm dependency.**
+- **No change to `hooks/useApi.ts` or `components/MapView.tsx`** — another agent's
+  territory this round. See "outside this issue" below for what I would do there.
+- **`storage.ts` unchanged.** `estimateStorageChars` is O(everything stored), but
+  it runs once at startup from `App.tsx` and measuring everything is the point of
+  it.
+- **Legacy migration retry semantics left alone.** I tried a once-per-session
+  flag and backed it out: `sessionSites.test.ts` writes `dt-sites` part-way
+  through a file and expects it picked up, and more generally an import or
+  restore path could legitimately write that key later. So every read and write
+  still probes `dt-sites`. After a successful migration that is a null lookup and
+  costs nothing.
+
+## Things I found that are outside this issue
+
+- **The bulk API is the real problem and it is in `useApi.ts`.** `createSite`,
+  `updateSite` and `deleteSite` all round-trip the entire list to change one
+  site, and `saveLocalSite`/`loadLocalSite` already exist. `updateSite` in
+  particular could be `loadSite(id)` → spread → `saveSite`, which needs no cache
+  at all to be O(1). The cache exists to make the *existing* shape cheap; the
+  shape itself is still wrong. Worth a follow-up issue.
+- `sortSitesByCreatedAtDesc(sites)` is called on every bulk save and sorts the
+  whole list. Cheap next to what it used to sit beside, less cheap now that
+  everything else is 0.3 ms.
+- A failed migration (quota exhausted with a legacy blob present) re-reads and
+  re-parses the whole blob on every single save until it succeeds. Documented in
+  the module. It only happens in a state where the user is already being told
+  storage is full, and each retry is a chance to rescue the blob, so I left it.
+
+## What I would not vouch for
+
+- **The immutability contract.** The identity shortcut in `saveSites` assumes no
+  caller mutates a site returned by the store in place. I grepped for in-place
+  property assignment on sites across `frontend/src` and found none — every
+  update is a spread, which is what React state requires anyway — and the
+  contract is documented at the top of the module. But it is a convention, not
+  something the type system enforces, and a future caller that mutates in place
+  and then calls `saveSites` would have its change silently dropped.
+  Two things limit the blast radius: `saveSite` (the single-site path every
+  interactive editor uses — `App.tsx`, `IndicatorEditorPage.tsx`, `MapView.tsx`)
+  **never** takes the shortcut and always writes; and `invalidateSiteCache` is
+  exported. If someone wants belt and braces, the next step would be a dev-mode
+  assertion that re-serialises and compares on the skip path — I left it out
+  because it would restore exactly the O(store) cost in development and make dev
+  unrepresentative of production.
+- **Same-tab external mutation of localStorage.** `storage` events only fire in
+  *other* tabs. If something in this tab writes `dt-site:*` or clears
+  localStorage without going through this module, the cache goes stale.
+  `clearSiteStore()` handles the test path; nothing else in the app does this
+  today.
+- **Serialisation stability.** The "unfamiliar but identical" comparison assumes
+  `JSON.stringify(normaliseForStorage(JSON.parse(raw))) === raw`. That holds
+  because `JSON.parse` and object spread both preserve source key order for
+  string keys, and site objects have string keys. It would not hold for
+  integer-like top-level keys. Not a case that occurs, but it is an assumption.
+- The benchmark numbers are jsdom, not a browser. The ratio and the flatness are
+  what matter; the absolute milliseconds will differ.
+
+## Tests
+
+`npx vitest run` in `frontend/`:
+
+- before: 19 files, 127 tests, all passing
+- after: 19 files, 143 tests, all passing
+
+`npx tsc --noEmit` and `npx eslint` clean.
+
+16 new tests in `src/test/siteStore.test.ts`, under `what a save actually costs`,
+`what a save touches, observed from outside`, and `the cache never outlives what
+it describes`. I checked they fail against the previous implementation: stubbing
+the new exports onto `HEAD`'s `siteStore.ts` and running the file gives 8
+failures, including the spy-based one that observes reads and writes from outside
+the module and so does not depend on the new counters.
+
+Note `frontend/node_modules` in this worktree is a symlink to the one in the main
+checkout, so the suite could be run without an install. Remove it before doing
+anything that writes to `node_modules`.

--- a/frontend/src/lib/siteStore.ts
+++ b/frontend/src/lib/siteStore.ts
@@ -24,6 +24,64 @@ import { safeSetItem, safeRemoveItem } from './storage';
  * costs the size of that record rather than the size of the store. Sites are
  * normalised on the way in: the breakdown is dropped, and so is the duplicated
  * id list if an old document still carries it.
+ *
+ * ## Why one key per site was not enough on its own
+ *
+ * Splitting the keys fixed the *write*, not the work around it. The three bulk
+ * callers in hooks/useApi.ts — create, update, delete a site — still do
+ * load-everything, change one entry, write-everything-back, because that is the
+ * shape the API has always had. Against per-site records that became: parse all
+ * N records on the way in, then re-serialise all N on the way out to work out
+ * which one differed. Same O(store) main-thread cost as the blob, spread over
+ * more keys.
+ *
+ * So this module keeps a **record cache**: for each id, the object it last
+ * handed out or wrote, and the exact string that object serialises to. That
+ * buys two things.
+ *
+ *   - A read whose stored string is unchanged returns the cached object without
+ *     parsing.
+ *   - A bulk write can recognise an unchanged site by **reference identity** —
+ *     it is the very object the cache handed out — and skip serialising it
+ *     entirely. One changed site out of N costs one `JSON.stringify`, not N.
+ *
+ * ## The contract that makes that sound
+ *
+ * **Sites handed out by this module are values. Do not mutate one in place.**
+ * Change a site by building a new object (`{ ...site, title }`), which is what
+ * React state requires anyway and what every caller in this codebase already
+ * does. A site mutated in place is indistinguishable, cheaply, from one that
+ * was not, and the bulk path would skip writing it.
+ *
+ * Two things keep that from being a trap:
+ *
+ *   - `saveSite` — the explicit single-site write, and the one every interactive
+ *     editor uses — **never** takes the identity shortcut. If a caller says a
+ *     site changed, it is written. The shortcut applies only to `saveSites`,
+ *     whose whole job is to work out which of a list changed.
+ *   - `invalidateSiteCache` is exported for anything that needs to opt out.
+ *
+ * ## What is not deferred
+ *
+ * Writes are still synchronous and still happen on the call. Nothing is
+ * debounced, batched or queued, so there is **no window in which an accepted
+ * save has not reached disk** — close the tab immediately after a save returns
+ * true and the work is there. Making saves cheaper was the fix; making them
+ * later would have traded the user's only copy of their work for smoothness.
+ *
+ * Moving the work off the main thread proper is not possible here: Web Storage
+ * is not exposed to workers. Storing in IndexedDB, which is, is issue #72.
+ *
+ * ## One cost left, on purpose
+ *
+ * Every read and write still probes the legacy `dt-sites` key first. Once it has
+ * been migrated the key is gone and the probe is a null lookup, so it costs
+ * nothing worth caching — and not caching it means a `dt-sites` written later,
+ * by an import or a restore, is still picked up. In the one state where the
+ * probe is expensive, a migration that failed because storage was full, the blob
+ * is re-read and re-parsed on every save; that is deliberate, because in that
+ * state the blob is still the user's only copy and every attempt is a chance to
+ * rescue it.
  */
 
 const INDEX_KEY = 'dt-site-index';
@@ -45,6 +103,107 @@ function recordKey(id: string): string {
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && !!window.localStorage;
+}
+
+/**
+ * How much work the store has done, in the units that actually cost something.
+ *
+ * Exists because "a save is proportional to what changed" is only a claim until
+ * it is counted. The tests assert on these: saving one site out of fifty must
+ * serialise one site, not fifty.
+ */
+export interface SiteStoreStats {
+  /** Sites put through `JSON.stringify`. */
+  serialised: number;
+  /** Records put through `JSON.parse`. */
+  parsed: number;
+  /** `getItem` calls for site records. */
+  recordReads: number;
+  /** `setItem` calls for site records. */
+  recordWrites: number;
+  /** `setItem` calls for the index. */
+  indexWrites: number;
+}
+
+const stats: SiteStoreStats = {
+  serialised: 0,
+  parsed: 0,
+  recordReads: 0,
+  recordWrites: 0,
+  indexWrites: 0,
+};
+
+export function getSiteStoreStats(): SiteStoreStats {
+  return { ...stats };
+}
+
+export function resetSiteStoreStats(): void {
+  stats.serialised = 0;
+  stats.parsed = 0;
+  stats.recordReads = 0;
+  stats.recordWrites = 0;
+  stats.indexWrites = 0;
+}
+
+/**
+ * One entry per known record: the object callers hold, and the string that is
+ * in storage for it.
+ *
+ * `raw` is only ever set from a read that succeeded or a write that succeeded,
+ * so it is what is on disk, never what we hoped was.
+ */
+interface CachedRecord {
+  site: Site;
+  raw: string;
+}
+
+const recordCache = new Map<string, CachedRecord>();
+
+/** The index, when it is known to match storage. Null means "go and read it". */
+let indexCache: string[] | null = null;
+
+function forgetEverything(): void {
+  recordCache.clear();
+  indexCache = null;
+}
+
+/**
+ * Drop cached knowledge of a record, or of all of them.
+ *
+ * The escape hatch for the immutability contract above: anything that has
+ * changed a site in place, or changed storage behind this module's back, calls
+ * this and the next read or write goes to storage.
+ */
+export function invalidateSiteCache(id?: string): void {
+  if (id === undefined) {
+    forgetEverything();
+    return;
+  }
+  recordCache.delete(id);
+}
+
+/**
+ * Another tab wrote to our storage, so what we have cached may be stale.
+ *
+ * `storage` events fire in every tab *except* the one that wrote, which is
+ * exactly the set of tabs whose caches are now wrong. Without this, two tabs
+ * open on the same sites would each keep serving their own stale copy — and
+ * worse, the identity shortcut in `saveSites` would decide a record needed no
+ * write when the other tab had already replaced it.
+ */
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('storage', (event: StorageEvent) => {
+    // A null key means the whole area was cleared.
+    if (event.key === null) {
+      forgetEverything();
+      return;
+    }
+    if (event.key === INDEX_KEY) {
+      indexCache = null;
+    } else if (event.key.startsWith(RECORD_PREFIX)) {
+      recordCache.delete(event.key.slice(RECORD_PREFIX.length));
+    }
+  });
 }
 
 /**
@@ -73,29 +232,109 @@ export function normaliseForStorage(site: Site): Site {
   return copy as unknown as Site;
 }
 
+/** The one place a site becomes a string, so the cost has somewhere to be counted. */
+function serialise(site: Site): string {
+  stats.serialised++;
+  return JSON.stringify(normaliseForStorage(site));
+}
+
+function getRecordRaw(id: string): string | null {
+  if (!isBrowser()) return null;
+  try {
+    stats.recordReads++;
+    return window.localStorage.getItem(recordKey(id));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a record and remember it.
+ *
+ * The cache entry is set only when the write succeeded, and cleared when it did
+ * not — so a quota failure can never leave this module believing a site is
+ * stored when it is not. That is the whole point of `safeSetItem` returning a
+ * boolean, and losing it here would recreate the silent-loss bug one level up.
+ */
+function writeRecord(site: Site, raw: string): boolean {
+  stats.recordWrites++;
+  if (!safeSetItem(recordKey(site.id), raw)) {
+    recordCache.delete(site.id);
+    return false;
+  }
+  recordCache.set(site.id, { site, raw });
+  return true;
+}
+
 function readIndex(): string[] {
   if (!isBrowser()) return [];
+  if (indexCache) return indexCache;
   try {
     const raw = window.localStorage.getItem(INDEX_KEY);
-    if (!raw) return [];
+    if (!raw) {
+      indexCache = [];
+      return indexCache;
+    }
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+    indexCache = Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : [];
+    return indexCache;
   } catch {
     return [];
   }
 }
 
-function writeIndex(ids: string[]): boolean {
-  return safeSetItem(INDEX_KEY, JSON.stringify(ids));
+function sameIds(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
+/**
+ * Write the index, unless it already says this.
+ *
+ * The bulk path used to rewrite the index on every save even when membership
+ * and order were unchanged, which is most saves.
+ */
+function writeIndex(ids: string[]): boolean {
+  if (indexCache && sameIds(indexCache, ids)) return true;
+  stats.indexWrites++;
+  if (!safeSetItem(INDEX_KEY, JSON.stringify(ids))) {
+    indexCache = null;
+    return false;
+  }
+  indexCache = ids.slice();
+  return true;
+}
+
+/**
+ * Read one record, parsing only when the stored string is not the one already
+ * parsed.
+ *
+ * Returns the cached object itself, not a copy — see the immutability contract
+ * at the top of this file. Handing out a stable reference is what lets a later
+ * `saveSites` recognise an untouched site for free.
+ */
 function readRecord(id: string): Site | null {
   if (!isBrowser()) return null;
+
+  const raw = getRecordRaw(id);
+  if (!raw) {
+    recordCache.delete(id);
+    return null;
+  }
+
+  const cached = recordCache.get(id);
+  if (cached && cached.raw === raw) return cached.site;
+
   try {
-    const raw = window.localStorage.getItem(recordKey(id));
-    if (!raw) return null;
+    stats.parsed++;
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as Site) : null;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const site = parsed as Site;
+    recordCache.set(id, { site, raw });
+    return site;
   } catch {
     return null;
   }
@@ -134,9 +373,9 @@ export function migrateLegacyStore(): Site[] | null {
   const sites = (parsed as Site[]).filter((s) => s && typeof s.id === 'string');
 
   for (const site of sites) {
-    if (!safeSetItem(recordKey(site.id), JSON.stringify(normaliseForStorage(site)))) {
-      return sites;
-    }
+    // Deliberately not retried on failure: the blob below is still the user's
+    // copy, and a reload will try again once there is room.
+    if (!writeRecord(site, serialise(site))) return sites;
   }
   if (!writeIndex(sites.map((s) => s.id))) return sites;
 
@@ -168,6 +407,10 @@ export function loadSite(id: string): Site | null {
 
 /**
  * Write one site. Touches one record, and the index only when the site is new.
+ *
+ * Always writes, even if the site looks unchanged: a caller reaching for this
+ * function is asserting that it changed, and second-guessing that is how work
+ * gets lost. Costs one serialisation regardless of how much is stored.
  */
 export function saveSite(site: Site): boolean {
   if (!isBrowser()) return true;
@@ -175,9 +418,7 @@ export function saveSite(site: Site): boolean {
 
   migrateLegacyStore();
 
-  if (!safeSetItem(recordKey(site.id), JSON.stringify(normaliseForStorage(site)))) {
-    return false;
-  }
+  if (!writeRecord(site, serialise(site))) return false;
 
   const ids = readIndex();
   if (!ids.includes(site.id)) {
@@ -188,11 +429,14 @@ export function saveSite(site: Site): boolean {
 
 /**
  * Write a whole list, as the old whole-store save did — but only the records
- * that actually changed.
+ * that actually changed, and only serialising the ones that might have.
  *
- * Callers overwhelmingly pass the full list back with one site modified. The
- * comparison is against the serialised record, so an unchanged site costs a
- * read and a string compare rather than a write to disk.
+ * Callers overwhelmingly pass the full list back with one site modified, having
+ * got the list from `loadSites`. Every site they did not touch is still the
+ * object this module handed them, so it is recognised by reference and costs
+ * nothing at all. A site that is not recognised is serialised and compared
+ * against what is stored, so an unfamiliar object that happens to be identical
+ * still does not reach disk.
  */
 export function saveSites(sites: Site[]): boolean {
   if (!isBrowser()) return true;
@@ -201,27 +445,37 @@ export function saveSites(sites: Site[]): boolean {
 
   let ok = true;
   const ids: string[] = [];
+  const kept = new Set<string>();
 
   for (const site of sites) {
     if (!site || typeof site.id !== 'string') continue;
     ids.push(site.id);
+    kept.add(site.id);
 
-    const next = JSON.stringify(normaliseForStorage(site));
-    let current: string | null = null;
-    try {
-      current = window.localStorage.getItem(recordKey(site.id));
-    } catch {
-      current = null;
+    // The object we handed out, unchanged. Nothing to serialise, nothing to
+    // write. This is the case that makes a save proportional to the edit.
+    const cached = recordCache.get(site.id);
+    if (cached && cached.site === site) continue;
+
+    const next = serialise(site);
+    // Prefer what the cache knows is on disk over re-reading it; getItem copies
+    // the whole record string, which for a continent-scale site is ~2 M chars.
+    const current = cached ? cached.raw : getRecordRaw(site.id);
+    if (current === next) {
+      recordCache.set(site.id, { site, raw: next });
+      continue;
     }
-    if (current === next) continue;
 
-    if (!safeSetItem(recordKey(site.id), next)) ok = false;
+    if (!writeRecord(site, next)) ok = false;
   }
 
   // Records dropped from the list are deleted, so the store cannot accumulate
   // sites the caller believes it removed.
   for (const id of readIndex()) {
-    if (!ids.includes(id)) safeRemoveItem(recordKey(id));
+    if (!kept.has(id)) {
+      safeRemoveItem(recordKey(id));
+      recordCache.delete(id);
+    }
   }
 
   if (!writeIndex(ids)) ok = false;
@@ -232,14 +486,19 @@ export function deleteSite(id: string): boolean {
   if (!isBrowser()) return true;
   migrateLegacyStore();
   const removed = safeRemoveItem(recordKey(id));
+  recordCache.delete(id);
   const ids = readIndex().filter((entry) => entry !== id);
   return writeIndex(ids) && removed;
 }
 
 /** Test seam: forget everything this module owns. */
 export function clearSiteStore(): void {
-  if (!isBrowser()) return;
+  if (!isBrowser()) {
+    forgetEverything();
+    return;
+  }
   for (const id of readIndex()) safeRemoveItem(recordKey(id));
   safeRemoveItem(INDEX_KEY);
   safeRemoveItem(LEGACY_KEY);
+  forgetEverything();
 }

--- a/frontend/src/test/siteStore.test.ts
+++ b/frontend/src/test/siteStore.test.ts
@@ -3,10 +3,13 @@ import {
   LEGACY_KEY,
   clearSiteStore,
   deleteSite,
+  getSiteStoreStats,
+  invalidateSiteCache,
   loadSite,
   loadSites,
   migrateLegacyStore,
   normaliseForStorage,
+  resetSiteStoreStats,
   saveSite,
   saveSites,
 } from '../lib/siteStore';
@@ -45,6 +48,7 @@ function countWrites() {
 beforeEach(() => {
   window.localStorage.clear();
   clearSiteStore();
+  resetSiteStoreStats();
 });
 
 afterEach(() => {
@@ -225,5 +229,262 @@ describe('reading and writing', () => {
 
   it('refuses a site with no id rather than writing a broken key', () => {
     expect(saveSite({ title: 'no id' } as unknown as Site)).toBe(false);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// The cost of a save
+//
+// Splitting the blob into one key per site fixed the write but not the work
+// around it: the bulk callers still load every site, change one and hand the
+// whole list back, so the store parsed N records on the way in and re-serialised
+// N on the way out to find the one that differed. These tests count that work,
+// because "proportional to what changed" is a claim until it is a number.
+// ---------------------------------------------------------------------------
+
+function manySites(n: number): Site[] {
+  return Array.from({ length: n }, (_, i) => site(`s${i}`, { title: `site ${i}` }));
+}
+
+describe('what a save actually costs', () => {
+  it('serialises one site when one site of fifty changed', () => {
+    saveSites(manySites(50));
+    const loaded = loadSites();
+
+    const changed = [...loaded];
+    changed[17] = { ...loaded[17], title: 'edited' } as Site;
+
+    resetSiteStoreStats();
+    expect(saveSites(changed)).toBe(true);
+    const cost = getSiteStoreStats();
+
+    expect(cost.serialised).toBe(1);
+    expect(cost.recordWrites).toBe(1);
+    // Membership and order did not change, so the index does not need rewriting.
+    expect(cost.indexWrites).toBe(0);
+    // And nothing had to be read back to work out which record differed.
+    expect(cost.recordReads).toBe(0);
+    expect(cost.parsed).toBe(0);
+  });
+
+  it('costs the same with fifty sites stored as with five — that is the whole issue', () => {
+    function costOfOneEdit(n: number) {
+      window.localStorage.clear();
+      clearSiteStore();
+      saveSites(manySites(n));
+      const loaded = loadSites();
+      const changed = [...loaded];
+      changed[1] = { ...loaded[1], title: 'edited' } as Site;
+      resetSiteStoreStats();
+      saveSites(changed);
+      return getSiteStoreStats();
+    }
+
+    expect(costOfOneEdit(50)).toEqual(costOfOneEdit(5));
+  });
+
+  it('does no work at all when nothing changed', () => {
+    saveSites(manySites(20));
+    const loaded = loadSites();
+
+    resetSiteStoreStats();
+    expect(saveSites(loaded)).toBe(true);
+
+    expect(getSiteStoreStats()).toMatchObject({
+      serialised: 0,
+      recordWrites: 0,
+      indexWrites: 0,
+      parsed: 0,
+    });
+  });
+
+  it('still recognises an equal site it has never seen the object of', () => {
+    // A caller that rebuilt the list from somewhere else gets no identity hit,
+    // so the record is serialised — but an identical string must not be written.
+    saveSites(manySites(3));
+    invalidateSiteCache();
+
+    resetSiteStoreStats();
+    saveSites(manySites(3));
+
+    expect(getSiteStoreStats().serialised).toBe(3);
+    expect(getSiteStoreStats().recordWrites).toBe(0);
+  });
+
+  it('parses each record once however often it is read', () => {
+    saveSites(manySites(10));
+    invalidateSiteCache();
+
+    resetSiteStoreStats();
+    loadSites();
+    const first = getSiteStoreStats().parsed;
+    loadSites();
+    loadSites();
+    const total = getSiteStoreStats().parsed;
+
+    expect(first).toBe(10);
+    expect(total).toBe(10);
+  });
+
+  it('hands out a stable reference, which is what makes the shortcut sound', () => {
+    saveSites(manySites(3));
+    invalidateSiteCache();
+
+    const a = loadSites();
+    const b = loadSites();
+
+    expect(a[0]).toBe(b[0]);
+    expect(a[2]).toBe(b[2]);
+  });
+
+  it('writes the index only when membership or order changed', () => {
+    saveSites(manySites(3));
+
+    resetSiteStoreStats();
+    saveSites([...loadSites()].reverse());
+    expect(getSiteStoreStats().indexWrites).toBe(1);
+
+    resetSiteStoreStats();
+    saveSites(loadSites());
+    expect(getSiteStoreStats().indexWrites).toBe(0);
+
+    expect(loadSites().map((s) => s.id)).toEqual(['s2', 's1', 's0']);
+  });
+
+  it('an explicit single-site save is never skipped, however unchanged it looks', () => {
+    // Durability beats cleverness: a caller reaching for saveSite is asserting
+    // the site changed, and a store that argued would lose someone's work.
+    const s = site('a');
+    saveSite(s);
+
+    resetSiteStoreStats();
+    expect(saveSite(s)).toBe(true);
+
+    expect(getSiteStoreStats().recordWrites).toBe(1);
+  });
+});
+
+// Deliberately spy-based rather than counter-based, so it says something about
+// the store's observable behaviour rather than about its own bookkeeping — and
+// so it can be pointed at any implementation. Against the version that compared
+// each site to storage, this read fifty records to save one.
+describe('what a save touches, observed from outside', () => {
+  it('reads no records to save one site out of fifty', () => {
+    saveSites(manySites(50));
+    const loaded = loadSites();
+    const changed = [...loaded];
+    changed[7] = { ...loaded[7], title: 'edited' } as Site;
+
+    const reads: string[] = [];
+    const writes: string[] = [];
+    const realGet = Storage.prototype.getItem;
+    const realSet = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function (this: Storage, k: string) {
+      reads.push(k);
+      return realGet.call(this, k);
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      k: string,
+      v: string,
+    ) {
+      writes.push(k);
+      realSet.call(this, k, v);
+    });
+
+    saveSites(changed);
+    vi.restoreAllMocks();
+
+    // The version that compared each site against storage read all fifty here.
+    expect(reads.filter((k) => k.startsWith('dt-site:'))).toEqual([]);
+    expect(writes).toEqual(['dt-site:s7']);
+  });
+});
+
+describe('the cache never outlives what it describes', () => {
+  it('does not believe a record is stored when the write failed', () => {
+    const s = site('a', { title: 'precious' });
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(saveSites([s])).toBe(false);
+    vi.restoreAllMocks();
+
+    // Same object, so the identity shortcut would skip it if the failed write
+    // had been cached. It must not have been.
+    expect(saveSites([s])).toBe(true);
+    expect(loadSite('a')?.title).toBe('precious');
+  });
+
+  it('surfaces a quota failure from the list path, not just the single path', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(saveSites([site('a')])).toBe(false);
+  });
+
+  it('surfaces a failure to write the index', () => {
+    saveSites([site('a')]);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      k: string,
+    ) {
+      if (k === 'dt-site-index') throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    // A new site changes membership, so the index must be rewritten.
+    expect(saveSite(site('b'))).toBe(false);
+  });
+
+  it('re-reads a record another tab replaced', () => {
+    saveSites([site('a', { title: 'ours' })]);
+    const ours = loadSites();
+
+    // What another tab writing dt-site:a looks like from in here.
+    window.localStorage.setItem('dt-site:a', JSON.stringify(site('a', { title: 'theirs' })));
+    window.dispatchEvent(new StorageEvent('storage', { key: 'dt-site:a' }));
+
+    expect(loadSite('a')?.title).toBe('theirs');
+
+    // And the stale object we still hold is written back rather than skipped.
+    resetSiteStoreStats();
+    saveSites(ours);
+    expect(getSiteStoreStats().recordWrites).toBe(1);
+    expect(loadSite('a')?.title).toBe('ours');
+  });
+
+  it('forgets everything when another tab clears storage', () => {
+    saveSites([site('a')]);
+    window.localStorage.clear();
+    window.dispatchEvent(new StorageEvent('storage', { key: null }));
+
+    expect(loadSites()).toEqual([]);
+  });
+
+  it('forgets a deleted site rather than serving it from cache', () => {
+    saveSites([site('a'), site('b')]);
+    loadSites();
+    deleteSite('a');
+
+    expect(loadSite('a')).toBeNull();
+    expect(loadSites().map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('migrates the legacy blob even with a warm cache, and indexes it', () => {
+    saveSites([site('kept')]);
+    loadSites();
+
+    window.localStorage.setItem(LEGACY_KEY, JSON.stringify([site('old-a'), site('old-b')]));
+
+    expect(loadSites().map((s) => s.id)).toEqual(['old-a', 'old-b']);
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem('dt-site-index') as string)).toEqual([
+      'old-a',
+      'old-b',
+    ]);
+    // The migrated records are readable through the cache that was already warm.
+    expect(loadSite('old-a')?.title).toBe('site old-a');
   });
 });


### PR DESCRIPTION
Fixes #70

Saving one site cost as much as saving all of them.

The per-record split already landed on `main` — `dt-site:{id}` plus
`dt-site-index` — which fixed the write but not the work around it. The three
bulk callers still loaded every stored site, changed one, and wrote them all
back, so `JSON.parse` and `JSON.stringify` ran across the whole store on the main
thread for every edit. The cost grew with everything a user had ever saved rather
than with what changed.

## What changed

`frontend/src/lib/siteStore.ts` only, plus its tests. A module-level record cache
holding, per id, the object last handed out or written and the exact string it
serialises to.

- Reads re-parse only when the stored string differs, and return the cached
  object — so the reference is stable.
- `saveSites` recognises an untouched site by reference identity and skips
  serialising it. An unrecognised object is still serialised and compared, so
  identical-but-unfamiliar input cannot slip past.
- The index is cached and rewritten only when membership or order changed; it
  used to be rewritten on every bulk save. The removal sweep uses a `Set` rather
  than `Array.includes` in a loop.
- A `storage` event listener drops entries another tab replaced, so the identity
  shortcut cannot skip a write over another tab's value.

## Measured

jsdom, editing one site out of 200, store at 4,091,627 characters — **78% of this
machine's measured 5,241,856-character localStorage ceiling**:

| | before | after |
| --- | --- | --- |
| save | 24.94 ms | **0.28 ms** |
| reload | 17.90 ms | **0.60 ms** |

The figure that matters is not the ratio. It is that the new cost barely moves
between an 807,000-character store (0.21 ms) and a 4.1-million one (0.28 ms): it
is now proportional to the edit, not to the store.

## Durability

**No window is introduced.** Nothing is deferred, debounced or batched; writes
stay synchronous. These records are the user's only copy of their work — sites
live in browser storage by design — so trading durability for latency would be
the wrong trade at any speed.

Quota failures cannot be hidden by the cache: an entry is written only when
`safeSetItem` returned true, and **deleted** when it returned false, so a failed
write can never leave the module believing a site is stored. There is prior art
here — `frontend/test/storage.test.ts` opens with a note recording that every
localStorage write once discarded its error, so saves failed silently once the
quota was exhausted. A test fails the same object twice and then proves the retry
really writes.

## Tests

19 files / 127 tests before → 19 files / **143 tests** after, all passing.
`tsc --noEmit` and `eslint` clean. The 16 new tests were verified to fail against
the old code by stubbing the new exports onto `HEAD`'s `siteStore.ts` — 8
failures — including a spy-based test that observes reads and writes from outside
the module, so it does not depend on the implementation's own counters. The
legacy migration tests are untouched and still green.

No npm dependency added.

## Judgement calls

- **The immutability contract.** The identity shortcut assumes nobody mutates a
  returned site in place. All of `frontend/src` was checked and every site update
  is a spread, and it is documented at the top of the module — but it is a
  convention, not something the type system enforces. The blast radius is
  bounded: `saveSite`, used by `App.tsx`, `IndicatorEditorPage.tsx` and
  `MapView.tsx`, never takes the shortcut and always writes. A dev-mode
  re-serialise-and-verify assertion was considered and rejected because it would
  restore the full O(store) cost in development.
- A once-per-session migration flag was tried and **backed out**:
  `sessionSites.test.ts` writes `dt-sites` part-way through a file and expects it
  to be picked up, and an import or restore path could legitimately do the same.
  The legacy probe still runs on every call — a null lookup after migration.

## Out of scope

The bulk API in `hooks/useApi.ts` is the deeper problem: `updateSite` could be
`loadSite(id)` → spread → `saveSite` and be O(1) with no cache at all. That file
belongs to #60 and was left alone; worth a follow-up issue.

Not attempted: moving to IndexedDB, which is #72.
