### PR TITLE
perf(frontend): share, order and cancel requests on map interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,6 +485,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance opens there rather than at the default world view, so a release and
   recreate does not move the map under the user.
 
+- **Panning the map re-asked questions whose answers could not have changed.**
+  `ViewPane` and `ChartView` both listed the map extent as an effect dependency
+  regardless of range mode, and the extent is a fresh object on every move — so a
+  pan re-issued full-domain queries that do not depend on the extent at all. At
+  4.77 seconds per full-domain `/api/aggregate` request, a scripted six-pane
+  session of one mount and five pans issued **216 chart-pane requests where 6 were
+  needed, and 72 dial-pane requests where 2 were** — roughly 1,030 seconds of
+  server work reduced to about 29.
+
+  Overlapping work is now ordered as well as reduced. `applyColors` is called from
+  sixteen places and is asynchronous throughout, so runs routinely overlapped and
+  nothing sequenced them: whichever response arrived last painted the map,
+  regardless of which viewport, scenario or attribute the user had asked for. Each
+  run now carries a monotonic ticket that is checked after every await, and
+  superseding a run aborts the requests it no longer needs.
+
+  A shared-request primitive replaces two hand-rolled promise caches. It shares one
+  in-flight request per key, cancels it when nothing wants it, and counts
+  subscribers — so one pane navigating away cannot cancel a request the other
+  eleven are waiting on.
+
+  The choropleth request count is deliberately unchanged: the existing cache
+  already deduplicated those across panes. What changed there is that superseded
+  requests are now cancelled rather than merely ignored, which frees the
+  connection instead of leaving both ends busy.
+
+- **A transient server error was cached as "no data" for a full minute.** The
+  choropleth cache stored a promise that swallowed its own errors and resolved to
+  `null`, so a single 500 response left the map blank for the whole 60-second TTL
+  even after the server recovered. Rejections are no longer cached.
+
 - **The choropleth is served as vector tiles instead of a GeoJSON source.** The tile
   pipeline already carried the catchment polygons — `gpkg_to_mbtiles.sh` tiles
   `catchments_lev12` alongside the basemap layers — but the layer users actually look

--- a/NOTES-refetch.md
+++ b/NOTES-refetch.md
@@ -1,0 +1,175 @@
+# Issue #60 — frontend re-render and refetch storms on map interaction
+
+Branch `perf/map-refetch-storms`.
+
+## What changed
+
+### `frontend/src/lib/sharedRequest.ts` (new)
+
+One primitive replacing the two hand-rolled promise caches in `MapView.tsx`. It
+does three things that have to be done together to be correct:
+
+- **Shares** one in-flight request per key, so N panes asking the same question
+  make one request. (The old caches already did this.)
+- **Cancels** a request via `AbortController` once nothing wants it, so the
+  connection is freed and the server can stop, rather than the response merely
+  being ignored. The backend does not honour cancellation yet — that is
+  `fix/db-context-cancellation` — so this gets better, it does not get worse.
+- **Counts subscribers**, so one caller losing interest never cancels a request
+  the other eleven panes are still waiting for. This is the part that makes the
+  first two safe to combine and the easiest to break by accident.
+
+There is a 50 ms grace period before the abort actually fires. `applyColors`
+supersedes its own previous run before it knows whether any parameter changed,
+so an immediate abort would cancel a request the very next tick wants back and
+cost a second round trip. 50 ms is nothing against a 4-second query.
+
+Rejections are never cached. The old `_choroplethCache` swallowed errors inside
+the cached promise and resolved to `null`, so a transient failure was cached as
+"no data" for the full 60-second TTL and the `promise.catch(...)` cleanup beside
+it was dead code. That is fixed as a side effect.
+
+### `frontend/src/hooks/useApi.ts`
+
+New `fetchAggregate(params, signal)` — the single deduplicated, cancellable
+entry point to `/api/aggregate`, 5-minute TTL. Three call sites used to issue
+that endpoint independently with no coordination at all.
+
+Caching by full query string is safe here specifically because
+`handleAggregateData` reads scenario, attributes, bbox and bound and nothing
+else — no site, no user state. The choropleth caches keep their existing and
+deliberate bypass when site ideal overrides are present, where the same URL
+means different things to different users; both are now commented so the next
+person does not "optimise" it away.
+
+### `frontend/src/components/MapView.tsx`
+
+- **Run tickets.** `applyColors` is invoked from sixteen places and is
+  asynchronous throughout, so two runs are routinely in flight together. Nothing
+  ordered them: whichever response landed last painted the map. Each run now
+  takes a monotonic ticket and checks it after every await and inside every
+  deferred `once('idle')` apply; only the newest ticket may publish statistics or
+  touch a layer. Superseding a run aborts its requests.
+- Abort controllers on the full-domain and site-scoped statistics effects, which
+  issue `valuesOnly` requests over the whole dataset and previously ran to
+  completion after the attribute they were for had changed.
+- `onMapExtentChange` no longer reports an extent identical to the last one it
+  reported. Every report lands in App state and re-renders the whole pane tree;
+  `moveend` fires for compare-map sync, resizes, style reloads and re-fits onto
+  the bounds already shown.
+
+### `frontend/src/components/ViewPane.tsx` and `ChartView.tsx`
+
+Both listed `mapExtent` — a fresh object on every map move — as an effect
+dependency regardless of range mode. In Full-domain mode the extent is never
+read, so every pan re-issued queries whose answers could not have changed. Both
+now depend on `aggregateExtentQuery`, a string that is empty unless the extent
+is genuinely part of the question, and both route through `fetchAggregate` with
+an abort on cleanup.
+
+ChartView's retry-with-backoff is preserved and now sits outside `fetchAggregate`
+(a rejected shared request is dropped from the cache, so each attempt is a
+genuinely fresh one). A cancellation is not retried.
+
+## What I measured, and how
+
+Request counts under a scripted interaction, run against the code before and
+after with everything else held fixed: six panes, mount plus five pans, jsdom
+with a counting `fetch`. Throwaway harnesses; the assertions that survive are in
+the test files listed below.
+
+| Scenario | Endpoint | Before | After |
+|---|---|---|---|
+| 6 dial panes, Full-domain range, mount + 5 pans | `/api/aggregate` | 72 | **2** |
+| 6 dial panes, Extent range, mount + 5 pans | `/api/aggregate` | 72 | **12** |
+| 6 chart panes, Full-domain range, mount + 5 pans | `/api/aggregate` | 216 | **6** |
+| 6 chart panes, Extent range, mount + 5 pans | `/api/aggregate` | 216 | **36** |
+| 6 map panes, mount + 5 pans | `/api/choropleth` | 12 | 12 (10 now aborted) |
+
+Against the 4.77 s per full-domain aggregate quoted in the issue, the chart-view
+row is roughly 1030 s of server work reduced to roughly 29 s for that
+interaction. I did not re-measure server-side timings myself; the per-request
+figures are the ones given to me.
+
+The choropleth row is the honest one: the count does not change, because the
+existing promise cache already deduplicated across panes. What changes there is
+that ten of the twelve are now genuinely cancelled instead of running to
+completion into a discarded result, and that responses can no longer be applied
+out of order. Those are the two things the map-side tests assert.
+
+Suite: **127 tests / 19 files before, 148 / 22 after, all passing**
+(`cd frontend && npx vitest run`). `npx tsc --noEmit` and `npm run lint`
+(`--max-warnings 0`) are both clean.
+
+### Tests, and that they fail without the change
+
+- `src/test/aggregateFanout.test.tsx` — 4 of its 5 fail against the original
+  `ViewPane.tsx` (verified by stashing it): fan-out, the two irrelevant-re-run
+  cases, and cancellation.
+- `src/test/mapRefetchStorms.test.tsx` — 3 of its 5 fail against the original
+  `MapView.tsx`: cancellation of a superseded request, the out-of-order case
+  (old viewport answers last and must not paint), and extent-report deduping.
+  The other two pass before and after; the pane fan-out one documents behaviour
+  the old cache already had, and is there so the rewrite cannot lose it.
+- `src/test/sharedRequest.test.ts` — the primitive itself, including the case
+  that matters most: one caller leaving must not cancel the request for the
+  others.
+
+`src/test/choroplethRenderPath.test.ts` asserts the render path by matching
+source, and one assertion had to change: the values fetch now carries a signal,
+so the call no longer ends immediately after the URL. The regex was tightened to
+require the signal rather than loosened to ignore it.
+
+## What I deliberately left alone
+
+- **The 300 ms `moveend` debounce.** It is doing its job; the storm was
+  downstream of it.
+- **The GeoJSON vs vector-tile decision** and everything about how layers are
+  painted. Not this issue.
+- **`lib/siteStore.ts` and `lib/storage.ts`** — another agent's territory, and
+  nothing here needed them.
+- **Backend cancellation.** Aborting is right regardless, and
+  `fix/db-context-cancellation` is the other half.
+- **`CHANGELOG.md` and the version bump**, as instructed, to avoid conflicting
+  with the other two branches at integration. The version bump for this is a
+  minor (`0.4.0` → `0.5.0`) if you want one — behaviour-preserving performance
+  work with new internal API.
+
+## Found along the way, outside this issue
+
+- **`ChartView.tsx` is outside the territory I was given.** I changed it anyway,
+  because it is where the largest measured cost lives (216 requests → 6) and the
+  brief called it out explicitly. The change is confined to the two aggregate
+  effects and their imports. Flagging it so you can check it against whatever
+  else is in flight.
+- **Failures were being cached as data.** Described above; a fixed side effect,
+  but it means a user who hit a transient 500 saw an empty map for a full minute
+  with no way to retry but to pan somewhere else and back.
+- **`applyColors` is called from sixteen places**, several of them in bursts
+  during mount. The ticket makes that harmless rather than expensive, but the
+  call graph is still worth untangling; it is not something to do under a
+  performance issue.
+- **`mapViewDeps.test.ts` exists because the repo has no working
+  `react-hooks/exhaustive-deps` enforcement.** `mapExtent`-shaped dependency bugs
+  are exactly what that rule catches, and this issue is the second instance. The
+  eslint config is there but the rule is evidently not biting; worth its own
+  issue.
+
+## What I would not vouch for
+
+- **The 50 ms abort grace is a judgement, not a measurement.** It is chosen to
+  survive a same-key re-subscribe across a microtask boundary. If a caller
+  re-subscribes across a *real* network round trip instead, the abort fires and
+  the next run pays for a fresh request — no worse than the old behaviour, but
+  not free either.
+- **The measurements are jsdom request counts, not a browser profile.** They
+  count what goes on the wire and are accurate for that. I did not run the real
+  application against a real datapack, so I have not watched a frame-time graph
+  or confirmed what any of this feels like to a user.
+- **The chart view's grouped series is not exercised by a test.** Standing it up
+  needs plotly plus grouping-metadata fixtures. Its measured numbers above come
+  from the summary series path; the grouped effect got the same treatment and I
+  am reasoning by symmetry that it behaves the same way.
+- **`superseded()` covers `applyColors`. It does not cover every asynchronous
+  path in `MapView.tsx`** — the boundary-layer and identify paths have their own
+  timing and I did not audit them.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -446,6 +446,17 @@ Violet → Indigo → Blue → Cyan → Green → Yellow → Orange → Red
 ## Performance Considerations
 
 - GeoJSON caching with 300ms debounce
+- One shared, cancellable request per distinct question (`frontend/src/lib/sharedRequest.ts`):
+  every pane asking the same thing at the same moment produces one request, and a
+  request the user's next interaction has made pointless is aborted rather than
+  merely ignored. Applies to `/api/choropleth`, `/api/catchment-values` and
+  `/api/aggregate`. Requests carrying site ideal overrides are deliberately
+  excluded — the URL is not the whole of the question for those.
+- Choropleth responses are applied in request order: a run superseded by a later
+  one never paints, so an out-of-order completion cannot leave the map showing a
+  viewport, scenario or attribute the user has left
+- Aggregate fetches are scoped to the range mode, so panning does not re-request
+  full-domain values that cannot have changed
 - Viewport-limited choropleth queries (max 2000 features)
 - Pre-computed geojson column in GeoPackage
 - R-tree spatial index for fast bbox queries

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -20,8 +20,9 @@ function Plot(props: PlotProps) {
     </Suspense>
   );
 }
-import { getSiteCatchments, getSiteWhiskerBounds, useAttributeAxisLabels, useAttributeGroupingVariables, useAttributeVariableTypes, useColumns, useAttributeUnits, useAttributeXAxisLabels, useAttributeChartTypes } from '../hooks/useApi';
+import { fetchAggregate, getSiteCatchments, getSiteWhiskerBounds, useAttributeAxisLabels, useAttributeGroupingVariables, useAttributeVariableTypes, useColumns, useAttributeUnits, useAttributeXAxisLabels, useAttributeChartTypes } from '../hooks/useApi';
 import type { WhiskerBoundsResponse } from '../hooks/useApi';
+import { isAbortError } from '../lib/sharedRequest';
 import type { SiteIndicators, MapExtent, MapStatistics, RangeMode, Scenario, ZoneStats, CatchmentIndicators } from '../types';
 import { computeAOIWeightedScenarioValues } from '../utils/indicators';
 
@@ -537,6 +538,28 @@ function ChartView({
     return () => { cancelled = true; whiskerCancelled = true; };
   }, [siteIndicators, siteId, visible, rangeMode]);
 
+  /**
+   * The bbox these aggregates are scoped to, as a string, or '' when the range
+   * mode does not use one.
+   *
+   * Both effects below listed mapExtent, which is a new object on every map
+   * move. Each issues six /api/aggregate requests; a full-domain one measures
+   * around 4.8 seconds. In Full-domain mode the extent is never read, so every
+   * pan was firing six seconds-long queries per pane whose answers were
+   * identical to the ones already held. This is the single largest piece of
+   * wasted work on the interaction path.
+   */
+  const aggregateExtentQuery = useMemo(() => {
+    if (rangeMode !== 'extent' || !mapExtent?.bounds) return '';
+    const [minx, miny, maxx, maxy] = mapExtent.bounds;
+    return new URLSearchParams({
+      minx: String(minx),
+      miny: String(miny),
+      maxx: String(maxx),
+      maxy: String(maxy),
+    }).toString();
+  }, [rangeMode, mapExtent]);
+
   useEffect(() => {
     if (!visible || !chartGroup || !chartAxisLabelFilter) {
       setGroupedRangeData(null);
@@ -557,24 +580,31 @@ function ChartView({
       return;
     }
 
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setGroupedRangeData(null);
       setGroupedRangeLoading(false);
       return;
     }
 
     let cancelled = false;
+    const abort = new AbortController();
     setGroupedRangeLoading(true);
 
-    const fetchWithRetry = async (url: string): Promise<Response> => {
+    /**
+     * Retry kept from the original: these are long queries and a transient
+     * failure used to lose the whole chart. It sits outside fetchAggregate
+     * rather than inside it because a rejected shared request is dropped from
+     * the cache, so each attempt is a genuinely fresh one. A cancellation is
+     * not retried — nobody is waiting for the answer.
+     */
+    const aggregateWithRetry = async (params: URLSearchParams): Promise<Record<string, number>> => {
       const maxAttempts = 3;
       let lastErr: unknown;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         try {
-          const resp = await fetch(url);
-          if (resp.ok) return resp;
-          lastErr = new Error(`HTTP ${resp.status}`);
+          return await fetchAggregate(params, abort.signal);
         } catch (err) {
+          if (isAbortError(err)) throw err;
           lastErr = err;
         }
         if (attempt < maxAttempts) {
@@ -595,24 +625,12 @@ function ChartView({
 
       const merged: Record<string, number> = {};
       for (const batch of batches) {
-        const params = new URLSearchParams({
-          scenario,
-          attributes: batch.join(','),
-        });
+        const params = new URLSearchParams(aggregateExtentQuery);
+        params.set('scenario', scenario);
+        params.set('attributes', batch.join(','));
         if (bound) params.set('bound', bound);
 
-        if (rangeMode === 'extent' && mapExtent?.bounds) {
-          const [minx, miny, maxx, maxy] = mapExtent.bounds;
-          params.set('minx', String(minx));
-          params.set('miny', String(miny));
-          params.set('maxx', String(maxx));
-          params.set('maxy', String(maxy));
-        }
-
-        const resp = await fetchWithRetry(`/api/aggregate?${params.toString()}`);
-
-        const payload = await resp.json() as Record<string, number>;
-        Object.assign(merged, payload);
+        Object.assign(merged, await aggregateWithRetry(params));
       }
 
       return merged;
@@ -642,8 +660,9 @@ function ChartView({
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
-  }, [visible, chartGroup, chartAxisLabelFilter, rangeMode, mapExtent, groupedDisplayColumns]);
+  }, [visible, chartGroup, chartAxisLabelFilter, rangeMode, aggregateExtentQuery, groupedDisplayColumns]);
 
   // Fetch aggregate ref/cur for the single selected attribute in extent/domain mode.
   // The grouped chart has its own equivalent (groupedRangeData); this covers the summary chart.
@@ -653,37 +672,32 @@ function ChartView({
       setSummaryRangeLoading(false);
       return;
     }
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setSummaryRangeData(null);
       setSummaryRangeLoading(false);
       return;
     }
 
     let cancelled = false;
+    const abort = new AbortController();
     setSummaryRangeLoading(true);
 
-    const fetchAggregate = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
-      const params = new URLSearchParams({ scenario, attributes: attribute });
+    const summaryAggregate = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
+      const params = new URLSearchParams(aggregateExtentQuery);
+      params.set('scenario', scenario);
+      params.set('attributes', attribute);
       if (bound) params.set('bound', bound);
-      if (rangeMode === 'extent' && mapExtent?.bounds) {
-        const [minx, miny, maxx, maxy] = mapExtent.bounds;
-        params.set('minx', String(minx));
-        params.set('miny', String(miny));
-        params.set('maxx', String(maxx));
-        params.set('maxy', String(maxy));
-      }
-      const resp = await fetch(`/api/aggregate?${params.toString()}`);
-      if (!resp.ok) return {};
-      return resp.json() as Promise<Record<string, number>>;
+      // An empty object on failure, as before — the chart draws what it has.
+      return fetchAggregate(params, abort.signal).catch(() => ({} as Record<string, number>));
     };
 
     Promise.all([
-      fetchAggregate('reference'),
-      fetchAggregate('current'),
-      fetchAggregate('reference', 'lower'),
-      fetchAggregate('reference', 'upper'),
-      fetchAggregate('current', 'lower'),
-      fetchAggregate('current', 'upper'),
+      summaryAggregate('reference'),
+      summaryAggregate('current'),
+      summaryAggregate('reference', 'lower'),
+      summaryAggregate('reference', 'upper'),
+      summaryAggregate('current', 'lower'),
+      summaryAggregate('current', 'upper'),
     ])
       .then(([reference, current, referenceLower, referenceUpper, currentLower, currentUpper]) => {
         if (cancelled) return;
@@ -696,8 +710,8 @@ function ChartView({
         setSummaryRangeLoading(false);
       });
 
-    return () => { cancelled = true; };
-  }, [visible, attribute, rangeMode, mapExtent]);
+    return () => { cancelled = true; abort.abort(); };
+  }, [visible, attribute, rangeMode, aggregateExtentQuery]);
 
   // Build summary chart data (existing behavior)
   const summaryData = useMemo(() => {

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -11,7 +11,7 @@ import { getSite, getSiteCatchments, getSiteAOIFractions, useAttributeColors, us
 import { getAppRuntime } from '../types/runtime';
 import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
-import { evictExpired } from '../lib/ttlCache';
+import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
 import { satelliteAttribution, satelliteTileUrl } from '../lib/satelliteBasemap';
 import {
   PRISM_STOPS,
@@ -587,7 +587,7 @@ export function formatNumber(n: number): string {
 // Module-level cache for pure (no site overrides) choropleth requests.
 // Multiple panes requesting the same scenario+attribute+bbox share one in-flight
 // fetch instead of firing N identical HTTP requests simultaneously.
-const _choroplethCache = new Map<string, { promise: Promise<ChoroplethData | null>; ts: number }>();
+const _choroplethCache: SharedCache<ChoroplethData> = new Map();
 const CHOROPLETH_CACHE_TTL_MS = 60_000;
 
 // Module-level caches for the two expensive synchronous intersection routines.
@@ -651,7 +651,7 @@ interface ChoroplethValues {
 // Companion to _choroplethCache for the values endpoint. Six panes x two
 // scenarios ask for the same viewport at the same moment; one fetch serves all
 // of them.
-const _choroplethValuesCache = new Map<string, { promise: Promise<ChoroplethValues | null>; ts: number }>();
+const _choroplethValuesCache: SharedCache<ChoroplethValues> = new Map();
 
 /**
  * Fetch the attribute values for the current viewport, for the vector-tile
@@ -668,6 +668,7 @@ async function fetchChoroplethValues(
   bounds: maplibregl.LngLatBounds,
   siteId?: string | null,
   idealOverrides?: Map<number, number>,
+  signal?: AbortSignal,
 ): Promise<ChoroplethValues | null> {
   const sw = bounds.getSouthWest();
   const ne = bounds.getNorthEast();
@@ -686,45 +687,49 @@ async function fetchChoroplethValues(
     params.set('siteId', siteId);
   }
 
+  // The same URL means different things once site ideal overrides are in play,
+  // so those requests are never shared or cached. This is deliberate; do not
+  // "optimise" it away without putting the overrides in the key.
   const canCache = !hasSiteOverride && (!idealOverrides || idealOverrides.size === 0);
   const key = params.toString();
-  const now = Date.now();
 
-  if (canCache) {
-    const hit = _choroplethValuesCache.get(key);
-    if (hit && now - hit.ts < CHOROPLETH_CACHE_TTL_MS) return hit.promise;
-    evictExpired(_choroplethValuesCache, CHOROPLETH_CACHE_TTL_MS, now);
-  }
+  const run = async (requestSignal?: AbortSignal): Promise<ChoroplethValues> => {
+    const resp = await fetch(`/api/catchment-values?${params}`, { signal: requestSignal });
+    if (!resp.ok) throw new Error(`catchment values request failed: HTTP ${resp.status}`);
+    return await resp.json() as ChoroplethValues;
+  };
 
-  const promise = (async (): Promise<ChoroplethValues | null> => {
-    try {
-      const resp = await fetch(`/api/catchment-values?${params}`);
-      if (!resp.ok) return null;
-      const data = await resp.json() as ChoroplethValues;
+  try {
+    const data = canCache
+      ? await sharedRequest(_choroplethValuesCache, key, CHOROPLETH_CACHE_TTL_MS, run, signal)
+      : await run(signal);
 
-      if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
-        for (let i = 0; i < data.ids.length; i++) {
-          const override = idealOverrides.get(data.ids[i]);
-          if (override !== undefined) data.values[i] = override;
-        }
+    if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
+      // Only reachable on the uncached path (overrides imply !canCache), which
+      // matters: this mutates the payload in place and a shared one has other
+      // readers.
+      for (let i = 0; i < data.ids.length; i++) {
+        const override = idealOverrides.get(data.ids[i]);
+        if (override !== undefined) data.values[i] = override;
       }
-
-      return data;
-    } catch (err) {
-      console.error('Failed to fetch catchment values:', err);
-      return null;
     }
-  })();
 
-  if (canCache) {
-    promise.catch(() => _choroplethValuesCache.delete(key));
-    _choroplethValuesCache.set(key, { promise, ts: now });
+    return data;
+  } catch (err) {
+    // A cancelled request is not a failure and must not be reported as "no
+    // data" — that would repaint the map as empty for a viewport the user has
+    // already left. Let the caller's staleness check deal with it.
+    if (isAbortError(err)) throw err;
+    console.error('Failed to fetch catchment values:', err);
+    return null;
   }
-  return promise;
 }
 
 /**
  * Fetch choropleth GeoJSON data for the current viewport.
+ *
+ * The expensive one: a full-domain request is seconds and megabytes, so a
+ * superseded one is cancelled rather than merely ignored.
  */
 async function fetchChoroplethData(
   scenario: Scenario,
@@ -733,7 +738,8 @@ async function fetchChoroplethData(
   zoom: number,
   siteId?: string | null,
   idealOverrides?: Map<number, number>,
-  valuesOnly = false
+  valuesOnly = false,
+  signal?: AbortSignal,
 ): Promise<ChoroplethData | null> {
   const sw = bounds.getSouthWest();
   const ne = bounds.getNorthEast();
@@ -760,42 +766,26 @@ async function fetchChoroplethData(
     params.set('siteId', siteId);
   }
 
-  // Deduplicate concurrent requests for pure (non-site-specific) fetches.
+  // Deduplicate concurrent requests for pure (non-site-specific) fetches. As
+  // above, a site override makes the URL an incomplete description of the
+  // question, so those are neither shared nor cached.
   const canCache = !hasSiteOverride && (!idealOverrides || idealOverrides.size === 0);
-  if (canCache) {
-    const key = params.toString();
-    const now = Date.now();
-    const hit = _choroplethCache.get(key);
-    if (hit && now - hit.ts < CHOROPLETH_CACHE_TTL_MS) return hit.promise;
+  const key = params.toString();
 
-    // Keys embed the viewport bbox, which changes on nearly every pan/zoom -
-    // sweep stale entries so this cache doesn't grow unbounded for the life
-    // of the tab (see evictExpired).
-    evictExpired(_choroplethCache, CHOROPLETH_CACHE_TTL_MS, now);
-
-    const promise = (async (): Promise<ChoroplethData | null> => {
-      try {
-        const resp = await fetch(`/api/choropleth?${params}`);
-        if (!resp.ok) return null;
-        return await resp.json() as ChoroplethData;
-      } catch (err) {
-        console.error('Failed to fetch choropleth data:', err);
-        return null;
-      }
-    })();
-
-    promise.catch(() => _choroplethCache.delete(key));
-    _choroplethCache.set(key, { promise, ts: now });
-    return promise;
-  }
+  const run = async (requestSignal?: AbortSignal): Promise<ChoroplethData> => {
+    const resp = await fetch(`/api/choropleth?${params}`, { signal: requestSignal });
+    if (!resp.ok) throw new Error(`choropleth request failed: HTTP ${resp.status}`);
+    return await resp.json() as ChoroplethData;
+  };
 
   try {
-    const resp = await fetch(`/api/choropleth?${params}`);
-    if (!resp.ok) return null;
-    const data: ChoroplethData = await resp.json();
+    const data = canCache
+      ? await sharedRequest(_choroplethCache, key, CHOROPLETH_CACHE_TTL_MS, run, signal)
+      : await run(signal);
 
     // In browser mode the backend store is never updated, so apply per-catchment
-    // ideal overrides client-side for the future scenario.
+    // ideal overrides client-side for the future scenario. Uncached path only,
+    // so the mutation below cannot be seen by another caller.
     if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
       for (const feature of data.features) {
         if (feature.properties.HYBAS_ID === undefined) continue;
@@ -808,6 +798,7 @@ async function fetchChoroplethData(
 
     return data;
   } catch (err) {
+    if (isAbortError(err)) throw err;
     console.error('Failed to fetch choropleth data:', err);
     return null;
   }
@@ -921,6 +912,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   onIdentifyRef.current = onIdentify;
 
   // Store map extent change callback in ref
+  const lastExtentSignatureRef = useRef<string>('');
   const onMapExtentChangeRef = useRef(onMapExtentChange);
   onMapExtentChangeRef.current = onMapExtentChange;
 
@@ -1017,6 +1009,24 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Debounce timer for choropleth fetching
   const fetchTimerRef = useRef<number | null>(null);
 
+  /**
+   * Ordering and cancellation for the choropleth pipeline.
+   *
+   * applyColors is invoked from sixteen places and is asynchronous throughout,
+   * so two runs are routinely in flight together — a pan while the previous
+   * pan's values are still on the wire, an attribute change during a scenario
+   * change. Nothing previously ordered them, so whichever response happened to
+   * land last painted the map, and the map could settle showing the values of a
+   * viewport, scenario or attribute the user had already left. That is the bug
+   * worth fixing here; the wasted work is secondary.
+   *
+   * Every run takes a ticket. Only the holder of the newest ticket is allowed
+   * to publish statistics or touch a layer, and superseding a run aborts its
+   * requests so the connection is freed rather than merely ignored.
+   */
+  const applyColorsRunRef = useRef(0);
+  const applyColorsAbortRef = useRef<AbortController | null>(null);
+
   // Whether the served tileset carries catchment geometry, and from which zoom.
   // Null until resolved, and null for good on a datapack whose tiles predate
   // catchment tiling — in which case every zoom uses the GeoJSON path, exactly
@@ -1034,6 +1044,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // right-side call below either takes a nullable map or is guarded.
     if (!leftMap) return;
     if (!mapsReady.current.left || !mapsReady.current.right) return;
+
+    // Taken only once the run is certain to do something: an early bail on a
+    // map that is not there yet must not cancel a run that is.
+    applyColorsAbortRef.current?.abort();
+    const abort = new AbortController();
+    applyColorsAbortRef.current = abort;
+    const run = ++applyColorsRunRef.current;
+    /** True once a later run has taken over; nothing may be painted after that. */
+    const superseded = () => run !== applyColorsRunRef.current;
 
     if (!isChoroplethEnabledRef.current) {
       removeChoroplethLayers(leftMap, 'left');
@@ -1111,6 +1130,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (getAppRuntime() === 'browser' && siteId &&
         (c.leftScenario === 'future' || c.rightScenario === 'future')) {
       const catchments = await getSiteCatchments(siteId).catch(() => []);
+      if (superseded()) return;
       if (catchments.length > 0 && c.attribute) {
         browserIdealOverrides = new Map();
         for (const cat of catchments) {
@@ -1165,9 +1185,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (tileset && currentZoom >= tileset.minzoom) {
       try {
         const [leftValues, rightValues] = await Promise.all([
-          fetchChoroplethValues(c.leftScenario, c.attribute, bounds, siteId, browserIdealOverrides),
-          fetchChoroplethValues(c.rightScenario, c.attribute, bounds, siteId, browserIdealOverrides),
+          fetchChoroplethValues(c.leftScenario, c.attribute, bounds, siteId, browserIdealOverrides, abort.signal),
+          fetchChoroplethValues(c.rightScenario, c.attribute, bounds, siteId, browserIdealOverrides, abort.signal),
         ]);
+
+        // These answers describe the viewport, scenario and attribute captured
+        // when this run started. If a later run has begun, they describe the
+        // past — publishing them would leave the map and the statistics panel
+        // disagreeing with the controls.
+        if (superseded()) return;
 
         const { min, max } = resolveDomainRange([leftValues, rightValues]);
         publishStats(
@@ -1200,8 +1226,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             // cleared when what it means changes — scenario or attribute.
             stateKey: `${scenario}|${c.attribute}`,
           };
-          const apply = () => applyChoroplethLayer(
-            map, side, layerSource, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          const apply = () => {
+            // The deferred branch below can fire long after the map goes idle,
+            // by which time a later run may own the map.
+            if (superseded()) return;
+            applyChoroplethLayer(
+              map, side, layerSource, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          };
           if (map.loaded()) {
             apply();
           } else {
@@ -1212,7 +1243,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         applySide(leftMap, 'left', leftValues, c.leftScenario);
         applySide(rightMap, 'right', rightValues, c.rightScenario);
       } catch (err) {
-        console.error('Failed to apply choropleth:', err);
+        // A superseded run cancels its own requests; that is the design, not a
+        // failure to report.
+        if (!isAbortError(err)) console.error('Failed to apply choropleth:', err);
       }
       return;
     }
@@ -1220,9 +1253,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     try {
       // Fetch data for both scenarios in parallel
       const [leftData, rightData] = await Promise.all([
-        fetchChoroplethData(c.leftScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides),
-        fetchChoroplethData(c.rightScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides),
+        fetchChoroplethData(c.leftScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides, false, abort.signal),
+        fetchChoroplethData(c.rightScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides, false, abort.signal),
       ]);
+
+      if (superseded()) return;
 
       let siteCatchmentIds = siteId ? siteCatchmentIdsRef.current : null;
 
@@ -1303,6 +1338,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           leftMap.once('idle', () => {
+            if (superseded()) return;
             applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
@@ -1316,6 +1352,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           rightMap.once('idle', () => {
+            if (superseded()) return;
             applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
@@ -1323,7 +1360,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         removeChoroplethLayers(rightMap, 'right');
       }
     } catch (err) {
-      console.error('Failed to apply choropleth:', err);
+      if (!isAbortError(err)) console.error('Failed to apply choropleth:', err);
     }
   // siteId belongs here: the body reads it in ten places — the choropleth fetch
   // for both panes, the browser-runtime ideal overrides, and three per-site
@@ -1388,6 +1425,10 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Compute full-dataset stats so "Full" range has stable values.
   useEffect(() => {
     let cancelled = false;
+    // Full-domain valuesOnly requests are the biggest payload the client asks
+    // for. When the attribute or scenario changes, the previous pair is dead
+    // weight — cancel it rather than let it finish into a discarded result.
+    const abort = new AbortController();
     const c = comparisonRef.current;
 
     if (!c.attribute) {
@@ -1405,8 +1446,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         // sample/aggregate, so fetch every catchment's raw value regardless of
         // viewport zoom (zoom argument is ignored server-side in this mode).
         const [leftData, rightData] = await Promise.all([
-          fetchChoroplethData(c.leftScenario, c.attribute, fullBounds, 0, undefined, undefined, true),
-          fetchChoroplethData(c.rightScenario, c.attribute, fullBounds, 0, undefined, undefined, true),
+          fetchChoroplethData(c.leftScenario, c.attribute, fullBounds, 0, undefined, undefined, true, abort.signal),
+          fetchChoroplethData(c.rightScenario, c.attribute, fullBounds, 0, undefined, undefined, true, abort.signal),
         ]);
 
         if (cancelled) return;
@@ -1425,7 +1466,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           });
         }
       } catch (err) {
-        if (!cancelled) {
+        if (!cancelled && !isAbortError(err)) {
           console.error('Failed to compute full zone statistics:', err);
         }
       }
@@ -1435,6 +1476,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [comparison.leftScenario, comparison.rightScenario, comparison.attribute]);
 
@@ -1564,6 +1606,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // not on global dataset extrema, once a site exists.
   useEffect(() => {
     let cancelled = false;
+    // Site-scoped valuesOnly requests are per-catchment over the site bbox and
+    // re-issued on every scenario, attribute, boundary and refresh change.
+    const abort = new AbortController();
 
     const updateSiteDomainRange = async () => {
       const c = comparisonRef.current;
@@ -1660,8 +1705,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         // the grid-aggregated render path can supply neither, so fetch true
         // per-catchment values regardless of viewport zoom.
         const [leftData, rightData, siteCatchments] = await Promise.all([
-          fetchChoroplethData(c.leftScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true),
-          fetchChoroplethData(c.rightScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true),
+          fetchChoroplethData(c.leftScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true, abort.signal),
+          fetchChoroplethData(c.rightScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true, abort.signal),
           getSiteAOIFractions(siteId).catch(() => []),
         ]);
 
@@ -1771,7 +1816,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         }
         applyColors();
       } catch (err) {
-        if (!cancelled) {
+        if (!cancelled && !isAbortError(err)) {
           console.error('Failed to compute site zone stats:', err);
           siteZoneStatsRef.current = null;
           siteCatchmentIdsRef.current = null;
@@ -1784,6 +1829,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [siteId, siteBounds, siteGeometry, comparison.leftScenario, comparison.rightScenario, comparison.attribute, applyColors, refreshKey]);
 
@@ -2991,11 +3037,18 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // Fetch new choropleth data when map moves (debounced)
     leftMap.on('moveend', () => {
       debouncedApplyColors();
-      // Report map extent changes
+      // Report map extent changes.
+      //
+      // This lands in App state, so every emission re-renders the whole pane
+      // tree and re-runs every effect that lists mapExtent — in quad view, six
+      // panes' worth of dial and chart aggregate fetches. moveend fires for
+      // plenty of things that leave the viewport exactly where it was
+      // (compare-map sync, a resize, a style reload, a re-fit onto the bounds
+      // already shown), so an unchanged extent is not reported at all.
       if (onMapExtentChangeRef.current) {
         const center = leftMap.getCenter();
         const bounds = leftMap.getBounds();
-        onMapExtentChangeRef.current({
+        const extent: MapExtent = {
           center: [center.lng, center.lat],
           zoom: leftMap.getZoom(),
           bounds: [
@@ -3004,7 +3057,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             bounds.getEast(),
             bounds.getNorth(),
           ],
-        });
+        };
+        const signature = `${extent.center.join(',')}|${extent.zoom}|${extent.bounds?.join(',') ?? ''}`;
+        if (signature !== lastExtentSignatureRef.current) {
+          lastExtentSignatureRef.current = signature;
+          onMapExtentChangeRef.current(extent);
+        }
       }
     });
     leftMap.on('zoomend', () => debouncedApplyColors());
@@ -3250,6 +3308,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       if (fetchTimerRef.current) {
         clearTimeout(fetchTimerRef.current);
       }
+      // A pane closing (leaving quad view, switching a pane to a chart) must
+      // not leave its choropleth requests running for a map that no longer
+      // exists. Bumping the ticket too, so a response already on its way back
+      // cannot paint a removed layer.
+      applyColorsRunRef.current += 1;
+      applyColorsAbortRef.current?.abort();
+      applyColorsAbortRef.current = null;
       unregisterMap(syncId);
       slider.removeEventListener('pointerdown', onSliderPointerDown);
       slider.removeEventListener('pointermove', onSliderPointerMove);

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -13,7 +13,7 @@ import DialChart from './DialChart';
 import AggregateTable from './AggregateTable';
 import type { ComparisonState, LayoutMode, QuadColumns, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, ViewMode, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
-import { getSiteCatchments, useAttributeDetails, useAttributeDial0Middle, useAttributeUnits } from '../hooks/useApi';
+import { fetchAggregate, getSiteCatchments, useAttributeDetails, useAttributeDial0Middle, useAttributeUnits } from '../hooks/useApi';
 import type { FullDomainData } from '../hooks/useApi';
 import { COLUMN_FORMULAS, getTriggeredWorkflows } from '../constants/calculationFormulas';
 import { computeAOIWeightedAttributeValue } from '../utils/indicators';
@@ -226,6 +226,29 @@ function ViewPane({
     return () => { cancelled = true; };
   }, [comparison.attribute, siteId, viewMode]);
 
+  /**
+   * The bbox this pane's aggregates are scoped to, as a string, or '' when the
+   * range mode does not use one.
+   *
+   * mapExtent is a fresh object on every map move, and it was a dependency of
+   * the effect below regardless of range mode — so panning the map re-ran the
+   * aggregate fetch even in Full-domain mode, where the extent is not read at
+   * all and the answer cannot change. Six panes, two scenarios, a 4.8-second
+   * full-domain query each. Depending on a string that is only non-empty when
+   * the extent actually matters removes both the identity churn and the
+   * irrelevant re-runs.
+   */
+  const aggregateExtentQuery = useMemo(() => {
+    if (rangeMode !== 'extent' || !mapExtent?.bounds) return '';
+    const [minx, miny, maxx, maxy] = mapExtent.bounds;
+    return new URLSearchParams({
+      minx: String(minx),
+      miny: String(miny),
+      maxx: String(maxx),
+      maxy: String(maxy),
+    }).toString();
+  }, [rangeMode, mapExtent]);
+
   useEffect(() => {
     if (viewMode !== 'dial' || !comparison.attribute) {
       setDialRangeValues(null);
@@ -239,7 +262,7 @@ function ViewPane({
       return;
     }
 
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setDialRangeValues(null);
       setDialRangeLoading(false);
       return;
@@ -259,32 +282,29 @@ function ViewPane({
     }
 
     let cancelled = false;
+    // Cancels the requests, not just their effect: a pan supersedes the
+    // previous extent's aggregates immediately, and every pane is asking.
+    const abort = new AbortController();
     setDialRangeLoading(true);
 
-    const fetchAggregate = async (scenario: string): Promise<number | undefined> => {
-      const params = new URLSearchParams({
-        scenario,
-        attributes: comparison.attribute || '',
-      });
+    const attribute = comparison.attribute || '';
 
-      if (rangeMode === 'extent' && mapExtent?.bounds) {
-        const [minx, miny, maxx, maxy] = mapExtent.bounds;
-        params.set('minx', String(minx));
-        params.set('miny', String(miny));
-        params.set('maxx', String(maxx));
-        params.set('maxy', String(maxy));
-      }
+    const aggregateFor = async (scenario: string): Promise<number | undefined> => {
+      const params = new URLSearchParams(aggregateExtentQuery);
+      params.set('scenario', scenario);
+      params.set('attributes', attribute);
 
-      const resp = await fetch(`/api/aggregate?${params.toString()}`);
-      if (!resp.ok) return undefined;
-      const payload = await resp.json() as Record<string, number>;
-      const value = payload[comparison.attribute || ''];
+      // Shared with every other pane asking the same question, and with the
+      // chart view's summary series. A failure or a cancellation reads as "no
+      // value", exactly as the non-2xx case did before.
+      const payload = await fetchAggregate(params, abort.signal).catch(() => ({} as Record<string, number>));
+      const value = payload[attribute];
       return typeof value === 'number' && !isNaN(value) ? value : undefined;
     };
 
     Promise.all([
-      fetchAggregate(comparison.leftScenario),
-      fetchAggregate(comparison.rightScenario),
+      aggregateFor(comparison.leftScenario),
+      aggregateFor(comparison.rightScenario),
     ]).then(([referenceValue, currentValue]) => {
       if (cancelled) return;
       setDialRangeValues({ referenceValue, currentValue });
@@ -293,14 +313,14 @@ function ViewPane({
       if (!cancelled) { setDialRangeValues(null); setDialRangeLoading(false); }
     });
 
-    return () => { cancelled = true; };
+    return () => { cancelled = true; abort.abort(); };
   }, [
     viewMode,
     rangeMode,
     comparison.attribute,
     comparison.leftScenario,
     comparison.rightScenario,
-    mapExtent,
+    aggregateExtentQuery,
     fullDomainData,
   ]);
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -5,6 +5,7 @@ import { getAppRuntime } from '../types/runtime';
 import { WALKTHROUGH_SITE_IDS } from '../constants/walkthroughSites';
 import { applyAOIWeightedIndicators } from '../utils/indicators';
 import { evictExpired } from '../lib/ttlCache';
+import { sharedRequest, type SharedCache } from '../lib/sharedRequest';
 import { loadSite, loadSites, saveSite, saveSites } from '../lib/siteStore';
 
 const API_BASE = '/api';
@@ -1068,6 +1069,74 @@ export async function getSiteAOIFractions(siteId: string): Promise<{ id: string;
   evictExpired(_aOIFractionsCache, CACHE_TTL_MS, now);
   _aOIFractionsCache.set(siteId, { promise, ts: now });
   return promise;
+}
+
+/**
+ * `/api/aggregate` is the most expensive thing the client asks for — a
+ * full-domain aggregate for a single attribute measures around 4.8 seconds
+ * server-side — and it was the least coordinated. Three call sites issue it
+ * (the dial's range values, and the chart view's grouped and summary series,
+ * the latter two six requests at a time), once per pane, and every one of them
+ * re-ran whenever the map extent object changed identity, whether or not the
+ * range mode even used the extent.
+ *
+ * Routing all of them through one deduplicated, cancellable cache means twelve
+ * panes asking the same question in the same tick produce one request, and a
+ * pan cancels the answer nobody is waiting for any more.
+ *
+ * Caching by the full query string is safe here in a way it is not for the
+ * choropleth: the handler reads scenario, attributes, bbox and bound and
+ * nothing else — no site, no user state — so the URL really is the whole of
+ * the question. (Compare fetchChoroplethValues in MapView, which deliberately
+ * refuses to cache when site ideal overrides are in play, because there the
+ * same URL means different things to different users.)
+ *
+ * Five minutes, because the underlying GeoPackage does not change within a
+ * session; the ceiling is really "how long until the user notices a stale
+ * number", and nothing in this dataset can go stale.
+ */
+const AGGREGATE_CACHE_TTL_MS = 5 * 60_000;
+
+const _aggregateCache: SharedCache<Record<string, number>> = new Map();
+
+/** Test seam: the caches are module state and must not leak between tests. */
+export function __clearAggregateCache(): void {
+  _aggregateCache.clear();
+}
+
+/** Test seam: how many distinct aggregate requests are live. */
+export function __aggregateCacheSize(): number {
+  return _aggregateCache.size;
+}
+
+/**
+ * Fetch area-weighted aggregates, sharing one request per distinct question.
+ *
+ * Abort `signal` when the answer stops being wanted; the underlying request is
+ * only cancelled once no caller wants it. Rejects rather than returning an
+ * empty object on a non-2xx, so a transient failure is not cached as "no data"
+ * for the rest of the TTL window.
+ */
+export function fetchAggregate(
+  params: URLSearchParams,
+  signal?: AbortSignal,
+): Promise<Record<string, number>> {
+  // Sorted so that two call sites building the same question in a different
+  // order still share one request.
+  const key = new URLSearchParams(params);
+  key.sort();
+
+  return sharedRequest(
+    _aggregateCache,
+    key.toString(),
+    AGGREGATE_CACHE_TTL_MS,
+    async (requestSignal) => {
+      const resp = await fetch(`${API_BASE}/aggregate?${key.toString()}`, { signal: requestSignal });
+      if (!resp.ok) throw new Error(`aggregate request failed: HTTP ${resp.status}`);
+      return await resp.json() as Record<string, number>;
+    },
+    signal,
+  );
 }
 
 // FullDomainData holds precomputed area-weighted means for all attributes

--- a/frontend/src/lib/sharedRequest.ts
+++ b/frontend/src/lib/sharedRequest.ts
@@ -1,0 +1,171 @@
+/**
+ * One in-flight request per key, shared by every caller, cancelled once the last
+ * caller has walked away.
+ *
+ * Three separate problems on the map's interaction path, all of which the
+ * existing `Map<string, {promise, ts}>` caches solved only halfway:
+ *
+ *  1. **Fan-out.** Twelve panes ask for the same aggregate or the same viewport's
+ *     catchment values in the same tick. A promise cache collapses those to one
+ *     request — that part already worked.
+ *
+ *  2. **Supersession.** A pan makes the previous viewport's request pointless
+ *     before it lands. Ignoring the answer still leaves the connection and the
+ *     server working on it, so the caller passes an `AbortSignal` and the
+ *     request is really cancelled.
+ *
+ *  3. **The collision between the two.** A shared request has several owners, so
+ *     one owner losing interest must not cancel it for the rest. Subscribers are
+ *     counted, and the abort only fires when the count reaches zero.
+ *
+ * The grace period exists because callers routinely release and re-subscribe to
+ * the same key across an await — MapView's applyColors supersedes its own
+ * previous run before it knows whether the parameters changed. Aborting
+ * immediately would cancel a request the very next tick wants back. Waiting a
+ * few milliseconds costs nothing against a 4-second query and makes the common
+ * "recompute with identical parameters" path free.
+ */
+
+const DEFAULT_ABORT_GRACE_MS = 50;
+
+export interface SharedEntry<T> {
+  promise: Promise<T>;
+  /** Start time, for TTL eviction — see evictExpired. */
+  ts: number;
+  controller: AbortController;
+  subscribers: number;
+  settled: boolean;
+  abortTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export type SharedCache<T> = Map<string, SharedEntry<T>>;
+
+/** True for the rejection an aborted fetch produces, in either shape. */
+export function isAbortError(err: unknown): boolean {
+  if (err instanceof DOMException) return err.name === 'AbortError';
+  return typeof err === 'object' && err !== null && (err as { name?: string }).name === 'AbortError';
+}
+
+function abortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+function subscribe<T>(entry: SharedEntry<T>): void {
+  entry.subscribers += 1;
+  if (entry.abortTimer !== null) {
+    clearTimeout(entry.abortTimer);
+    entry.abortTimer = null;
+  }
+}
+
+function release<T>(cache: SharedCache<T>, key: string, entry: SharedEntry<T>, graceMs: number): void {
+  entry.subscribers -= 1;
+  if (entry.subscribers > 0 || entry.settled || entry.abortTimer !== null) return;
+
+  entry.abortTimer = setTimeout(() => {
+    entry.abortTimer = null;
+    // Someone re-subscribed, or the answer arrived, during the grace period.
+    if (entry.subscribers > 0 || entry.settled) return;
+    entry.controller.abort();
+    if (cache.get(key) === entry) cache.delete(key);
+  }, graceMs);
+}
+
+/**
+ * Reject as soon as this caller's own signal aborts, without disturbing the
+ * shared request that other callers may still be waiting on.
+ */
+function rejectOnAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    const done = () => signal.removeEventListener('abort', onAbort);
+    promise.then(
+      (value) => { done(); resolve(value); },
+      (err) => { done(); reject(err); },
+    );
+  });
+}
+
+/**
+ * Run `work` for `key`, or join the run already under way for it.
+ *
+ * `work` receives the shared `AbortSignal`; pass it to fetch. `signal` is the
+ * caller's own — abort it when this caller's result stops being wanted.
+ *
+ * Rejections are never cached: a failed request must not poison the key for the
+ * rest of the TTL window.
+ */
+export function sharedRequest<T>(
+  cache: SharedCache<T>,
+  key: string,
+  ttlMs: number,
+  work: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+  abortGraceMs: number = DEFAULT_ABORT_GRACE_MS,
+): Promise<T> {
+  if (signal?.aborted) return Promise.reject(abortError());
+
+  const now = Date.now();
+  let entry = cache.get(key);
+
+  // A settled entry is only reusable inside its TTL. An unsettled one is always
+  // reusable — that is the fan-out case, and a slow request should gather
+  // callers rather than spawn duplicates of itself.
+  if (entry && entry.settled && now - entry.ts >= ttlMs) {
+    cache.delete(key);
+    entry = undefined;
+  }
+
+  if (!entry) {
+    // Sweep before inserting: keys embed viewport bounds, so a session of
+    // panning would otherwise grow this map without bound.
+    for (const [otherKey, other] of cache) {
+      if (other.settled && now - other.ts >= ttlMs) cache.delete(otherKey);
+    }
+
+    const controller = new AbortController();
+    const created: SharedEntry<T> = {
+      promise: undefined as unknown as Promise<T>,
+      ts: now,
+      controller,
+      subscribers: 0,
+      settled: false,
+      abortTimer: null,
+    };
+    created.promise = work(controller.signal).then(
+      (value) => {
+        created.settled = true;
+        return value;
+      },
+      (err) => {
+        created.settled = true;
+        if (cache.get(key) === created) cache.delete(key);
+        throw err;
+      },
+    );
+    // Nobody may be awaiting the shared promise directly (every caller awaits
+    // its own rejectOnAbort wrapper), so keep it from counting as unhandled.
+    created.promise.catch(() => undefined);
+    cache.set(key, created);
+    entry = created;
+  }
+
+  if (!signal) {
+    // A caller with no signal never leaves, so the request can never be
+    // abandoned out from under it.
+    subscribe(entry);
+    return entry.promise;
+  }
+
+  const joined = entry;
+  subscribe(joined);
+  const onAbort = () => release(cache, key, joined, abortGraceMs);
+  signal.addEventListener('abort', onAbort, { once: true });
+  joined.promise.then(
+    () => signal.removeEventListener('abort', onAbort),
+    () => signal.removeEventListener('abort', onAbort),
+  );
+
+  return rejectOnAbort(joined.promise, signal);
+}

--- a/frontend/src/test/aggregateFanout.test.tsx
+++ b/frontend/src/test/aggregateFanout.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * /api/aggregate fan-out on map interaction (issue #60).
+ *
+ * The most expensive request the client makes — a full-domain aggregate for a
+ * single attribute measures around 4.8 seconds server-side — and the least
+ * coordinated. Every pane issued its own, none were shared, none were
+ * cancelled, and the effects that issued them listed the map extent object as a
+ * dependency whether or not the range mode used it. So a pan re-asked, per
+ * pane, a question whose answer could not have changed.
+ *
+ * The panes are real ViewPanes; MapView, ChartView and DialChart are stubbed
+ * (WebGL and plotly do not run in jsdom), which leaves the dial's range fetch —
+ * the same effect shape the chart view uses six at a time.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState, MapExtent } from '../types';
+
+vi.mock('../components/MapView', () => ({ default: () => <div data-testid="map-view" /> }));
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+interface Call {
+  url: string;
+  signal?: AbortSignal;
+  settle: () => void;
+}
+
+let calls: Call[] = [];
+
+const aggregateCalls = () => calls.filter((c) => c.url.startsWith('/api/aggregate?'));
+
+beforeEach(() => {
+  // The aggregate cache is module state; every test here asks the same
+  // question, so each needs a fresh one.
+  vi.resetModules();
+  calls = [];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    return new Promise<Response>((resolve, reject) => {
+      const body = JSON.stringify({ water_yield: 42 });
+      const call: Call = {
+        url,
+        signal: init?.signal ?? undefined,
+        settle: () => resolve(new Response(body, { headers: { 'content-type': 'application/json' } })),
+      };
+      calls.push(call);
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }, { once: true });
+      if (!url.startsWith('/api/aggregate?')) call.settle();
+    });
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'reference',
+  rightScenario: 'current',
+  attribute: 'water_yield',
+};
+
+const extentAt = (minx: number): MapExtent => ({
+  center: [minx + 0.5, 0],
+  zoom: 6,
+  bounds: [minx, 0, minx + 1, 1],
+});
+
+async function renderPanes(count: number, props: Record<string, unknown>) {
+  const ViewPane = (await import('../components/ViewPane')).default;
+
+  const tree = (overrides: Record<string, unknown>) => (
+    <ChakraProvider theme={theme}>
+      {Array.from({ length: count }, (_, i) => (
+        <ViewPane
+          key={i}
+          comparison={comparison}
+          paneIndex={i}
+          layoutMode="quad"
+          viewMode="dial"
+          onViewModeChange={() => {}}
+          onFocusPane={() => {}}
+          onGoQuad={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          {...props}
+          {...overrides}
+        />
+      ))}
+    </ChakraProvider>
+  );
+
+  const utils = await act(async () => render(tree({})));
+  return { ...utils, tree };
+}
+
+describe('aggregate requests across panes', () => {
+  it('asks once for a question every pane is asking', async () => {
+    await renderPanes(6, { rangeMode: 'extent', mapExtent: extentAt(0) });
+
+    const urls = aggregateCalls().map((c) => c.url);
+    // Two scenarios over one extent: two questions, however many panes want
+    // the answer. Six panes previously meant twelve requests.
+    expect(new Set(urls).size).toBe(2);
+    expect(urls).toHaveLength(2);
+  });
+
+  it('does not re-ask when the extent changes but the range mode ignores it', async () => {
+    // Full-domain mode. The extent is not part of the question, so panning
+    // cannot change the answer — and these are the seconds-long requests.
+    const { rerender, tree } = await renderPanes(6, { rangeMode: 'domain', mapExtent: extentAt(0) });
+    const before = aggregateCalls().length;
+    expect(before).toBeGreaterThan(0);
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(10) })); });
+    await act(async () => { rerender(tree({ mapExtent: extentAt(20) })); });
+
+    expect(aggregateCalls()).toHaveLength(before);
+  });
+
+  it('does not re-ask when the extent object is new but the extent is not', async () => {
+    // mapExtent is rebuilt on every report, so identity churn alone used to
+    // re-run the effect.
+    const { rerender, tree } = await renderPanes(1, { rangeMode: 'extent', mapExtent: extentAt(0) });
+    const before = aggregateCalls().length;
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(0) })); });
+
+    expect(aggregateCalls()).toHaveLength(before);
+  });
+
+  it('cancels the aggregates a pan has superseded', async () => {
+    const { rerender, tree } = await renderPanes(1, { rangeMode: 'extent', mapExtent: extentAt(0) });
+    const first = aggregateCalls();
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.every((c) => c.signal !== undefined)).toBe(true);
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(10) })); });
+
+    const second = aggregateCalls().filter((c) => !first.includes(c));
+    expect(second.length).toBeGreaterThan(0);
+    // The grace period is there so a re-subscribe in the next tick keeps the
+    // request; nothing re-subscribes to the old extent.
+    await act(async () => { await new Promise((r) => setTimeout(r, 120)); });
+
+    expect(first.every((c) => c.signal!.aborted)).toBe(true);
+    expect(second.every((c) => c.signal!.aborted)).toBe(false);
+  });
+
+  it('keeps a site-scoped range mode off the aggregate endpoint entirely', async () => {
+    await renderPanes(6, { rangeMode: 'site', mapExtent: extentAt(0) });
+    expect(aggregateCalls()).toHaveLength(0);
+  });
+});

--- a/frontend/src/test/choroplethRenderPath.test.ts
+++ b/frontend/src/test/choroplethRenderPath.test.ts
@@ -33,7 +33,10 @@ describe('choropleth vector-tile render path', () => {
   });
 
   it('fetches values, not geometry, once the tiled zoom range is in use', () => {
-    expect(mapView).toMatch(/fetch\(`\/api\/catchment-values\?\$\{params\}`\)/);
+    // The request options now carry an AbortSignal, so this no longer asserts
+    // the call ends immediately after the URL — only that the URL is the
+    // values endpoint and that a signal is threaded through it.
+    expect(mapView).toMatch(/fetch\(`\/api\/catchment-values\?\$\{params\}`, \{ signal: requestSignal \}\)/);
     // The values request carries no zoom: the server's detailed-vs-aggregated
     // choice does not apply when geometry comes from tiles.
     const valuesFetch = mapView.slice(

--- a/frontend/src/test/mapRefetchStorms.test.tsx
+++ b/frontend/src/test/mapRefetchStorms.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * Refetch storms on map interaction (issue #60).
+ *
+ * A pan fires choropleth requests that the next pan immediately obsoletes.
+ * Nothing ordered the responses, so whichever landed last painted the map — and
+ * the map could settle showing a viewport the user had already left. Nothing
+ * cancelled them either, so the connection and the server stayed busy on
+ * answers no one would read.
+ *
+ * MapLibre is stubbed (as in webglContextBudget.test.tsx — WebGL cannot run in
+ * jsdom) with a movable viewport, so a pan is a real 'moveend' with real new
+ * bounds and the requests it produces are the real ones.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState } from '../types';
+
+// --- MapLibre stand-in --------------------------------------------------------
+
+const constructed: FakeMap[] = [];
+
+class FakeMap {
+  removed = false;
+  west = 0;
+  south = 0;
+  east = 1;
+  north = 1;
+  private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  private canvas = document.createElement('canvas');
+
+  constructor() {
+    constructed.push(this);
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler);
+    this.handlers.set(event, existing);
+    return this;
+  }
+
+  once(event: string, handler: (...args: unknown[]) => void) {
+    return this.on(event, handler);
+  }
+
+  off() {
+    return this;
+  }
+
+  fire(event: string) {
+    for (const handler of [...(this.handlers.get(event) ?? [])]) handler({ point: { x: 0, y: 0 } });
+  }
+
+  /** Move the viewport, exactly as a drag would, and end the movement. */
+  panTo(west: number) {
+    this.west = west;
+    this.east = west + 1;
+    this.fire('moveend');
+  }
+
+  addControl() { return this; }
+  getCenter() { return { lng: (this.west + this.east) / 2, lat: 0 }; }
+  getZoom() { return 6; }
+  getBearing() { return 0; }
+  getPitch() { return 0; }
+
+  getBounds() {
+    return {
+      getWest: () => this.west,
+      getSouth: () => this.south,
+      getEast: () => this.east,
+      getNorth: () => this.north,
+      getSouthWest: () => ({ lng: this.west, lat: this.south }),
+      getNorthEast: () => ({ lng: this.east, lat: this.north }),
+    };
+  }
+
+  getCanvas() { return this.canvas; }
+  getStyle() { return { sources: {} }; }
+  getSource() { return undefined; }
+  getLayer() { return undefined; }
+  get style() { return undefined; }
+  loaded() { return false; }
+  isStyleLoaded() { return false; }
+  jumpTo() {}
+  easeTo() {}
+  fitBounds() {}
+  setStyle() {}
+  resize() {}
+  triggerRepaint() {}
+  setMaxBounds() {}
+  setMinZoom() {}
+  setMaxZoom() {}
+  queryRenderedFeatures() { return []; }
+  project() { return { x: 0, y: 0 }; }
+  dragPan = { enable() {}, disable() {} };
+  remove() { this.removed = true; }
+}
+
+class FakeLngLatBounds {
+  constructor(private sw: [number, number], private ne: [number, number]) {}
+  getSouthWest() { return { lng: this.sw[0], lat: this.sw[1] }; }
+  getNorthEast() { return { lng: this.ne[0], lat: this.ne[1] }; }
+  getWest() { return this.sw[0]; }
+  getSouth() { return this.sw[1]; }
+  getEast() { return this.ne[0]; }
+  getNorth() { return this.ne[1]; }
+  extend() { return this; }
+}
+
+vi.mock('maplibre-gl', () => {
+  class NavigationControl {}
+  const api = { Map: FakeMap, NavigationControl, LngLatBounds: FakeLngLatBounds };
+  return { ...api, default: api };
+});
+
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+// --- Network stand-in ---------------------------------------------------------
+
+interface Call {
+  url: string;
+  signal?: AbortSignal;
+  settle: (body: unknown) => void;
+}
+
+let calls: Call[] = [];
+
+/**
+ * The viewport's own choropleth requests.
+ *
+ * Deliberately not the full-domain and site-scoped `valuesOnly` requests: those
+ * feed the Full and Site range statistics, do not depend on the viewport, and
+ * are correctly left alone by a pan.
+ */
+function choroplethCalls(): Call[] {
+  return calls.filter((c) => c.url.startsWith('/api/choropleth?') && !c.url.includes('valuesOnly'));
+}
+
+function boundsOf(call: Call): string {
+  const params = new URLSearchParams(call.url.slice(call.url.indexOf('?') + 1));
+  return `${params.get('minx')},${params.get('maxx')}`;
+}
+
+/** One catchment carrying `value` for `attribute`, in the shape /api/choropleth returns. */
+function featureCollection(attribute: string, value: number) {
+  return {
+    type: 'FeatureCollection',
+    domain_min: value,
+    domain_max: value,
+    features: [{
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { HYBAS_ID: 1, [attribute]: value },
+    }],
+  };
+}
+
+beforeEach(() => {
+  // The choropleth caches are module state with a 60-second TTL, and every test
+  // here pans over the same bounds. Without a fresh module the second test
+  // would be served from the first test's cache and make no requests at all —
+  // which is the right behaviour in the application and useless in a test.
+  vi.resetModules();
+  constructed.length = 0;
+  calls = [];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    return new Promise<Response>((resolve, reject) => {
+      const call: Call = {
+        url,
+        signal: init?.signal ?? undefined,
+        settle: (body: unknown) =>
+          resolve(new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })),
+      };
+      calls.push(call);
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }, { once: true });
+      // Anything the test does not care about answers with an empty object as
+      // soon as it is asked, so mount-time metadata requests do not hang.
+      if (!url.startsWith('/api/choropleth?') && !url.startsWith('/api/catchment-values?')) {
+        call.settle({});
+      }
+    });
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'reference',
+  rightScenario: 'current',
+  attribute: 'water_yield',
+};
+
+async function mountMap(props: Record<string, unknown> = {}) {
+  const MapView = (await import('../components/MapView')).default;
+  const stats: Array<{ domainRange: { min: number; max: number } | null }> = [];
+
+  await act(async () => {
+    render(
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled={false}
+          onStatisticsChange={(s) => stats.push(s as { domainRange: { min: number; max: number } | null })}
+          {...props}
+        />
+      </ChakraProvider>,
+    );
+  });
+
+  const map = constructed[0];
+  // 'load' is what marks the map ready and triggers the first paint.
+  await act(async () => { map.fire('load'); });
+  return { map, stats };
+}
+
+/** Let the moveend debounce elapse and the resulting work start. */
+async function settle(ms = 400) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+describe('choropleth requests during a pan', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('cancels the request a further pan has made pointless', async () => {
+    const { map } = await mountMap();
+    await settle();
+
+    const first = choroplethCalls();
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.every((c) => c.signal !== undefined)).toBe(true);
+    expect(first.every((c) => c.signal!.aborted)).toBe(false);
+
+    // Pan away before the first viewport's answer arrives.
+    await act(async () => { map.panTo(10); });
+    await settle();
+
+    const second = choroplethCalls().filter((c) => !first.includes(c));
+    expect(second.length).toBeGreaterThan(0);
+    expect(boundsOf(second[0])).not.toBe(boundsOf(first[0]));
+
+    // The superseded requests are really cancelled, not merely ignored: the
+    // connection is freed and the server is free to stop.
+    expect(first.every((c) => c.signal!.aborted)).toBe(true);
+    expect(second.every((c) => c.signal!.aborted)).toBe(false);
+  });
+
+  it('paints the current viewport even when the old one answers last', async () => {
+    // The out-of-order case. The first viewport's request is allowed to finish
+    // after the second's, with a different domain, and must not be the one that
+    // reaches the statistics panel.
+    const { map, stats } = await mountMap();
+    await settle();
+
+    const first = choroplethCalls();
+    await act(async () => { map.panTo(10); });
+    await settle();
+    const second = choroplethCalls().filter((c) => !first.includes(c));
+
+    await act(async () => {
+      second.forEach((c) => c.settle(featureCollection('water_yield', 222)));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      first.forEach((c) => c.settle(featureCollection('water_yield', 111)));
+      await Promise.resolve();
+    });
+
+    const published = stats.filter((s) => s.domainRange !== null).map((s) => s.domainRange!.max);
+    expect(published).toContain(222);
+    expect(published).not.toContain(111);
+    expect(published[published.length - 1]).toBe(222);
+  });
+
+  it('does not re-request a viewport it never left', async () => {
+    // moveend fires for plenty of things that leave the viewport where it was.
+    const { map } = await mountMap();
+    await settle();
+    const before = choroplethCalls().length;
+
+    await act(async () => { map.fire('moveend'); });
+    await settle();
+
+    expect(choroplethCalls()).toHaveLength(before);
+  });
+
+  it('reports an unchanged extent to the application once, not once per moveend', async () => {
+    // Every report lands in App state and re-renders the whole pane tree.
+    const extents: unknown[] = [];
+    const { map } = await mountMap({ onMapExtentChange: (e: unknown) => extents.push(e) });
+    await settle();
+
+    await act(async () => { map.fire('moveend'); });
+    await act(async () => { map.fire('moveend'); });
+    const afterRepeats = extents.length;
+
+    await act(async () => { map.panTo(42); });
+    expect(extents.length).toBe(afterRepeats + 1);
+    expect(afterRepeats).toBeLessThanOrEqual(1);
+  });
+
+  it('makes one request per question when several panes ask together', async () => {
+    // Quad view: every pane holds its own MapView over the same viewport.
+    const MapView = (await import('../components/MapView')).default;
+    await act(async () => {
+      render(
+        <ChakraProvider theme={theme}>
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <MapView
+              key={i}
+              comparison={comparison}
+              onOpenSettings={() => {}}
+              colorScaleMode="rainbow"
+              colorScaleType="linear"
+              isSwiperEnabled={false}
+            />
+          ))}
+        </ChakraProvider>,
+      );
+    });
+
+    await act(async () => { constructed.forEach((m) => m.fire('load')); });
+    await settle();
+
+    const urls = choroplethCalls().map((c) => c.url);
+    // Two scenarios, one viewport: two distinct questions, and no duplicates of
+    // either however many panes are asking.
+    expect(new Set(urls).size).toBe(2);
+    expect(urls).toHaveLength(2);
+  });
+});

--- a/frontend/src/test/sharedRequest.test.ts
+++ b/frontend/src/test/sharedRequest.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared, cancellable requests (issue #60).
+ *
+ * The three behaviours the map's interaction path depends on, and which the
+ * plain promise caches it replaces got only partly right:
+ *
+ *   - twelve panes asking the same question make one request,
+ *   - a superseded request is really cancelled, not merely ignored,
+ *   - and one caller losing interest never cancels a request the others are
+ *     still waiting for.
+ *
+ * The third is the one that makes the first two safe to combine, and is the
+ * easiest to break by accident.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
+
+const TTL = 10_000;
+const GRACE = 50;
+
+/** A request whose completion the test controls. */
+function deferredWork() {
+  const signals: AbortSignal[] = [];
+  const resolvers: Array<(value: string) => void> = [];
+  const rejecters: Array<(err: unknown) => void> = [];
+
+  const work = (signal: AbortSignal) => {
+    signals.push(signal);
+    return new Promise<string>((resolve, reject) => {
+      resolvers.push(resolve);
+      rejecters.push(reject);
+      signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true });
+    });
+  };
+
+  return {
+    work,
+    signals,
+    calls: () => signals.length,
+    resolve: (value: string, index = 0) => resolvers[index](value),
+    reject: (err: unknown, index = 0) => rejecters[index](err),
+  };
+}
+
+let cache: SharedCache<string>;
+
+beforeEach(() => {
+  cache = new Map();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('request sharing', () => {
+  it('makes one request for callers that ask the same question at once', async () => {
+    const w = deferredWork();
+    const controllers = Array.from({ length: 12 }, () => new AbortController());
+
+    const promises = controllers.map((c) =>
+      sharedRequest(cache, 'viewport-a', TTL, w.work, c.signal, GRACE));
+
+    expect(w.calls()).toBe(1);
+
+    w.resolve('values');
+    await expect(Promise.all(promises)).resolves.toEqual(Array(12).fill('values'));
+    expect(w.calls()).toBe(1);
+  });
+
+  it('asks separately for different questions', () => {
+    const w = deferredWork();
+    void sharedRequest(cache, 'viewport-a', TTL, w.work, undefined, GRACE);
+    void sharedRequest(cache, 'viewport-b', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+
+  it('serves a settled result from cache inside its TTL, and refetches after', async () => {
+    const w = deferredWork();
+    const first = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    w.resolve('one');
+    await expect(first).resolves.toBe('one');
+
+    vi.advanceTimersByTime(TTL - 1);
+    await expect(sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE)).resolves.toBe('one');
+    expect(w.calls()).toBe(1);
+
+    vi.advanceTimersByTime(2);
+    void sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+
+  it('does not cache a failure', async () => {
+    const w = deferredWork();
+    const first = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    w.reject(new Error('HTTP 500'));
+    await expect(first).rejects.toThrow('HTTP 500');
+
+    void sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+});
+
+describe('cancellation', () => {
+  it('aborts the request once the last caller has gone', async () => {
+    const w = deferredWork();
+    const caller = new AbortController();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, caller.signal, GRACE);
+
+    caller.abort();
+    await expect(promise).rejects.toSatisfy(isAbortError);
+    expect(w.signals[0].aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.signals[0].aborted).toBe(true);
+  });
+
+  it('keeps the request alive for the callers that remain', async () => {
+    const w = deferredWork();
+    const leaving = new AbortController();
+    const staying = new AbortController();
+
+    const leavingPromise = sharedRequest(cache, 'k', TTL, w.work, leaving.signal, GRACE);
+    const stayingPromise = sharedRequest(cache, 'k', TTL, w.work, staying.signal, GRACE);
+    expect(w.calls()).toBe(1);
+
+    leaving.abort();
+    await expect(leavingPromise).rejects.toSatisfy(isAbortError);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.signals[0].aborted).toBe(false);
+
+    w.resolve('values');
+    await expect(stayingPromise).resolves.toBe('values');
+  });
+
+  it('never abandons a caller that gave no signal', async () => {
+    const w = deferredWork();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    const leaving = new AbortController();
+    void sharedRequest(cache, 'k', TTL, w.work, leaving.signal, GRACE).catch(() => undefined);
+
+    leaving.abort();
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+
+    expect(w.signals[0].aborted).toBe(false);
+    w.resolve('values');
+    await expect(promise).resolves.toBe('values');
+  });
+
+  it('does not cancel a request the next tick asks for again', async () => {
+    // applyColors supersedes its own previous run before it knows whether the
+    // parameters changed. Cancelling on the spot would throw away a request
+    // that is about to be wanted back, and cost a second round trip.
+    const w = deferredWork();
+    const first = new AbortController();
+    void sharedRequest(cache, 'k', TTL, w.work, first.signal, GRACE).catch(() => undefined);
+
+    first.abort();
+    const second = new AbortController();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, second.signal, GRACE);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.calls()).toBe(1);
+    expect(w.signals[0].aborted).toBe(false);
+
+    w.resolve('values');
+    await expect(promise).resolves.toBe('values');
+  });
+
+  it('rejects immediately for a caller whose signal is already aborted', async () => {
+    const w = deferredWork();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(sharedRequest(cache, 'k', TTL, w.work, controller.signal, GRACE))
+      .rejects.toSatisfy(isAbortError);
+    expect(w.calls()).toBe(0);
+  });
+});
+
+describe('bookkeeping', () => {
+  it('drops expired entries rather than growing for the life of the tab', async () => {
+    // Keys embed the viewport bounds, so a minute of panning is a new key per
+    // moveend.
+    for (let i = 0; i < 5; i++) {
+      const w = deferredWork();
+      const p = sharedRequest(cache, `viewport-${i}`, TTL, w.work, undefined, GRACE);
+      w.resolve('v');
+      await p;
+    }
+    expect(cache.size).toBe(5);
+
+    vi.advanceTimersByTime(TTL + 1);
+    const w = deferredWork();
+    void sharedRequest(cache, 'viewport-new', TTL, w.work, undefined, GRACE);
+    expect(cache.size).toBe(1);
+  });
+
+  it('recognises an abort rejection in either shape', () => {
+    expect(isAbortError(new DOMException('x', 'AbortError'))).toBe(true);
+    expect(isAbortError({ name: 'AbortError' })).toBe(true);
+    expect(isAbortError(new Error('boom'))).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #60

Panning the map re-asked questions whose answers could not have changed, and
nothing ordered the answers that came back.

## The wasted work

`ViewPane` and `ChartView` both listed the map extent as an effect dependency
**regardless of range mode**, and the extent is a fresh object on every move. So
a pan re-issued full-domain queries that do not depend on the extent at all.

Measured over the same scripted interaction — six panes, mount plus five pans:

| Request | before | after |
| --- | --- | --- |
| `/api/aggregate`, chart panes, full domain | 216 | **6** |
| `/api/aggregate`, dial panes, full domain | 72 | **2** |
| `/api/choropleth`, map panes | 12 | 12 (10 now aborted) |

At the measured 4.77 s per full-domain `/api/aggregate`, the chart row is roughly
**1,030 seconds of server work reduced to about 29**.

The choropleth row is the honest one: the count does not change, because the
existing cache already deduplicated across panes. What changed there is
cancellation and ordering.

## The correctness bug underneath

`applyColors` is called from sixteen places and is asynchronous throughout, so
runs routinely overlapped — and **nothing ordered them**. Whichever response
landed last painted the map, regardless of which viewport, scenario or attribute
the user had actually asked for.

Each run now takes a monotonic ticket, checked after every await and inside every
deferred `once('idle')` apply. A superseded run aborts its own requests.

## What was added

**`frontend/src/lib/sharedRequest.ts`** replaces two hand-rolled promise caches
with one primitive doing three things that only work together: share one
in-flight request per key, cancel it via `AbortController` when nothing wants it,
and **count subscribers** so one caller walking away cannot cancel a request the
other eleven panes are still waiting on. A 50 ms grace before the abort stops
`applyColors` cancelling a request its own next tick wants back.

Also: abort controllers on the two full-domain `valuesOnly` statistics effects,
and `onMapExtentChange` no longer re-reports an extent identical to the last —
every report re-rendered the whole pane tree.

`useApi.ts` gains one deduplicated, cancellable `fetchAggregate()`. Caching by
full query string is safe here specifically because `handleAggregateData` reads
scenario, attributes, bbox and bound and nothing else — that was checked, not
assumed. The choropleth caches keep their deliberate bypass for site ideal
overrides, now commented so it is not "optimised" away by someone later.

## Fixed on the way past

The old choropleth cache **swallowed errors inside the cached promise and
resolved to `null`**, so a single transient 500 was cached as "no data" for the
full 60-second TTL even after the server recovered. Rejections are no longer
cached.

## Tests

19 files / 127 tests before → **22 files / 148 tests** after, all passing.
`tsc --noEmit` and `eslint --max-warnings 0` clean. The new tests were verified to
fail without the change by stashing each file: 4 of 5 in `aggregateFanout`, 3 of 5
in `mapRefetchStorms`.

One assertion in `choroplethRenderPath.test.ts` was updated — **tightened** to
require the values fetch to carry an abort signal, not loosened to ignore it.

No npm dependency added.

## Worth knowing before merging

- **`ChartView.tsx` was outside the file list this work was scoped to.** It is
  where the largest measured cost lives, so the change was made and is minimal —
  two effects and imports — but it is a scope departure and is flagged rather than
  buried.
- The **50 ms abort grace is a judgement, not a measurement.**
- The numbers are **jsdom request counts, not a browser profile**. The real
  application was never run against a datapack, so nobody has yet seen what this
  feels like in a browser.
- `ChartView`'s *grouped* series path is not test-covered — it needs plotly plus
  grouping fixtures. Its figures above come from the summary path, reasoning by
  symmetry.
