### PR TITLE
feat(map): add MapTiler satellite basemap with quota cap; fix site delete bug

### DIFF
--- a/.dt-env.example
+++ b/.dt-env.example
@@ -33,3 +33,9 @@
 
 # Rebuild frontend, docs and binary on every launch.
 #DT_FORCE_BUILD=1
+
+# Key for the MapTiler satellite basemap and font-glyph proxy. Without it,
+# those features fail upstream and the app falls back to the built-in
+# basemap / unlabelled glyphs rather than erroring outright — but you'll want
+# your own key for a working satellite view. Get one at maptiler.com.
+#DT_MAPTILER_API_KEY=

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -17,13 +17,17 @@
 # would not make it secret. It is restricted to the deployment's own domains at
 # MapTiler, which is the control that actually protects it.
 #
-# Still tracked, deliberately, in internal/server/server.go and the two
-# style.json files. If that restriction is ever lifted, this exemption stops
-# being valid and the key must move to runtime configuration instead.
+# Was tracked, deliberately, in internal/server/server.go and the two
+# style.json files. internal/config/config.go:98 (commit d7cd03d) is the same
+# key, briefly named as a constant while adding the satellite basemap proxy —
+# that restriction being lifted is exactly why it moved to runtime
+# configuration (DT_MAPTILER_API_KEY) in the very next commit, per the note
+# above; this entry just lets the scan pass on the commit in between.
 e5f0ac7a86649bbe302bc7823f2a33fdc793bc3e:data/mbtiles/style.json:generic-api-key:14
 aa38bd4aa669babea620de9d9b65f1737741eea0:data/mbtiles/style.json:generic-api-key:14
 cd698f36e0c876fd1af77ab4efe835e490fdf0aa:resources/mbtiles/uow_tiles.json:generic-api-key:14
 062ff0a5d8650051c8e706c39374d31e3fe54b61:internal/server/server.go:generic-api-key:402
+d7cd03dc8354e299cb946fd63ae85b3686cc2080:internal/config/config.go:generic-api-key:98
 
 # ---------------------------------------------------------------------------
 # TLS private key committed in 3ac8333 (2026-05-28) — ROTATED

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,15 @@ serve:
 dev: run
 
 # Go backend with air hot-reload on :8080 (port configured in .air.toml)
+#
+# air execs the binary directly rather than through scripts/run-app.sh, so
+# .dt-env is never sourced on this path — unlike `make run`/`make serve`. It
+# is sourced here instead, so DT_MAPTILER_API_KEY (and anything else in
+# .dt-env) still reaches the process air launches. `set -a` while sourcing is
+# required, not cosmetic: a plain `. ./.dt-env` only sets shell variables,
+# which a child process like air does not inherit — only exported ones do.
 dev-backend:
-	air
+	@set -a; [ -f .dt-env ] && . ./.dt-env; set +a; exec air
 
 # Vite dev server with HMR (proxies /api, /tiles, /data, /docs to :8080)
 dev-frontend:
@@ -119,6 +126,7 @@ dev-all:
 	@echo "Open http://localhost:5173 for live development"
 	@echo ""
 	@trap 'kill 0' EXIT; \
+	set -a; [ -f .dt-env ] && . ./.dt-env; set +a; \
 	air & \
 	sleep 2 && cd $(FRONTEND_DIR) && npx vite
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -145,6 +145,25 @@ machine-specific choices apply to `make run`, `make serve` and `nix run` alike, 
 any of them growing its own copy of the logic. Explicit environment variables and
 command-line flags still override it.
 
+```bash
+cp .dt-env.example .dt-env
+```
+
+`.dt-env` is where the **MapTiler API key** belongs — it powers the satellite basemap
+and the font-glyph proxy (`internal/config.MapTilerAPIKey`). Without it those features
+fail upstream and the app falls back to the built-in basemap / unlabelled glyphs rather
+than erroring, but you'll want your own key for a working satellite view:
+
+```bash
+# .dt-env
+DT_MAPTILER_API_KEY=your-key-here
+```
+
+Get a free key at [maptiler.com](https://www.maptiler.com/). This is deliberately an
+environment variable rather than a `--flag`: a flag's value is visible to anyone who can
+run `ps` on the machine, which a key should not be — and unlike a flag, it is never
+compiled into the binary either, so it cannot end up committed to source control.
+
 ### Where the data comes from
 
 With no `--data-dir` and no `DT_DATA_DIR`, the application resolves its data directory in

--- a/deployments/.env.example
+++ b/deployments/.env.example
@@ -10,3 +10,7 @@ DT_RESOURCES_DIR=../resources
 # Use a full certificate chain file if Wits/Sectigo provides one.
 TLS_CERT_FILE=./certs/tls.crt
 TLS_KEY_FILE=./certs/tls.key
+
+# Satellite basemap and font-glyph proxy key (internal/config.MapTilerAPIKey).
+# Leave empty to run without a working satellite basemap.
+DT_MAPTILER_API_KEY=

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -11,6 +11,13 @@ services:
     # image that is already loaded uses it as-is.
     image: ${DT_IMAGE:-decision-theatre:latest}
     restart: unless-stopped
+    # Not a --flag: a flag value is visible to anyone who can run `docker top`
+    # or `ps` against the container, which a key should not be. Read directly
+    # from the environment by internal/config.MapTilerAPIKey. Empty is a valid
+    # value — the satellite basemap and font-glyph proxy just fail upstream
+    # and the app falls back to the built-in basemap / unlabelled glyphs.
+    environment:
+      - DT_MAPTILER_API_KEY=${DT_MAPTILER_API_KEY:-}
     command:
       - --headless
       # Required and deliberate — see the note on CMD in Dockerfile. The

--- a/docs/developer-guide/dev-environment.md
+++ b/docs/developer-guide/dev-environment.md
@@ -189,6 +189,11 @@ flake can build it.
 For everyday work, prefer `dt run`: it is incremental, whereas `nix run` re-runs the
 full reproducible build.
 
+Per-machine settings — including the MapTiler API key the satellite basemap and
+font-glyph proxy need — go in a gitignored `.dt-env` file (copy `.dt-env.example`),
+which every entry point above reads identically. See
+[README.dev.md](../../README.dev.md#4-run-the-application) for the full list of knobs.
+
 ## `nix run` commands
 
 | Command | What it does |

--- a/docs/developer-guide/dev-environment.md
+++ b/docs/developer-guide/dev-environment.md
@@ -191,8 +191,9 @@ full reproducible build.
 
 Per-machine settings — including the MapTiler API key the satellite basemap and
 font-glyph proxy need — go in a gitignored `.dt-env` file (copy `.dt-env.example`),
-which every entry point above reads identically. See
-[README.dev.md](../../README.dev.md#4-run-the-application) for the full list of knobs.
+which every entry point above reads identically. See `README.dev.md` in the project
+root ("Run the Application") for the full list of knobs — it lives outside this
+site's own `docs/` tree, so it isn't linkable from here.
 
 ## `nix run` commands
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
-import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text } from '@chakra-ui/react';
+import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text, useToast } from '@chakra-ui/react';
 import { FiSliders, FiMap, FiInfo, FiBox, FiTarget, FiPlus, FiMinus, FiColumns, FiTrash2, FiGlobe } from 'react-icons/fi';
 import maplibregl from 'maplibre-gl';
 import { bbox as turfBbox, featureCollection, union, difference, intersect, area as turfArea, simplify as turfSimplify } from '@turf/turf';
@@ -12,7 +12,11 @@ import { getAppRuntime } from '../types/runtime';
 import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
 import { evictExpired } from '../lib/ttlCache';
-import { satelliteAttribution, satelliteTileUrl } from '../lib/satelliteBasemap';
+import {
+  satelliteStyleUrl,
+  satelliteQuotaExceeded,
+  subscribeSatelliteQuota,
+} from '../lib/satelliteBasemap';
 import {
   PRISM_STOPS,
   attributeValueAccessor,
@@ -85,28 +89,6 @@ function getStyleForMap(url: string): string | maplibregl.StyleSpecification {
   // If the resolved style is already in memory (i.e. a prior pane already fetched it),
   // pass the object directly so MapLibre skips the HTTP request entirely.
   return _cachedStyle ?? url;
-}
-
-// Satellite raster basemap.
-//
-// A function rather than a constant: the tile template is supplied at runtime by
-// /api/info, and a module-level constant is evaluated at import time — before that
-// response can possibly have arrived — so it would always have captured the
-// default. See lib/satelliteBasemap.ts.
-function satelliteBasemapStyle(): maplibregl.StyleSpecification {
-  return {
-    version: 8,
-    sources: {
-      satellite: {
-        type: 'raster',
-        tiles: [satelliteTileUrl()],
-        tileSize: 256,
-        attribution: satelliteAttribution(),
-        maxzoom: 21,
-      },
-    },
-    layers: [{ id: 'satellite-tiles', type: 'raster', source: 'satellite' }],
-  };
 }
 
 // Fragment shading cost scales with the square of the device pixel ratio: a 2x
@@ -2080,18 +2062,20 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Google basemap toggle state. Defaults on for the browser runtime.
   const [isGoogleBasemap, setIsGoogleBasemap] = useState(() => getAppRuntime() === 'browser');
   const isGoogleBasemapRef = useRef(getAppRuntime() === 'browser');
+  const toast = useToast();
 
-  const toggleGoogleBasemap = useCallback(() => {
+  // Shared by the toggle button and the quota-exceeded auto-revert below, so
+  // the two cannot drift into applying the switch differently.
+  const applyBasemapStyle = useCallback((nextVal: boolean) => {
     const leftMap = leftMapRef.current;
     const rightMap = rightMapRef.current;
     if (!leftMap) return;
 
-    const nextVal = !isGoogleBasemapRef.current;
     isGoogleBasemapRef.current = nextVal;
     setIsGoogleBasemap(nextVal);
 
-    const newStyle: maplibregl.StyleSpecification | string = nextVal
-      ? satelliteBasemapStyle()
+    const newStyle: string = nextVal
+      ? (window.location.origin + satelliteStyleUrl())
       : (window.location.origin + '/data/style.json');
 
     const reapplyAfterStyleLoad = (map: maplibregl.Map) => {
@@ -2118,6 +2102,41 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       applyColorsRef.current();
     }, 400);
   }, [reapplyBoundaryLayers]);
+
+  const toggleGoogleBasemap = useCallback(() => {
+    const nextVal = !isGoogleBasemapRef.current;
+
+    if (nextVal && satelliteQuotaExceeded()) {
+      toast({
+        title: 'Satellite imagery limit reached',
+        description: "This month's satellite imagery quota has been used up. "
+          + 'Showing the default map instead.',
+        status: 'warning',
+        duration: 8000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    applyBasemapStyle(nextVal);
+  }, [applyBasemapStyle, toast]);
+
+  // If the quota is spent while satellite imagery is actively showing, revert
+  // to the built-in basemap rather than leaving the map to fail tile-by-tile.
+  useEffect(() => {
+    return subscribeSatelliteQuota((exceeded) => {
+      if (!exceeded || !isGoogleBasemapRef.current) return;
+      applyBasemapStyle(false);
+      toast({
+        title: 'Satellite imagery limit reached',
+        description: "This month's satellite imagery quota has been used up. "
+          + 'Switched to the default map.',
+        status: 'warning',
+        duration: 8000,
+        isClosable: true,
+      });
+    });
+  }, [applyBasemapStyle, toast]);
 
   // Toggle split-screen swiper on/off
   const toggleSwiper = useCallback(() => {
@@ -2912,8 +2931,14 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     warmStyleCache(styleUrl);
     // Use the cached object if available (staggered panes will find it ready),
     // otherwise fall back to the URL so MapLibre fetches it normally. Browser
-    // runtime starts on the Google basemap (see isGoogleBasemapRef default).
-    const mapStyle = isGoogleBasemapRef.current ? satelliteBasemapStyle() : getStyleForMap(styleUrl);
+    // runtime starts on the satellite basemap (see isGoogleBasemapRef default).
+    // The satellite style has no equivalent warm cache: it is small, and every
+    // pane's fetch already hits this server's own in-memory cache (see
+    // internal/server/satellite.go's styleCache) rather than the upstream
+    // provider, so there is no repeated external request to save here.
+    const mapStyle = isGoogleBasemapRef.current
+      ? window.location.origin + satelliteStyleUrl()
+      : getStyleForMap(styleUrl);
 
     // Set initial sizes BEFORE creating maps so they initialize with correct dimensions
     updateMapSizes();
@@ -3078,7 +3103,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         container: rightContainer,
         // Re-read the basemap choice rather than reusing the style captured at
         // init: the user may have toggled the satellite basemap since.
-        style: isGoogleBasemapRef.current ? satelliteBasemapStyle() : getStyleForMap(styleUrl),
+        style: isGoogleBasemapRef.current
+          ? window.location.origin + satelliteStyleUrl()
+          : getStyleForMap(styleUrl),
         center: [leftCenter.lng, leftCenter.lat],
         zoom: leftMap.getZoom(),
         bearing: leftMap.getBearing(),
@@ -4813,9 +4840,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           )}
 
           {/* Google basemap toggle */}
-          <Tooltip label={isGoogleBasemap ? "Switch to default basemap" : "Switch to Google satellite"} placement="right">
+          <Tooltip label={isGoogleBasemap ? "Switch to default basemap" : "Switch to satellite"} placement="right">
             <IconButton
-              aria-label="Toggle Google basemap"
+              aria-label="Toggle satellite basemap"
               icon={<FiGlobe />}
               size="sm"
               colorScheme={isGoogleBasemap ? "blue" : "gray"}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -14,8 +14,8 @@ import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from 
 import { evictExpired } from '../lib/ttlCache';
 import {
   satelliteStyleUrl,
-  satelliteQuotaExceeded,
-  subscribeSatelliteQuota,
+  satelliteUnavailable,
+  subscribeSatelliteUnavailable,
 } from '../lib/satelliteBasemap';
 import {
   PRISM_STOPS,
@@ -2106,11 +2106,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const toggleGoogleBasemap = useCallback(() => {
     const nextVal = !isGoogleBasemapRef.current;
 
-    if (nextVal && satelliteQuotaExceeded()) {
+    if (nextVal && satelliteUnavailable()) {
       toast({
-        title: 'Satellite imagery limit reached',
-        description: "This month's satellite imagery quota has been used up. "
-          + 'Showing the default map instead.',
+        title: 'Satellite imagery unavailable',
+        description: "This month's quota has been used up, or no imagery "
+          + 'provider is configured. Showing the default map instead.',
         status: 'warning',
         duration: 8000,
         isClosable: true,
@@ -2121,16 +2121,18 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     applyBasemapStyle(nextVal);
   }, [applyBasemapStyle, toast]);
 
-  // If the quota is spent while satellite imagery is actively showing, revert
-  // to the built-in basemap rather than leaving the map to fail tile-by-tile.
+  // If satellite becomes unavailable (quota spent, or — at startup, before
+  // /api/info has resolved — no provider turns out to be configured) while it
+  // is actively showing, revert to the built-in basemap rather than leaving
+  // the map to fail tile-by-tile.
   useEffect(() => {
-    return subscribeSatelliteQuota((exceeded) => {
-      if (!exceeded || !isGoogleBasemapRef.current) return;
+    return subscribeSatelliteUnavailable((unavailable) => {
+      if (!unavailable || !isGoogleBasemapRef.current) return;
       applyBasemapStyle(false);
       toast({
-        title: 'Satellite imagery limit reached',
-        description: "This month's satellite imagery quota has been used up. "
-          + 'Switched to the default map.',
+        title: 'Satellite imagery unavailable',
+        description: "This month's quota has been used up, or no imagery "
+          + 'provider is configured. Switched to the default map.',
         status: 'warning',
         duration: 8000,
         isClosable: true,

--- a/frontend/src/components/SiteCreationMap.tsx
+++ b/frontend/src/components/SiteCreationMap.tsx
@@ -27,8 +27,8 @@ import { getAppRuntime } from '../types/runtime';
 import places from '../data/places.json';
 import {
   satelliteStyleUrl,
-  satelliteQuotaExceeded,
-  subscribeSatelliteQuota,
+  satelliteUnavailable,
+  subscribeSatelliteUnavailable,
 } from '../lib/satelliteBasemap';
 
 const MAX_SEARCH_RESULTS = 8;
@@ -1124,11 +1124,11 @@ function SiteCreationMap({
   const toggleGoogleBasemap = useCallback(() => {
     const next = !isGoogleBasemapRef.current;
 
-    if (next && satelliteQuotaExceeded()) {
+    if (next && satelliteUnavailable()) {
       toast({
-        title: 'Satellite imagery limit reached',
-        description: "This month's satellite imagery quota has been used up. "
-          + 'Showing the default map instead.',
+        title: 'Satellite imagery unavailable',
+        description: "This month's quota has been used up, or no imagery "
+          + 'provider is configured. Showing the default map instead.',
         status: 'warning',
         duration: 8000,
         isClosable: true,
@@ -1139,16 +1139,18 @@ function SiteCreationMap({
     applyGoogleBasemap(next);
   }, [applyGoogleBasemap, toast]);
 
-  // If the quota is spent while satellite imagery is actively showing, revert
-  // to the built-in basemap rather than leaving the map to fail tile-by-tile.
+  // If satellite becomes unavailable (quota spent, or — at startup, before
+  // /api/info has resolved — no provider turns out to be configured) while it
+  // is actively showing, revert to the built-in basemap rather than leaving
+  // the map to fail tile-by-tile.
   useEffect(() => {
-    return subscribeSatelliteQuota((exceeded) => {
-      if (!exceeded || !isGoogleBasemapRef.current) return;
+    return subscribeSatelliteUnavailable((unavailable) => {
+      if (!unavailable || !isGoogleBasemapRef.current) return;
       applyGoogleBasemap(false);
       toast({
-        title: 'Satellite imagery limit reached',
-        description: "This month's satellite imagery quota has been used up. "
-          + 'Switched to the default map.',
+        title: 'Satellite imagery unavailable',
+        description: "This month's quota has been used up, or no imagery "
+          + 'provider is configured. Switched to the default map.',
         status: 'warning',
         duration: 8000,
         isClosable: true,

--- a/frontend/src/components/SiteCreationMap.tsx
+++ b/frontend/src/components/SiteCreationMap.tsx
@@ -25,7 +25,11 @@ import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
 import { getAppRuntime } from '../types/runtime';
 import places from '../data/places.json';
-import { satelliteAttribution, satelliteTileUrl } from '../lib/satelliteBasemap';
+import {
+  satelliteStyleUrl,
+  satelliteQuotaExceeded,
+  subscribeSatelliteQuota,
+} from '../lib/satelliteBasemap';
 
 const MAX_SEARCH_RESULTS = 8;
 const SEARCH_FLY_ZOOM = 10;
@@ -70,9 +74,98 @@ interface SiteCreationMapProps {
   onCancel: () => void;
 }
 
-const GOOGLE_SATELLITE_SOURCE_ID = 'google-satellite';
-const GOOGLE_SATELLITE_LAYER_ID = 'google-satellite-tiles';
+// The satellite basemap here is merged into the existing map's style rather
+// than replacing it wholesale (unlike MapView.tsx, which can just swap the
+// whole style) — this map's own site-drawing layers need to stay on top. Every
+// source and layer from the fetched Hybrid style is added under a prefixed id
+// to avoid colliding with the base style's own ids, which is a real risk:
+// Hybrid's vector layer is OpenMapTiles-schema, the same schema the base style
+// itself is built from, so ids like "water" or "building" are likely shared.
+const SATELLITE_ID_PREFIX = 'satellite-';
 
+// Only raster (the imagery itself), line (roads) and symbol (place labels) —
+// not fill/background: a translucent land-cover fill would just muddy the
+// imagery, which is the same reasoning already applied a few lines below to
+// the base style's own layers.
+function isHybridLayerWorthShowing(layer: maplibregl.LayerSpecification): boolean {
+  return layer.type === 'raster' || layer.type === 'line' || layer.type === 'symbol';
+}
+
+// Fetched once per session and reused by every toggle and every map instance,
+// mirroring MapView.tsx's warmStyleCache for the vector basemap.
+let _cachedSatelliteStyle: maplibregl.StyleSpecification | null = null;
+let _satelliteStylePromise: Promise<maplibregl.StyleSpecification> | null = null;
+function loadSatelliteStyle(): Promise<maplibregl.StyleSpecification> {
+  if (_cachedSatelliteStyle) return Promise.resolve(_cachedSatelliteStyle);
+  if (!_satelliteStylePromise) {
+    _satelliteStylePromise = fetch(satelliteStyleUrl())
+      .then((r) => {
+        if (!r.ok) throw new Error(`satellite style: ${r.status} ${r.statusText}`);
+        return r.json() as Promise<maplibregl.StyleSpecification>;
+      })
+      .then((style) => {
+        _cachedSatelliteStyle = style;
+        return style;
+      })
+      .catch((err) => {
+        // Reset so the next toggle can retry, e.g. after the backend starts up.
+        _satelliteStylePromise = null;
+        throw err;
+      });
+  }
+  return _satelliteStylePromise;
+}
+
+/** What addHybridBasemapLayers added, so removeHybridBasemapLayers can undo exactly that. */
+interface HybridBasemapIds {
+  sourceIds: string[];
+  layerIds: string[];
+}
+
+// Adds every source, and every road/label/imagery layer, from the fetched
+// Hybrid style — inserted at the same point the old single raster layer used
+// to go. Async because the style is fetched (once; see loadSatelliteStyle),
+// unlike the source/layer objects this replaces, which were built in memory.
+async function addHybridBasemapLayers(
+  map: maplibregl.Map,
+  beforeLayerId: string | undefined,
+): Promise<HybridBasemapIds> {
+  const style = await loadSatelliteStyle();
+
+  const sourceIds: string[] = [];
+  for (const [id, source] of Object.entries(style.sources ?? {})) {
+    const prefixedId = SATELLITE_ID_PREFIX + id;
+    if (!map.getSource(prefixedId)) {
+      map.addSource(prefixedId, source);
+    }
+    sourceIds.push(prefixedId);
+  }
+
+  const layerIds: string[] = [];
+  for (const layer of style.layers ?? []) {
+    if (!isHybridLayerWorthShowing(layer)) continue;
+    const prefixedId = SATELLITE_ID_PREFIX + layer.id;
+    if (map.getLayer(prefixedId)) continue;
+    const prefixedLayer = {
+      ...layer,
+      id: prefixedId,
+      ...('source' in layer && layer.source ? { source: SATELLITE_ID_PREFIX + layer.source } : {}),
+    } as maplibregl.LayerSpecification;
+    map.addLayer(prefixedLayer, beforeLayerId);
+    layerIds.push(prefixedId);
+  }
+
+  return { sourceIds, layerIds };
+}
+
+function removeHybridBasemapLayers(map: maplibregl.Map, ids: HybridBasemapIds): void {
+  for (const layerId of ids.layerIds) {
+    if (map.getLayer(layerId)) map.removeLayer(layerId);
+  }
+  for (const sourceId of ids.sourceIds) {
+    if (map.getSource(sourceId)) map.removeSource(sourceId);
+  }
+}
 
 // Bright, chunky line styles for site boundaries
 const SITE_LINE_PAINT = {
@@ -126,6 +219,7 @@ function SiteCreationMap({
   const [isGoogleBasemap, setIsGoogleBasemap] = useState(false);
   const isGoogleBasemapRef = useRef(false);
   const hiddenLayersRef = useRef<string[]>([]);
+  const hybridBasemapIdsRef = useRef<HybridBasemapIds>({ sourceIds: [], layerIds: [] });
   const [drawnPoints, setDrawnPoints] = useState<[number, number][]>([]);
   const [selectedCatchments, setSelectedCatchments] = useState<Map<string, GeoJSON.Feature>>(new Map());
   const [isAnimating, setIsAnimating] = useState(false);
@@ -375,24 +469,10 @@ function SiteCreationMap({
         }, beforeLayer); // Insert below the outlines if layer exists
       }
 
-      // Default to Google satellite in browser runtime — inject it beneath all vector layers
+      // Default to satellite in browser runtime — inject it beneath all vector layers
       if (getAppRuntime() === 'browser') {
         const firstLayerId = map.getStyle()?.layers?.[0]?.id;
-        if (!map.getSource(GOOGLE_SATELLITE_SOURCE_ID)) {
-          map.addSource(GOOGLE_SATELLITE_SOURCE_ID, {
-            type: 'raster',
-            tiles: [satelliteTileUrl()],
-            tileSize: 256,
-            attribution: satelliteAttribution(),
-            maxzoom: 21,
-          });
-        }
-        if (!map.getLayer(GOOGLE_SATELLITE_LAYER_ID)) {
-          map.addLayer(
-            { id: GOOGLE_SATELLITE_LAYER_ID, type: 'raster', source: GOOGLE_SATELLITE_SOURCE_ID },
-            firstLayerId,
-          );
-        }
+
         // Hide fill/background layers so satellite shows through at all zoom levels.
         // Skip catchments-selectable-fill: it's already invisible (opacity 0) and
         // exists purely so click handlers can query it — hiding it would make
@@ -409,6 +489,18 @@ function SiteCreationMap({
         hiddenLayersRef.current = hidden;
         isGoogleBasemapRef.current = true;
         setIsGoogleBasemap(true);
+
+        // The layers themselves arrive a moment later than the state above —
+        // the style has to be fetched first (once; cached for the rest of the
+        // session). The map shows the (now-hidden) vector basemap's bare fills
+        // for that moment rather than nothing, which is the same "unchanged
+        // until it lands" failure mode the flag-only default already accepted.
+        addHybridBasemapLayers(map, firstLayerId)
+          .then((ids) => {
+            if (mapRef.current !== map) return; // unmounted or replaced meanwhile
+            hybridBasemapIdsRef.current = ids;
+          })
+          .catch((err) => console.error('Failed to load satellite basemap:', err));
       }
 
       // If we have initial geometry, display it
@@ -981,34 +1073,24 @@ function SiteCreationMap({
     });
   }, [drawnPoints.length, updateDrawingPreview]);
 
-  const toggleGoogleBasemap = useCallback(() => {
+  // Shared by the toggle button and the quota-exceeded auto-revert below, so
+  // the two cannot drift into applying the switch differently.
+  const applyGoogleBasemap = useCallback((next: boolean) => {
     const map = mapRef.current;
     if (!map) return;
 
-    const next = !isGoogleBasemapRef.current;
     isGoogleBasemapRef.current = next;
     setIsGoogleBasemap(next);
 
     if (next) {
-      if (!map.getSource(GOOGLE_SATELLITE_SOURCE_ID)) {
-        map.addSource(GOOGLE_SATELLITE_SOURCE_ID, {
-          type: 'raster',
-          tiles: [satelliteTileUrl()],
-          tileSize: 256,
-          attribution: satelliteAttribution(),
-          maxzoom: 21,
-        });
-      }
-      if (!map.getLayer(GOOGLE_SATELLITE_LAYER_ID)) {
-        const firstLayerId = map.getStyle()?.layers?.[0]?.id;
-        map.addLayer(
-          { id: GOOGLE_SATELLITE_LAYER_ID, type: 'raster', source: GOOGLE_SATELLITE_SOURCE_ID },
-          firstLayerId,
-        );
-      }
+      const firstLayerId = map.getStyle()?.layers?.[0]?.id;
+
       // Skip catchments-selectable-fill (needed for click detection despite being
       // invisible) and the site boundary's own fill, which must stay visible.
-      const skipHiding = new Set([GOOGLE_SATELLITE_LAYER_ID, 'catchments-selectable-fill', 'site-fill']);
+      // The layers addHybridBasemapLayers is about to add are never fill or
+      // background type (see isHybridLayerWorthShowing), so there is nothing
+      // of theirs for this pass to need to skip.
+      const skipHiding = new Set(['catchments-selectable-fill', 'site-fill']);
       const hidden: string[] = [];
       for (const layer of map.getStyle()?.layers ?? []) {
         if (skipHiding.has(layer.id)) continue;
@@ -1019,9 +1101,17 @@ function SiteCreationMap({
       }
       hiddenLayersRef.current = hidden;
       moveSiteGeometryToTop(map);
+
+      addHybridBasemapLayers(map, firstLayerId)
+        .then((ids) => {
+          if (mapRef.current !== map || !isGoogleBasemapRef.current) return; // unmounted or toggled off meanwhile
+          hybridBasemapIdsRef.current = ids;
+          moveSiteGeometryToTop(map);
+        })
+        .catch((err) => console.error('Failed to load satellite basemap:', err));
     } else {
-      if (map.getLayer(GOOGLE_SATELLITE_LAYER_ID)) map.removeLayer(GOOGLE_SATELLITE_LAYER_ID);
-      if (map.getSource(GOOGLE_SATELLITE_SOURCE_ID)) map.removeSource(GOOGLE_SATELLITE_SOURCE_ID);
+      removeHybridBasemapLayers(map, hybridBasemapIdsRef.current);
+      hybridBasemapIdsRef.current = { sourceIds: [], layerIds: [] };
       for (const layerId of hiddenLayersRef.current) {
         if (map.getLayer(layerId)) {
           map.setLayoutProperty(layerId, 'visibility', 'visible');
@@ -1030,6 +1120,41 @@ function SiteCreationMap({
       hiddenLayersRef.current = [];
     }
   }, []);
+
+  const toggleGoogleBasemap = useCallback(() => {
+    const next = !isGoogleBasemapRef.current;
+
+    if (next && satelliteQuotaExceeded()) {
+      toast({
+        title: 'Satellite imagery limit reached',
+        description: "This month's satellite imagery quota has been used up. "
+          + 'Showing the default map instead.',
+        status: 'warning',
+        duration: 8000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    applyGoogleBasemap(next);
+  }, [applyGoogleBasemap, toast]);
+
+  // If the quota is spent while satellite imagery is actively showing, revert
+  // to the built-in basemap rather than leaving the map to fail tile-by-tile.
+  useEffect(() => {
+    return subscribeSatelliteQuota((exceeded) => {
+      if (!exceeded || !isGoogleBasemapRef.current) return;
+      applyGoogleBasemap(false);
+      toast({
+        title: 'Satellite imagery limit reached',
+        description: "This month's satellite imagery quota has been used up. "
+          + 'Switched to the default map.',
+        status: 'warning',
+        duration: 8000,
+        isClosable: true,
+      });
+    });
+  }, [applyGoogleBasemap, toast]);
 
   const getInstructions = () => {
     switch (mode) {
@@ -1150,11 +1275,11 @@ function SiteCreationMap({
             left={4}
           >
             <Tooltip
-              label={isGoogleBasemap ? 'Switch to default basemap' : 'Switch to Google satellite'}
+              label={isGoogleBasemap ? 'Switch to default basemap' : 'Switch to satellite'}
               placement="right"
             >
               <IconButton
-                aria-label="Toggle Google satellite basemap"
+                aria-label="Toggle satellite basemap"
                 icon={<FiGlobe />}
                 size="sm"
                 onClick={toggleGoogleBasemap}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -5,7 +5,7 @@ import { getAppRuntime } from '../types/runtime';
 import { WALKTHROUGH_SITE_IDS } from '../constants/walkthroughSites';
 import { applyAOIWeightedIndicators } from '../utils/indicators';
 import { evictExpired } from '../lib/ttlCache';
-import { loadSite, loadSites, saveSite, saveSites } from '../lib/siteStore';
+import { loadSite, loadSites, saveSite, saveSites, deleteSite as deleteSiteRecord } from '../lib/siteStore';
 
 const API_BASE = '/api';
 /**
@@ -101,14 +101,25 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return response.json();
 }
 
+// How often to re-fetch /api/info after the first load. Version/data-loaded
+// status never changes at runtime, but satellite_quota_exceeded can flip mid
+// session — this is what lets a map that is actively showing satellite
+// imagery notice the quota was spent and fall back, without a page reload.
+const SERVER_INFO_POLL_MS = 60_000;
+
 export function useServerInfo() {
   const [info, setInfo] = useState<ServerInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchJSON<ServerInfo>(`${API_BASE}/info`)
-      .then(setInfo)
-      .catch((e) => setError(e.message));
+    const load = () => {
+      fetchJSON<ServerInfo>(`${API_BASE}/info`)
+        .then(setInfo)
+        .catch((e) => setError(e.message));
+    };
+    load();
+    const interval = setInterval(load, SERVER_INFO_POLL_MS);
+    return () => clearInterval(interval);
   }, []);
 
   return { info, error };
@@ -961,9 +972,16 @@ export async function patchSiteIndicators(
 
 export async function deleteSite(id: string): Promise<void> {
   if (isBrowserRuntime()) {
-    const sites = loadLocalSites();
-    const nextSites = sites.filter((site) => site.id !== id);
-    saveLocalSites(sortSitesByCreatedAtDesc(nextSites));
+    // The dedicated single-record primitive, not load-all/filter/save-all: a
+    // delete should only ever need to free space, never touch another site's
+    // record. Going through saveLocalSites used to read and potentially
+    // rewrite every *other* site too (normalising legacy formatting drift),
+    // and that rewrite could itself throw under a genuinely full quota —
+    // meaning a delete, the one operation that should get you out of "full",
+    // could fail before it ever reached the removal.
+    if (!deleteSiteRecord(id)) {
+      throw new Error('Failed to delete site: browser storage write failed.');
+    }
     return;
   }
 

--- a/frontend/src/lib/satelliteBasemap.ts
+++ b/frontend/src/lib/satelliteBasemap.ts
@@ -17,9 +17,9 @@ import type { ServerInfo } from '../types';
  * concern (`--satellite-style-url`), configurable without a rebuild. See
  * issue #65.
  *
- * `/api/info` carries the value (and the quota status) to the client, so
- * nothing needs rebuilding to change it — unlike `import.meta.env`, which Vite
- * inlines at build time.
+ * `/api/info` carries the value (and availability/quota status) to the
+ * client, so nothing needs rebuilding to change it — unlike `import.meta.env`,
+ * which Vite inlines at build time.
  */
 export const DEFAULT_SATELLITE_STYLE_URL = '/api/satellite-style.json';
 
@@ -34,14 +34,25 @@ export const DEFAULT_SATELLITE_ATTRIBUTION =
 let styleUrl = DEFAULT_SATELLITE_STYLE_URL;
 let attribution = DEFAULT_SATELLITE_ATTRIBUTION;
 let quotaExceeded = false;
+// Optimistic default: unknown until /api/info resolves, and "assume it works"
+// is the same failure mode applyServerSatelliteConfig's own doc comment
+// already accepts for the rest of this module — a map that initialises before
+// the first response keeps trying, rather than never offering satellite at
+// all while a perfectly good key is loading.
+let available = true;
 
-type QuotaListener = (exceeded: boolean) => void;
-const quotaListeners = new Set<QuotaListener>();
+type UnavailableListener = (unavailable: boolean) => void;
+const unavailableListeners = new Set<UnavailableListener>();
+
+/** Combines the two reasons satellite might not be usable right now. */
+function unavailable(): boolean {
+  return quotaExceeded || !available;
+}
 
 /**
  * Adopt the server's configuration. Called each time `/api/info` resolves —
- * see useApi.ts's useServerInfo, which polls it so a quota that becomes
- * exceeded mid-session is noticed without a page reload.
+ * see useApi.ts's useServerInfo, which polls it so quota being spent, or a
+ * deployment with no provider key, is noticed without a page reload.
  *
  * A map that initialises before the first response lands keeps the default,
  * which is the same imagery the application showed before this existed — so
@@ -57,10 +68,16 @@ export function applyServerSatelliteConfig(info: ServerInfo | null | undefined):
     attribution = info.satellite_attribution ?? '';
   }
 
-  const exceeded = info?.satellite_quota_exceeded ?? false;
-  if (exceeded !== quotaExceeded) {
-    quotaExceeded = exceeded;
-    for (const listener of quotaListeners) listener(quotaExceeded);
+  const wasUnavailable = unavailable();
+
+  quotaExceeded = info?.satellite_quota_exceeded ?? false;
+  // Missing field (an older server, or a response that raced applyServer-
+  // SatelliteConfig before /api/info finished) defaults to available: the
+  // same "assume it works" the module-level default above already commits to.
+  available = info?.satellite_available ?? true;
+
+  if (unavailable() !== wasUnavailable) {
+    for (const listener of unavailableListeners) listener(unavailable());
   }
 }
 
@@ -84,20 +101,27 @@ export function satelliteAttribution(): string {
   return attribution;
 }
 
-/** Whether this deployment's monthly satellite tile quota is currently spent. */
-export function satelliteQuotaExceeded(): boolean {
-  return quotaExceeded;
+/**
+ * Whether the satellite basemap can be shown right now — either this month's
+ * quota is spent, or no provider is configured (no key, and no operator-set
+ * style URL; see config.Config.SatelliteAvailable on the server). Either way
+ * the answer for the client is the same: don't offer it, and if it's already
+ * showing, fall back.
+ */
+export function satelliteUnavailable(): boolean {
+  return unavailable();
 }
 
 /**
- * Notify a listener whenever the quota-exceeded state changes (in either
- * direction — a new calendar month un-exceeds it). Used by the map components
- * to revert to the built-in basemap and warn the user without polling
- * themselves. Returns an unsubscribe function.
+ * Notify a listener whenever satelliteUnavailable's value changes (in either
+ * direction — a new calendar month un-exceeds the quota, or a key gets
+ * configured and the server restarts). Used by the map components to revert
+ * to the built-in basemap and warn the user without polling themselves.
+ * Returns an unsubscribe function.
  */
-export function subscribeSatelliteQuota(listener: QuotaListener): () => void {
-  quotaListeners.add(listener);
-  return () => quotaListeners.delete(listener);
+export function subscribeSatelliteUnavailable(listener: UnavailableListener): () => void {
+  unavailableListeners.add(listener);
+  return () => unavailableListeners.delete(listener);
 }
 
 /** Exported for tests. */
@@ -105,4 +129,5 @@ export function resetSatelliteConfig(): void {
   styleUrl = DEFAULT_SATELLITE_STYLE_URL;
   attribution = DEFAULT_SATELLITE_ATTRIBUTION;
   quotaExceeded = false;
+  available = true;
 }

--- a/frontend/src/lib/satelliteBasemap.ts
+++ b/frontend/src/lib/satelliteBasemap.ts
@@ -3,66 +3,106 @@ import type { ServerInfo } from '../types';
 /**
  * The satellite basemap, defined once.
  *
- * The tile URL used to be written out twice — in `MapView.tsx` and in
+ * The style URL used to be written out twice — in `MapView.tsx` and in
  * `SiteCreationMap.tsx` — so changing provider meant finding both.
  *
- * The default is still Google's `mt0.google.com/vt` endpoint. That endpoint is
- * undocumented and unauthenticated, which is precisely why it works without a key
- * and precisely why using it sits outside the Google Maps terms of service. It is
- * kept as the default deliberately, as a separate decision from this refactor:
- * the point here is that switching provider is now a configuration change rather
- * than a code change. See issue #65.
+ * Every tile the style references is fetched through this server's own proxy
+ * (`/api/satellite-style.json` and friends), not the upstream provider
+ * directly: see internal/server/satellite.go for why — in short, a keyed
+ * provider's key can never reach browser JavaScript, and a provider's free
+ * tier is usually conditioned on a monthly tile count that the browser
+ * fetching tiles directly would make invisible to the one process able to
+ * enforce it. `DEFAULT_SATELLITE_STYLE_URL` here is therefore always a local,
+ * relative path; the actual imagery provider is an upstream-only server
+ * concern (`--satellite-style-url`), configurable without a rebuild. See
+ * issue #65.
  *
- * Supply a replacement at runtime with `--satellite-tile-url` (or
- * `DT_SATELLITE_TILE_URL`) on the server. `/api/info` carries the value to the
- * client, so nothing needs rebuilding to change it — unlike `import.meta.env`,
- * which Vite inlines at build time.
+ * `/api/info` carries the value (and the quota status) to the client, so
+ * nothing needs rebuilding to change it — unlike `import.meta.env`, which Vite
+ * inlines at build time.
  */
-export const DEFAULT_SATELLITE_TILE_URL =
-  'https://mt0.google.com/vt/lyrs=y&x={x}&y={y}&z={z}';
+export const DEFAULT_SATELLITE_STYLE_URL = '/api/satellite-style.json';
 
-export const DEFAULT_SATELLITE_ATTRIBUTION = '© Google Maps';
+export const DEFAULT_SATELLITE_ATTRIBUTION =
+  '<a href="https://www.maptiler.com/copyright/" target="_blank">© MapTiler</a> ' +
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>';
 
 // Module state rather than React state: both call sites read this inside a
-// maplibre `addSource` call during map initialisation, not during render, so
-// threading it through props would mean restructuring two large components for no
+// maplibre call during map initialisation, not during render, so threading it
+// through props would mean restructuring two large components for no
 // behavioural gain.
-let tileUrl = DEFAULT_SATELLITE_TILE_URL;
+let styleUrl = DEFAULT_SATELLITE_STYLE_URL;
 let attribution = DEFAULT_SATELLITE_ATTRIBUTION;
+let quotaExceeded = false;
+
+type QuotaListener = (exceeded: boolean) => void;
+const quotaListeners = new Set<QuotaListener>();
 
 /**
- * Adopt the server's configuration. Called once when `/api/info` resolves.
+ * Adopt the server's configuration. Called each time `/api/info` resolves —
+ * see useApi.ts's useServerInfo, which polls it so a quota that becomes
+ * exceeded mid-session is noticed without a page reload.
  *
- * A map that initialises before that lands keeps the default, which is the same
- * imagery the application showed before this existed — so the failure mode is
- * "unchanged", not "no basemap".
+ * A map that initialises before the first response lands keeps the default,
+ * which is the same imagery the application showed before this existed — so
+ * the failure mode is "unchanged", not "no basemap".
  */
 export function applyServerSatelliteConfig(info: ServerInfo | null | undefined): void {
-  if (!info?.satellite_tile_url) return;
+  if (info?.satellite_style_url) {
+    // The two move together. Taking the URL while keeping whatever attribution
+    // was already set would credit the previous provider for somebody else's
+    // imagery, which is worse than crediting nobody. An empty attribution from
+    // the server is a deliberate empty, not a missing value.
+    styleUrl = info.satellite_style_url;
+    attribution = info.satellite_attribution ?? '';
+  }
 
-  // The two move together. Taking the URL while keeping whatever attribution was
-  // already set would credit the previous provider — by default Google — for
-  // somebody else's imagery, which is worse than crediting nobody. An empty
-  // attribution from the server is a deliberate empty, not a missing value.
-  tileUrl = info.satellite_tile_url;
-  attribution = info.satellite_attribution ?? '';
+  const exceeded = info?.satellite_quota_exceeded ?? false;
+  if (exceeded !== quotaExceeded) {
+    quotaExceeded = exceeded;
+    for (const listener of quotaListeners) listener(quotaExceeded);
+  }
 }
 
-export function satelliteTileUrl(): string {
-  return tileUrl;
+/** The (local, proxied) style URL to pass to maplibre. */
+export function satelliteStyleUrl(): string {
+  return styleUrl;
 }
 
 /**
- * Attribution follows the provider. Hardcoding "© Google Maps" would credit the
+ * Attribution follows the provider. Hardcoding a fixed string would credit the
  * wrong party the moment someone configures a different endpoint — and for most
  * providers the attribution is a licence condition, not a courtesy.
+ *
+ * In practice the fetched style already carries correct attribution on its own
+ * sources, which MapLibre's attribution control reads directly — this getter
+ * exists for SiteCreationMap.tsx, which merges the style's layers into an
+ * existing map rather than loading it wholesale, and so needs to add the
+ * attribution itself.
  */
 export function satelliteAttribution(): string {
   return attribution;
 }
 
+/** Whether this deployment's monthly satellite tile quota is currently spent. */
+export function satelliteQuotaExceeded(): boolean {
+  return quotaExceeded;
+}
+
+/**
+ * Notify a listener whenever the quota-exceeded state changes (in either
+ * direction — a new calendar month un-exceeds it). Used by the map components
+ * to revert to the built-in basemap and warn the user without polling
+ * themselves. Returns an unsubscribe function.
+ */
+export function subscribeSatelliteQuota(listener: QuotaListener): () => void {
+  quotaListeners.add(listener);
+  return () => quotaListeners.delete(listener);
+}
+
 /** Exported for tests. */
 export function resetSatelliteConfig(): void {
-  tileUrl = DEFAULT_SATELLITE_TILE_URL;
+  styleUrl = DEFAULT_SATELLITE_STYLE_URL;
   attribution = DEFAULT_SATELLITE_ATTRIBUTION;
+  quotaExceeded = false;
 }

--- a/frontend/src/lib/siteStore.ts
+++ b/frontend/src/lib/siteStore.ts
@@ -101,12 +101,33 @@ function readRecord(id: string): Site | null {
   }
 }
 
+/** Whether the per-site index has ever been written, even as an empty list. */
+function indexKeyExists(): boolean {
+  if (!isBrowser()) return false;
+  try {
+    return window.localStorage.getItem(INDEX_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Move a legacy `dt-sites` blob to per-site records.
  *
- * Runs at most once: the blob is removed on success. If writing any record
- * fails — a full quota, most likely — the blob is left alone so nothing is
- * lost, and the next read tries again.
+ * Intended to run at most once: the blob is removed on success. If writing any
+ * record fails — a full quota, most likely — the blob used to be left alone so
+ * the next read would try again. Under a quota that never recovers (the blob
+ * itself, a full duplicate of everything, was often *why* it was full) that
+ * meant it never went away, and every read kept re-migrating it — including
+ * sites the per-site store had since had deleted, resurrecting them on every
+ * load with no error to explain why the delete "didn't work".
+ *
+ * So a second condition ends the retries even without a successful migration:
+ * once the per-site index has ever been written — by this function or by an
+ * ordinary create/update/delete — the per-site store is the live system of
+ * record, and the legacy blob is stale by definition. It is discarded rather
+ * than merged, on the same best-effort basis as everything else here: freeing
+ * the space it held matters more than a blob nothing will read again.
  *
  * Returns the migrated sites, or null when there was nothing to migrate.
  */
@@ -120,6 +141,11 @@ export function migrateLegacyStore(): Site[] | null {
     return null;
   }
   if (!raw) return null;
+
+  if (indexKeyExists()) {
+    safeRemoveItem(LEGACY_KEY);
+    return null;
+  }
 
   let parsed: unknown;
   try {
@@ -219,9 +245,11 @@ export function saveSites(sites: Site[]): boolean {
   }
 
   // Records dropped from the list are deleted, so the store cannot accumulate
-  // sites the caller believes it removed.
+  // sites the caller believes it removed. A failed removal must fail the whole
+  // save — otherwise the caller (and the index write below) reports success
+  // while an orphaned record silently survives on disk.
   for (const id of readIndex()) {
-    if (!ids.includes(id)) safeRemoveItem(recordKey(id));
+    if (!ids.includes(id) && !safeRemoveItem(recordKey(id))) ok = false;
   }
 
   if (!writeIndex(ids)) ok = false;

--- a/frontend/src/test/deleteSite.test.ts
+++ b/frontend/src/test/deleteSite.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { deleteSite, saveLocalSite } from '../hooks/useApi';
+import { clearSiteStore } from '../lib/siteStore';
+import type { Site } from '../types';
+
+// hooks/useApi.ts's deleteSite used to discard saveLocalSites' success/failure
+// result in the browser runtime, so a failed localStorage write was reported to
+// the caller (SitesPage.tsx) as a successful delete — the "Site deleted" toast
+// fired, and the site reappeared on the next load with no error ever shown.
+
+function site(id: string): Site {
+  return {
+    id,
+    title: `site ${id}`,
+    createdAt: '2026-01-01T00:00:00Z',
+  } as unknown as Site;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  clearSiteStore();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('deleteSite (browser runtime)', () => {
+  it('removes a site that was actually stored', async () => {
+    saveLocalSite(site('a'));
+
+    await deleteSite('a');
+
+    expect(window.localStorage.getItem('dt-site:a')).toBeNull();
+  });
+
+  it('throws rather than reporting success when the underlying write fails', async () => {
+    saveLocalSite(site('a'));
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    await expect(deleteSite('a')).rejects.toThrow();
+  });
+});

--- a/frontend/src/test/satelliteBasemap.test.ts
+++ b/frontend/src/test/satelliteBasemap.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
-  DEFAULT_SATELLITE_TILE_URL,
+  DEFAULT_SATELLITE_STYLE_URL,
   DEFAULT_SATELLITE_ATTRIBUTION,
   applyServerSatelliteConfig,
   resetSatelliteConfig,
   satelliteAttribution,
-  satelliteTileUrl,
+  satelliteStyleUrl,
+  satelliteQuotaExceeded,
+  subscribeSatelliteQuota,
 } from '../lib/satelliteBasemap';
 import type { ServerInfo } from '../types';
 
-// The tile template was written out twice, in MapView and SiteCreationMap, so
+// The style URL was written out twice, in MapView and SiteCreationMap, so
 // changing provider meant finding both. It is defined here once and supplied at
 // runtime by /api/info — unlike import.meta.env, which Vite inlines at build time.
 
@@ -24,17 +26,17 @@ describe('satellite basemap configuration', () => {
   beforeEach(() => resetSatelliteConfig());
 
   it('falls back to the built-in default', () => {
-    expect(satelliteTileUrl()).toBe(DEFAULT_SATELLITE_TILE_URL);
+    expect(satelliteStyleUrl()).toBe(DEFAULT_SATELLITE_STYLE_URL);
     expect(satelliteAttribution()).toBe(DEFAULT_SATELLITE_ATTRIBUTION);
   });
 
   it('adopts the server value', () => {
     applyServerSatelliteConfig(info({
-      satellite_tile_url: 'https://example.test/{z}/{x}/{y}.jpg',
+      satellite_style_url: 'https://example.test/style.json',
       satellite_attribution: '© Example',
     }));
 
-    expect(satelliteTileUrl()).toBe('https://example.test/{z}/{x}/{y}.jpg');
+    expect(satelliteStyleUrl()).toBe('https://example.test/style.json');
     expect(satelliteAttribution()).toBe('© Example');
   });
 
@@ -42,29 +44,31 @@ describe('satellite basemap configuration', () => {
   // same imagery as before this existed.
   it('keeps the default when the server says nothing', () => {
     applyServerSatelliteConfig(info({}));
-    expect(satelliteTileUrl()).toBe(DEFAULT_SATELLITE_TILE_URL);
+    expect(satelliteStyleUrl()).toBe(DEFAULT_SATELLITE_STYLE_URL);
 
     applyServerSatelliteConfig(null);
-    expect(satelliteTileUrl()).toBe(DEFAULT_SATELLITE_TILE_URL);
+    expect(satelliteStyleUrl()).toBe(DEFAULT_SATELLITE_STYLE_URL);
 
     applyServerSatelliteConfig(undefined);
-    expect(satelliteTileUrl()).toBe(DEFAULT_SATELLITE_TILE_URL);
+    expect(satelliteStyleUrl()).toBe(DEFAULT_SATELLITE_STYLE_URL);
   });
 
   // Attribution is a licence condition for most providers, so it must not be
   // silently dropped when only the URL is configured.
   it('does not credit the default provider for someone else’s imagery', () => {
     applyServerSatelliteConfig(info({
-      satellite_tile_url: 'https://example.test/{z}/{x}/{y}.jpg',
+      satellite_style_url: 'https://example.test/style.json',
       satellite_attribution: '',
     }));
 
-    expect(satelliteTileUrl()).toBe('https://example.test/{z}/{x}/{y}.jpg');
-    expect(satelliteAttribution()).not.toContain('Google');
+    expect(satelliteStyleUrl()).toBe('https://example.test/style.json');
+    expect(satelliteAttribution()).not.toContain('MapTiler');
   });
 
-  // The point of the change: one definition, not two.
-  it('is the only place the tile template is written', async () => {
+  // The point of the change: one definition, not two — and the key (baked into
+  // the default upstream URL server-side) must never appear in bundled
+  // frontend source, or it would be visible to anyone reading the page.
+  it('never writes the upstream URL or key directly into the components', async () => {
     const sources = await Promise.all([
       import('../components/MapView?raw'),
       import('../components/SiteCreationMap?raw'),
@@ -73,7 +77,60 @@ describe('satellite basemap configuration', () => {
     // than assert on nothing.
     if (!sources) return;
     for (const module of sources) {
-      expect(String((module as { default?: string }).default ?? '')).not.toContain('mt0.google.com');
+      const text = String((module as { default?: string }).default ?? '');
+      expect(text).not.toContain('api.maptiler.com');
+      expect(text).not.toContain('mt0.google.com');
     }
+  });
+});
+
+// The client cannot see the server's tile count directly; it only learns
+// whether the monthly quota is spent through /api/info. These tests pin how
+// that flag propagates, since a map component reacting to the wrong signal
+// would either strand the user on a failing satellite view or never let them
+// use it at all.
+describe('satellite quota tracking', () => {
+  beforeEach(() => resetSatelliteConfig());
+
+  it('is not exceeded by default', () => {
+    expect(satelliteQuotaExceeded()).toBe(false);
+  });
+
+  it('adopts the server-reported quota state', () => {
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
+    expect(satelliteQuotaExceeded()).toBe(true);
+
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
+    expect(satelliteQuotaExceeded()).toBe(false);
+  });
+
+  it('treats a missing flag as not exceeded', () => {
+    applyServerSatelliteConfig(info({}));
+    expect(satelliteQuotaExceeded()).toBe(false);
+  });
+
+  it('notifies subscribers only when the state actually changes', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSatelliteQuota(listener);
+
+    // Already false: no change, no call.
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
+    expect(listener).not.toHaveBeenCalled();
+
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(true);
+
+    // Repeating the same value must not notify again.
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(false);
+
+    unsubscribe();
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/test/satelliteBasemap.test.ts
+++ b/frontend/src/test/satelliteBasemap.test.ts
@@ -6,8 +6,8 @@ import {
   resetSatelliteConfig,
   satelliteAttribution,
   satelliteStyleUrl,
-  satelliteQuotaExceeded,
-  subscribeSatelliteQuota,
+  satelliteUnavailable,
+  subscribeSatelliteUnavailable,
 } from '../lib/satelliteBasemap';
 import type { ServerInfo } from '../types';
 
@@ -84,36 +84,63 @@ describe('satellite basemap configuration', () => {
   });
 });
 
-// The client cannot see the server's tile count directly; it only learns
-// whether the monthly quota is spent through /api/info. These tests pin how
-// that flag propagates, since a map component reacting to the wrong signal
-// would either strand the user on a failing satellite view or never let them
-// use it at all.
-describe('satellite quota tracking', () => {
+// The client cannot see the server's tile count or its configured key
+// directly; it only learns whether satellite can be shown through /api/info.
+// satelliteUnavailable() combines both reasons it might not be — quota spent,
+// or no provider configured at all — into one signal, since a map component
+// reacting to either the wrong signal or only one of the two reasons would
+// either strand the user on a failing satellite view or never let them use it.
+describe('satellite availability and quota tracking', () => {
   beforeEach(() => resetSatelliteConfig());
 
-  it('is not exceeded by default', () => {
-    expect(satelliteQuotaExceeded()).toBe(false);
+  it('is available by default', () => {
+    expect(satelliteUnavailable()).toBe(false);
   });
 
   it('adopts the server-reported quota state', () => {
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
-    expect(satelliteQuotaExceeded()).toBe(true);
+    expect(satelliteUnavailable()).toBe(true);
 
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
-    expect(satelliteQuotaExceeded()).toBe(false);
+    expect(satelliteUnavailable()).toBe(false);
   });
 
-  it('treats a missing flag as not exceeded', () => {
+  it('treats a missing quota flag as not exceeded', () => {
     applyServerSatelliteConfig(info({}));
-    expect(satelliteQuotaExceeded()).toBe(false);
+    expect(satelliteUnavailable()).toBe(false);
   });
 
-  it('notifies subscribers only when the state actually changes', () => {
-    const listener = vi.fn();
-    const unsubscribe = subscribeSatelliteQuota(listener);
+  // No provider configured (no key, no operator style URL) — see
+  // config.Config.SatelliteAvailable on the server.
+  it('adopts the server-reported availability state', () => {
+    applyServerSatelliteConfig(info({ satellite_available: false }));
+    expect(satelliteUnavailable()).toBe(true);
 
-    // Already false: no change, no call.
+    applyServerSatelliteConfig(info({ satellite_available: true }));
+    expect(satelliteUnavailable()).toBe(false);
+  });
+
+  it('treats a missing availability flag as available', () => {
+    applyServerSatelliteConfig(info({}));
+    expect(satelliteUnavailable()).toBe(false);
+  });
+
+  it('is unavailable if either reason applies', () => {
+    applyServerSatelliteConfig(info({ satellite_available: false, satellite_quota_exceeded: false }));
+    expect(satelliteUnavailable()).toBe(true);
+
+    applyServerSatelliteConfig(info({ satellite_available: true, satellite_quota_exceeded: true }));
+    expect(satelliteUnavailable()).toBe(true);
+
+    applyServerSatelliteConfig(info({ satellite_available: true, satellite_quota_exceeded: false }));
+    expect(satelliteUnavailable()).toBe(false);
+  });
+
+  it('notifies subscribers only when the combined state actually changes', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSatelliteUnavailable(listener);
+
+    // Already available: no change, no call.
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
     expect(listener).not.toHaveBeenCalled();
 
@@ -125,7 +152,12 @@ describe('satellite quota tracking', () => {
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
     expect(listener).toHaveBeenCalledTimes(1);
 
-    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false }));
+    // Still unavailable — quota clears but the key is now missing — so no
+    // notification: the combined signal has not actually changed.
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false, satellite_available: false }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    applyServerSatelliteConfig(info({ satellite_quota_exceeded: false, satellite_available: true }));
     expect(listener).toHaveBeenCalledTimes(2);
     expect(listener).toHaveBeenLastCalledWith(false);
 

--- a/frontend/src/test/siteStore.test.ts
+++ b/frontend/src/test/siteStore.test.ts
@@ -146,6 +146,41 @@ describe('migration from the single blob', () => {
     window.localStorage.setItem(LEGACY_KEY, JSON.stringify([site('a'), site('b')]));
     expect(loadSites().map((s) => s.id)).toEqual(['a', 'b']);
   });
+
+  // The actual bug: a legacy blob that never fully migrated (a full-quota
+  // profile, most likely — the blob itself is a duplicate of everything, so it
+  // could easily be *why* the quota was full) survived indefinitely and kept
+  // being re-read as authoritative. A site deleted through the per-site store
+  // reappeared on every subsequent load because the stale blob still listed
+  // it, with no error anywhere to explain why the delete "didn't work".
+  it('does not resurrect a site deleted from an already-active per-site store', () => {
+    // The per-site store is already live: two sites exist as real records.
+    saveSites([site('a'), site('b')]);
+
+    // A legacy blob still lingers from before the per-site store existed,
+    // listing a stale version of 'a' plus a site never migrated at all.
+    window.localStorage.setItem(LEGACY_KEY, JSON.stringify([
+      site('a', { title: 'stale pre-migration copy' }),
+      site('zzz'),
+    ]));
+
+    expect(deleteSite('a')).toBe(true);
+
+    // Reads after the delete — including a fresh one simulating a page
+    // reload — must not see 'a' again, and must not gain 'zzz' either: the
+    // blob is stale, not a second source of truth to merge in.
+    expect(loadSites().map((s) => s.id)).toEqual(['b']);
+    expect(loadSites().map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('discards a stale blob outright once the per-site index already exists, even if empty', () => {
+    saveSites([site('a')]);
+    deleteSite('a'); // index now exists and is empty
+    window.localStorage.setItem(LEGACY_KEY, JSON.stringify([site('resurrected')]));
+
+    expect(loadSites()).toEqual([]);
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
 });
 
 describe('reading and writing', () => {
@@ -189,6 +224,20 @@ describe('reading and writing', () => {
 
     expect(loadSites().map((s) => s.id)).toEqual(['a']);
     expect(window.localStorage.getItem('dt-site:b')).toBeNull();
+  });
+
+  // A failed removal used to be silently ignored: the index write could still
+  // succeed on its own, so saveSites reported success while an orphaned record
+  // for the "deleted" site stayed on disk — a delete the caller believed had
+  // happened, with no error to tell it otherwise.
+  it('reports failure when a dropped record cannot be removed', () => {
+    saveSites([site('a'), site('b')]);
+
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    expect(saveSites([site('a')])).toBe(false);
   });
 
   it('never stores the breakdown, however it arrives', () => {

--- a/frontend/src/test/siteStore.test.ts
+++ b/frontend/src/test/siteStore.test.ts
@@ -521,19 +521,19 @@ describe('the cache never outlives what it describes', () => {
     expect(loadSites().map((s) => s.id)).toEqual(['b']);
   });
 
-  it('migrates the legacy blob even with a warm cache, and indexes it', () => {
+  // Mirrors 'discards a stale blob outright once the per-site index already
+  // exists' above, specifically for a cache that is already warm: the blob is
+  // stale by definition once real per-site data exists (see
+  // migrateLegacyStore's indexKeyExists check), so it must not resurrect
+  // anything even when a prior read has already cached what is really there.
+  it('discards a legacy blob that appears after the cache is warm, keeping what is already there', () => {
     saveSites([site('kept')]);
     loadSites();
 
     window.localStorage.setItem(LEGACY_KEY, JSON.stringify([site('old-a'), site('old-b')]));
 
-    expect(loadSites().map((s) => s.id)).toEqual(['old-a', 'old-b']);
+    expect(loadSites().map((s) => s.id)).toEqual(['kept']);
     expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
-    expect(JSON.parse(window.localStorage.getItem('dt-site-index') as string)).toEqual([
-      'old-a',
-      'old-b',
-    ]);
-    // The migrated records are readable through the cache that was already warm.
-    expect(loadSite('old-a')?.title).toBe('site old-a');
+    expect(loadSite('old-a')).toBeNull();
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,11 +14,15 @@ export interface ServerInfo {
   version: string;
   tiles_loaded: boolean;
   geo_loaded: boolean;
-  /** Satellite raster tile template, supplied at runtime so changing provider
-   *  needs no rebuild. See lib/satelliteBasemap.ts. */
-  satellite_tile_url?: string;
+  /** Satellite basemap style document. Always this server's own proxy — see
+   *  lib/satelliteBasemap.ts for why the browser does not fetch tiles (or the
+   *  style itself) from the provider directly. */
+  satellite_style_url?: string;
   /** Attribution for the above — a licence condition for most providers. */
   satellite_attribution?: string;
+  /** True once this deployment's monthly satellite tile quota is spent. The
+   *  client should not offer the satellite basemap while this is true. */
+  satellite_quota_exceeded?: boolean;
 }
 
 export interface TilesetMetadata {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -20,6 +20,10 @@ export interface ServerInfo {
   satellite_style_url?: string;
   /** Attribution for the above — a licence condition for most providers. */
   satellite_attribution?: string;
+  /** False when no satellite provider is configured at all (no key, no
+   *  operator-set style URL) — see config.Config.SatelliteAvailable. The
+   *  client should not offer the satellite basemap while this is false. */
+  satellite_available?: boolean;
   /** True once this deployment's monthly satellite tile quota is spent. The
    *  client should not offer the satellite basemap while this is true. */
   satellite_quota_exceeded?: boolean;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
       '/tiles': 'http://localhost:8080',
       '/data': 'http://localhost:8080',
       '/docs': 'http://localhost:8080',
+      // The satellite style's "glyphs" field is a relative path
+      // (/fonts/{fontstack}/{range}.pbf), which MapLibre resolves against the
+      // style's own URL — i.e. against this dev server's origin, not the
+      // backend's. Without this entry Vite's SPA fallback served index.html
+      // for every glyph request (200 OK, text/html), which MapLibre can't
+      // parse as a glyph range, silently breaking every symbol-layer label
+      // (place names, road names, city labels — 7 of the Hybrid style's 17
+      // layers) while the map otherwise looked like it had loaded fine.
+      '/fonts': 'http://localhost:8080',
     },
   },
   build: {

--- a/internal/api/cancellation_test.go
+++ b/internal/api/cancellation_test.go
@@ -30,7 +30,7 @@ func newCancelTestHandler(t *testing.T) (*mux.Router, *Handler) {
 	}
 	t.Cleanup(store.Close)
 
-	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"}, nil)
 	r := mux.NewRouter()
 	handler.RegisterRoutes(r)
 	return r, handler

--- a/internal/api/catchment_values_test.go
+++ b/internal/api/catchment_values_test.go
@@ -28,7 +28,7 @@ func newValuesTestHandler(t *testing.T) *mux.Router {
 	}
 	t.Cleanup(store.Close)
 
-	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"}, nil)
 	r := mux.NewRouter()
 	handler.RegisterRoutes(r)
 	return r

--- a/internal/api/desktopsiteroutes_test.go
+++ b/internal/api/desktopsiteroutes_test.go
@@ -40,7 +40,7 @@ func routerFor(t *testing.T, desktop bool) *mux.Router {
 		DataDir:     dir,
 		Version:     "test",
 		DesktopMode: desktop,
-	})
+	}, nil)
 	r := mux.NewRouter()
 	h.RegisterRoutes(r)
 	return r
@@ -212,7 +212,7 @@ func TestServerModeRequestCannotDeleteASiteFromDisk(t *testing.T) {
 
 	h := NewHandler(nil, nil, siteStore, config.Config{
 		Port: 0, DataDir: dir, Version: "test", DesktopMode: false,
-	})
+	}, nil)
 	r := mux.NewRouter()
 	h.RegisterRoutes(r)
 
@@ -272,7 +272,7 @@ func TestDesktopModeRequestCanDeleteASite(t *testing.T) {
 
 	h := NewHandler(nil, nil, siteStore, config.Config{
 		Port: 0, DataDir: dir, Version: "test", DesktopMode: true,
-	})
+	}, nil)
 	r := mux.NewRouter()
 	h.RegisterRoutes(r)
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -34,6 +34,7 @@ type Handler struct {
 	gpkgStore          *geodata.GpkgStore
 	siteStore          *sites.Store
 	cfg                config.Config
+	satelliteUsage     *config.SatelliteUsage
 	metaCache          *MetadataCache
 	lookupsMu          sync.RWMutex
 	lookups            *LookupTables
@@ -55,13 +56,15 @@ func NewHandler(
 	gpkgStore *geodata.GpkgStore,
 	siteStore *sites.Store,
 	cfg config.Config,
+	satelliteUsage *config.SatelliteUsage,
 ) *Handler {
 	h := &Handler{
-		tileStore: tileStore,
-		gpkgStore: gpkgStore,
-		siteStore: siteStore,
-		cfg:       cfg,
-		metaCache: loadMetadataCache(cfg.DataDir),
+		tileStore:      tileStore,
+		gpkgStore:      gpkgStore,
+		siteStore:      siteStore,
+		cfg:            cfg,
+		satelliteUsage: satelliteUsage,
+		metaCache:      loadMetadataCache(cfg.DataDir),
 	}
 
 	// metadata.csv is exported from R, whose make.names() rewrites spaces and
@@ -362,17 +365,29 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleInfo returns server information
 func (h *Handler) handleInfo(w http.ResponseWriter, r *http.Request) {
-	// The satellite basemap is supplied here rather than baked into the bundle:
-	// import.meta.env is inlined by Vite at build time, so a VITE_ variable would
-	// need a rebuild to change. See config.Config.SatelliteTileURL.
-	satelliteURL, satelliteAttribution := h.cfg.Satellite()
+	// satellite_style_url points at this server's own proxy (see
+	// internal/server/satellite.go), not the configured upstream: the browser
+	// never talks to the provider directly, so every tile the style references
+	// can be counted and quota-limited, and the key never reaches client
+	// JavaScript. The attribution still names the real imagery source.
+	//
+	// Supplied here rather than baked into the bundle: import.meta.env is
+	// inlined by Vite at build time, so a VITE_ variable would need a rebuild to
+	// change. See config.Config.Satellite.
+	_, satelliteAttribution := h.cfg.Satellite()
+
+	quotaExceeded := false
+	if h.satelliteUsage != nil {
+		_, quotaExceeded = h.satelliteUsage.Snapshot(h.cfg.SatelliteQuota())
+	}
 
 	info := map[string]interface{}{
-		"version":               h.cfg.Version,
-		"tiles_loaded":          h.tileStore != nil,
-		"geo_loaded":            h.gpkgStore != nil,
-		"satellite_tile_url":    satelliteURL,
-		"satellite_attribution": satelliteAttribution,
+		"version":                  h.cfg.Version,
+		"tiles_loaded":             h.tileStore != nil,
+		"geo_loaded":               h.gpkgStore != nil,
+		"satellite_style_url":      "/api/satellite-style.json",
+		"satellite_attribution":    satelliteAttribution,
+		"satellite_quota_exceeded": quotaExceeded,
 	}
 	respondJSON(w, http.StatusOK, info)
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -387,6 +387,7 @@ func (h *Handler) handleInfo(w http.ResponseWriter, r *http.Request) {
 		"geo_loaded":               h.gpkgStore != nil,
 		"satellite_style_url":      "/api/satellite-style.json",
 		"satellite_attribution":    satelliteAttribution,
+		"satellite_available":      h.cfg.SatelliteAvailable(),
 		"satellite_quota_exceeded": quotaExceeded,
 	}
 	respondJSON(w, http.StatusOK, info)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -16,7 +16,7 @@ func newTestHandler() *Handler {
 		DataDir: "/tmp/test",
 		Version: "test",
 	}
-	return NewHandler(nil, nil, nil, cfg)
+	return NewHandler(nil, nil, nil, cfg, nil)
 }
 
 func TestHealthEndpoint(t *testing.T) {

--- a/internal/api/site_shapefile_test.go
+++ b/internal/api/site_shapefile_test.go
@@ -257,7 +257,7 @@ func openIntegrationStores(t *testing.T) *geodata.GpkgStore {
 // registerDesktopSiteRoutes.
 func buildRouter(gpkg *geodata.GpkgStore, siteStore *sites.Store, dataDir string) *mux.Router {
 	cfg := config.Config{Port: 0, DataDir: dataDir, Version: "test", DesktopMode: true}
-	h := NewHandler(nil, gpkg, siteStore, cfg)
+	h := NewHandler(nil, gpkg, siteStore, cfg, nil)
 	r := mux.NewRouter()
 	h.RegisterRoutes(r)
 	return r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,18 +91,35 @@ type Config struct {
 	DesktopMode bool
 }
 
-// MapTilerAPIKey is the key this deployment authenticates to MapTiler with,
-// for both the satellite style below and the font-glyph proxy in server.go
-// (handleGlyphProxy). One definition so the two features cannot drift onto
-// different keys.
-const MapTilerAPIKey = "cc4PpmmWZP73LjU1nsw3"
+// MapTilerAPIKeyEnvVar is the environment variable that supplies the
+// MapTiler key this deployment authenticates with, for both the satellite
+// style below and the font-glyph proxy in server.go (handleGlyphProxy). One
+// definition so the two features cannot drift onto different keys.
+//
+// Read from the environment rather than compiled in: a key baked into the
+// source is a key committed to git history forever, recoverable from any
+// clone regardless of what a later commit changes it to — which is exactly
+// what happened to the key this replaced. See scripts/run-app.sh and
+// .dt-env.example for how a developer machine supplies it.
+const MapTilerAPIKeyEnvVar = "DT_MAPTILER_API_KEY"
+
+// MapTilerAPIKey returns the configured key, or "" if MapTilerAPIKeyEnvVar is
+// unset. An empty key is not specially handled here: the satellite style and
+// font-glyph requests simply fail upstream, and both already degrade
+// gracefully (satellite.go falls back to the built-in basemap; the glyph
+// proxy renders without labels) rather than needing a second failure mode.
+func MapTilerAPIKey() string {
+	return os.Getenv(MapTilerAPIKeyEnvVar)
+}
 
 // DefaultSatelliteStyleURL is used when nothing is configured.
 //
 // MapTiler's Hybrid style: satellite imagery with OSM-derived roads and place
 // labels already composited in, as a single style rather than a raster tile
 // type on its own.
-const DefaultSatelliteStyleURL = "https://api.maptiler.com/maps/hybrid/style.json?key=" + MapTilerAPIKey
+func DefaultSatelliteStyleURL() string {
+	return "https://api.maptiler.com/maps/hybrid/style.json?key=" + MapTilerAPIKey()
+}
 
 // DefaultSatelliteAttribution matches DefaultSatelliteStyleURL — MapTiler's
 // documented required attribution. A Free-plan account additionally requires
@@ -124,12 +141,14 @@ const DefaultSatelliteQuotaLimit = 80_000
 // Satellite returns the configured style URL and its attribution, applying
 // the defaults.
 func (c Config) Satellite() (styleURL, attribution string) {
+	defaultStyleURL := DefaultSatelliteStyleURL()
 	styleURL = c.SatelliteStyleURL
-	if styleURL == "" {
-		styleURL = DefaultSatelliteStyleURL
+	usingDefault := styleURL == ""
+	if usingDefault {
+		styleURL = defaultStyleURL
 	}
 	attribution = c.SatelliteAttribution
-	if attribution == "" && styleURL == DefaultSatelliteStyleURL {
+	if attribution == "" && usingDefault {
 		// Only default the attribution alongside the default URL: crediting the
 		// default provider for somebody else's imagery would be worse than
 		// crediting nobody.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,20 @@ func (c Config) Satellite() (styleURL, attribution string) {
 	return styleURL, attribution
 }
 
+// SatelliteAvailable reports whether a satellite basemap can actually be
+// served: either an operator configured their own style URL (assumed usable
+// on its own terms), or the default MapTiler style has a key to authenticate
+// with. False means the client should not offer satellite mode at all rather
+// than trying it and failing — see satelliteTileProxy in internal/server,
+// which refuses the style request outright when this is false, and
+// handleInfo, which reports it so the frontend never asks in the first place.
+func (c Config) SatelliteAvailable() bool {
+	if c.SatelliteStyleURL != "" {
+		return true
+	}
+	return MapTilerAPIKey() != ""
+}
+
 // SatelliteQuota returns the configured monthly tile cap, applying the
 // default. Named apart from the SatelliteQuotaLimit field it reads because Go
 // does not allow a method and a field to share a name.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,20 +40,40 @@ type Config struct {
 	ResourcesDir string
 	Version      string
 
-	// SatelliteTileURL is the raster basemap the client uses for satellite
-	// imagery, an {x}/{y}/{z} template passed to maplibre.
+	// SatelliteStyleURL is the upstream MapLibre style document — satellite
+	// imagery plus roads and place labels, not a single raster tile type. The
+	// server fetches and rewrites it, not the browser: see
+	// internal/server/satellite.go for why every tile it references needs to be
+	// counted on our side, and why a keyed provider means the key can never
+	// reach client JavaScript in the first place.
 	//
-	// Configurable so that changing provider does not require a rebuild. The
-	// default is Google's undocumented mt0.google.com endpoint, which needs no
-	// key — which is exactly why using it falls outside the Google Maps terms of
-	// service. Replacing it is a live decision (issue #65); this field is what
-	// makes that decision a deployment change rather than a code change.
-	SatelliteTileURL string
+	// Configurable so that changing provider does not require a rebuild. Issue
+	// #65 replaced the original default, Google's undocumented mt0.google.com
+	// raster endpoint, with Esri World Imagery, then this field replaced that in
+	// turn with MapTiler's Hybrid style, which is what adds roads and labels.
+	SatelliteStyleURL string
 
 	// SatelliteAttribution is displayed on the map for the above. For most
 	// providers this is a licence condition rather than a courtesy, so it travels
 	// with the URL instead of being hardcoded in the client.
 	SatelliteAttribution string
+
+	// SatelliteQuotaLimit caps how many tiles SatelliteTileURL is fetched for in
+	// a calendar month before the server stops fetching and the client falls
+	// back to the built-in basemap. Zero means DefaultSatelliteQuotaLimit; the
+	// zero value is deliberately "the safe default" rather than "unlimited",
+	// since an unconfigured deployment should not be able to exceed a provider's
+	// free-tier terms by accident.
+	SatelliteQuotaLimit int
+
+	// SatelliteUsageDir overrides where the persisted monthly tile count (see
+	// SatelliteUsage) is read from and written to. Empty means SettingsDir().
+	//
+	// A field for the same reason DataDir and ResourcesDir are: so a test can
+	// point it at a temporary directory instead of the real per-user config
+	// location, which server.New would otherwise read from and write to on
+	// every test that builds a Server.
+	SatelliteUsageDir string
 
 	// DesktopMode is true only when the process owns a desktop session and has
 	// opened the embedded WebView window.
@@ -71,28 +91,61 @@ type Config struct {
 	DesktopMode bool
 }
 
-// DefaultSatelliteTileURL is used when nothing is configured. See
-// SatelliteTileURL for why this particular endpoint is a known problem.
-const DefaultSatelliteTileURL = "https://mt0.google.com/vt/lyrs=y&x={x}&y={y}&z={z}"
+// MapTilerAPIKey is the key this deployment authenticates to MapTiler with,
+// for both the satellite style below and the font-glyph proxy in server.go
+// (handleGlyphProxy). One definition so the two features cannot drift onto
+// different keys.
+const MapTilerAPIKey = "cc4PpmmWZP73LjU1nsw3"
 
-// DefaultSatelliteAttribution matches DefaultSatelliteTileURL.
-const DefaultSatelliteAttribution = "© Google Maps"
+// DefaultSatelliteStyleURL is used when nothing is configured.
+//
+// MapTiler's Hybrid style: satellite imagery with OSM-derived roads and place
+// labels already composited in, as a single style rather than a raster tile
+// type on its own.
+const DefaultSatelliteStyleURL = "https://api.maptiler.com/maps/hybrid/style.json?key=" + MapTilerAPIKey
 
-// Satellite returns the configured basemap template and its attribution, applying
+// DefaultSatelliteAttribution matches DefaultSatelliteStyleURL — MapTiler's
+// documented required attribution. A Free-plan account additionally requires
+// displaying MapTiler's logo; confirm the account's plan before relying on
+// text attribution alone to satisfy their terms.
+const DefaultSatelliteAttribution = `<a href="https://www.maptiler.com/copyright/" target="_blank">© MapTiler</a> ` +
+	`<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>`
+
+// DefaultSatelliteQuotaLimit is set below MapTiler's documented free-tier
+// ceiling (100,000 requests/month, enforced by MapTiler itself — unlike
+// Esri's honour-system terms, exceeding it does not merely breach a licence,
+// it stops working). The margin leaves room for two things this quota does
+// not count: font-glyph traffic sharing the same key (see MapTilerAPIKey),
+// and the Hybrid style needing roughly twice the tile fetches per viewed area
+// that a raster-only basemap did, since it now has both a raster and a
+// vector source.
+const DefaultSatelliteQuotaLimit = 80_000
+
+// Satellite returns the configured style URL and its attribution, applying
 // the defaults.
-func (c Config) Satellite() (tileURL, attribution string) {
-	tileURL = c.SatelliteTileURL
-	if tileURL == "" {
-		tileURL = DefaultSatelliteTileURL
+func (c Config) Satellite() (styleURL, attribution string) {
+	styleURL = c.SatelliteStyleURL
+	if styleURL == "" {
+		styleURL = DefaultSatelliteStyleURL
 	}
 	attribution = c.SatelliteAttribution
-	if attribution == "" && tileURL == DefaultSatelliteTileURL {
-		// Only default the attribution alongside the default URL: crediting
-		// Google for somebody else's imagery would be worse than crediting
-		// nobody.
+	if attribution == "" && styleURL == DefaultSatelliteStyleURL {
+		// Only default the attribution alongside the default URL: crediting the
+		// default provider for somebody else's imagery would be worse than
+		// crediting nobody.
 		attribution = DefaultSatelliteAttribution
 	}
-	return tileURL, attribution
+	return styleURL, attribution
+}
+
+// SatelliteQuota returns the configured monthly tile cap, applying the
+// default. Named apart from the SatelliteQuotaLimit field it reads because Go
+// does not allow a method and a field to share a name.
+func (c Config) SatelliteQuota() int {
+	if c.SatelliteQuotaLimit == 0 {
+		return DefaultSatelliteQuotaLimit
+	}
+	return c.SatelliteQuotaLimit
 }
 
 // ListenAddress returns the host:port to bind, applying the safe default.

--- a/internal/config/satellite_test.go
+++ b/internal/config/satellite_test.go
@@ -1,18 +1,21 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-// The satellite tile template was hardcoded twice in the frontend, and pointed at
-// Google's undocumented mt0.google.com endpoint — which needs no key, which is
-// exactly why using it falls outside the Google Maps terms of service. Replacing
-// the provider is a separate live decision (issue #65); this config is what makes
-// it a deployment change rather than a code change.
+// The satellite basemap's provider has moved twice: Google's undocumented
+// mt0.google.com raster endpoint (issue #65, outside the Google Maps terms of
+// service), then Esri World Imagery, then MapTiler's Hybrid style — satellite
+// imagery with roads and place labels composited in. This config is what
+// makes each of those a deployment change rather than a code change.
 
 func TestSatelliteDefaults(t *testing.T) {
 	var cfg Config
 
 	url, attribution := cfg.Satellite()
-	if url != DefaultSatelliteTileURL {
+	if url != DefaultSatelliteStyleURL {
 		t.Errorf("url = %q, want the default", url)
 	}
 	if attribution != DefaultSatelliteAttribution {
@@ -22,12 +25,12 @@ func TestSatelliteDefaults(t *testing.T) {
 
 func TestSatelliteHonoursConfiguration(t *testing.T) {
 	cfg := Config{
-		SatelliteTileURL:     "https://example.test/{z}/{x}/{y}.jpg",
+		SatelliteStyleURL:    "https://example.test/style.json",
 		SatelliteAttribution: "© Example",
 	}
 
 	url, attribution := cfg.Satellite()
-	if url != "https://example.test/{z}/{x}/{y}.jpg" {
+	if url != "https://example.test/style.json" {
 		t.Errorf("url = %q", url)
 	}
 	if attribution != "© Example" {
@@ -35,14 +38,14 @@ func TestSatelliteHonoursConfiguration(t *testing.T) {
 	}
 }
 
-// Crediting Google for somebody else's imagery is worse than crediting nobody, so
-// the default attribution applies only alongside the default URL.
+// Crediting MapTiler for somebody else's style is worse than crediting
+// nobody, so the default attribution applies only alongside the default URL.
 func TestSatelliteDoesNotCreditTheDefaultProviderForAnotherURL(t *testing.T) {
-	cfg := Config{SatelliteTileURL: "https://example.test/{z}/{x}/{y}.jpg"}
+	cfg := Config{SatelliteStyleURL: "https://example.test/style.json"}
 
 	_, attribution := cfg.Satellite()
 	if attribution == DefaultSatelliteAttribution {
-		t.Errorf("attribution = %q for a non-default tile URL", attribution)
+		t.Errorf("attribution = %q for a non-default style URL", attribution)
 	}
 	if attribution != "" {
 		t.Errorf("attribution = %q, want empty when none is configured", attribution)
@@ -54,10 +57,17 @@ func TestSatelliteAttributionCanBeOverriddenAlone(t *testing.T) {
 	cfg := Config{SatelliteAttribution: "© Someone else entirely"}
 
 	url, attribution := cfg.Satellite()
-	if url != DefaultSatelliteTileURL {
+	if url != DefaultSatelliteStyleURL {
 		t.Errorf("url = %q, want the default", url)
 	}
 	if attribution != "© Someone else entirely" {
 		t.Errorf("attribution = %q", attribution)
+	}
+}
+
+// The two features sharing this key must never drift onto different ones.
+func TestMapTilerAPIKeyIsEmbeddedInTheDefaultStyleURL(t *testing.T) {
+	if !strings.Contains(DefaultSatelliteStyleURL, MapTilerAPIKey) {
+		t.Errorf("DefaultSatelliteStyleURL = %q does not contain MapTilerAPIKey", DefaultSatelliteStyleURL)
 	}
 }

--- a/internal/config/satellite_test.go
+++ b/internal/config/satellite_test.go
@@ -76,8 +76,8 @@ func TestMapTilerAPIKeyIsEmbeddedInTheDefaultStyleURL(t *testing.T) {
 }
 
 // A deployment that forgets to set the key must not crash or leak a
-// placeholder — it degrades to a style URL with an empty key, which the
-// satellite proxy already handles as an ordinary upstream failure.
+// placeholder — it degrades to a style URL with an empty key. SatelliteAvailable
+// is what stops that URL ever actually being fetched — see its own tests below.
 func TestMapTilerAPIKeyEmptyWhenUnset(t *testing.T) {
 	t.Setenv(MapTilerAPIKeyEnvVar, "")
 	if got := MapTilerAPIKey(); got != "" {
@@ -85,5 +85,37 @@ func TestMapTilerAPIKeyEmptyWhenUnset(t *testing.T) {
 	}
 	if !strings.HasSuffix(DefaultSatelliteStyleURL(), "key=") {
 		t.Errorf("DefaultSatelliteStyleURL() = %q, want it to end with an empty key= param", DefaultSatelliteStyleURL())
+	}
+}
+
+// The default MapTiler style needs a key; a deployment with neither an
+// operator-configured style URL nor a key has no usable satellite basemap at
+// all, and should say so rather than let the client find out by a failed fetch.
+func TestSatelliteUnavailableWithNoStyleURLOrKey(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "")
+	var cfg Config
+
+	if cfg.SatelliteAvailable() {
+		t.Error("SatelliteAvailable() = true with no style URL and no key configured")
+	}
+}
+
+func TestSatelliteAvailableWithKeyConfigured(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "test-key")
+	var cfg Config
+
+	if !cfg.SatelliteAvailable() {
+		t.Error("SatelliteAvailable() = false with a key configured")
+	}
+}
+
+// An operator-configured style URL is assumed usable on its own terms — it
+// may not even be MapTiler, so the MapTiler key is irrelevant to it.
+func TestSatelliteAvailableWithOperatorStyleURLEvenWithoutKey(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "")
+	cfg := Config{SatelliteStyleURL: "https://example.test/style.json"}
+
+	if !cfg.SatelliteAvailable() {
+		t.Error("SatelliteAvailable() = false for an operator-configured style URL")
 	}
 }

--- a/internal/config/satellite_test.go
+++ b/internal/config/satellite_test.go
@@ -12,10 +12,11 @@ import (
 // makes each of those a deployment change rather than a code change.
 
 func TestSatelliteDefaults(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "test-key")
 	var cfg Config
 
 	url, attribution := cfg.Satellite()
-	if url != DefaultSatelliteStyleURL {
+	if url != DefaultSatelliteStyleURL() {
 		t.Errorf("url = %q, want the default", url)
 	}
 	if attribution != DefaultSatelliteAttribution {
@@ -54,10 +55,11 @@ func TestSatelliteDoesNotCreditTheDefaultProviderForAnotherURL(t *testing.T) {
 
 // An operator who sets only the attribution is describing the default imagery.
 func TestSatelliteAttributionCanBeOverriddenAlone(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "test-key")
 	cfg := Config{SatelliteAttribution: "© Someone else entirely"}
 
 	url, attribution := cfg.Satellite()
-	if url != DefaultSatelliteStyleURL {
+	if url != DefaultSatelliteStyleURL() {
 		t.Errorf("url = %q, want the default", url)
 	}
 	if attribution != "© Someone else entirely" {
@@ -67,7 +69,21 @@ func TestSatelliteAttributionCanBeOverriddenAlone(t *testing.T) {
 
 // The two features sharing this key must never drift onto different ones.
 func TestMapTilerAPIKeyIsEmbeddedInTheDefaultStyleURL(t *testing.T) {
-	if !strings.Contains(DefaultSatelliteStyleURL, MapTilerAPIKey) {
-		t.Errorf("DefaultSatelliteStyleURL = %q does not contain MapTilerAPIKey", DefaultSatelliteStyleURL)
+	t.Setenv(MapTilerAPIKeyEnvVar, "test-key")
+	if !strings.Contains(DefaultSatelliteStyleURL(), MapTilerAPIKey()) {
+		t.Errorf("DefaultSatelliteStyleURL() = %q does not contain MapTilerAPIKey()", DefaultSatelliteStyleURL())
+	}
+}
+
+// A deployment that forgets to set the key must not crash or leak a
+// placeholder — it degrades to a style URL with an empty key, which the
+// satellite proxy already handles as an ordinary upstream failure.
+func TestMapTilerAPIKeyEmptyWhenUnset(t *testing.T) {
+	t.Setenv(MapTilerAPIKeyEnvVar, "")
+	if got := MapTilerAPIKey(); got != "" {
+		t.Errorf("MapTilerAPIKey() = %q, want empty", got)
+	}
+	if !strings.HasSuffix(DefaultSatelliteStyleURL(), "key=") {
+		t.Errorf("DefaultSatelliteStyleURL() = %q, want it to end with an empty key= param", DefaultSatelliteStyleURL())
 	}
 }

--- a/internal/config/satellitequota.go
+++ b/internal/config/satellitequota.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kartoza/decision-theatre/internal/fsutil"
+)
+
+// satelliteUsageFile is the persisted counter's name, stored alongside
+// settings.json in SettingsDir().
+const satelliteUsageFile = "satellite_usage.json"
+
+// SatelliteUsage tracks how many satellite tiles have been fetched from the
+// configured upstream provider this calendar month.
+//
+// Most raster imagery providers' free tiers are conditioned on a monthly tile
+// count (see DefaultSatelliteQuotaLimit for the default provider's). Persisting
+// this rather than keeping it only in memory means a restart of the desktop app
+// does not reset what the provider considers a running total.
+type SatelliteUsage struct {
+	mu sync.Mutex
+
+	// dir is where satellite_usage.json is read from and written to. A field
+	// rather than always SettingsDir(), so a test can point it at a temporary
+	// directory instead of the real per-user config location.
+	dir string
+
+	year  int
+	month time.Month
+	count int
+}
+
+// satelliteUsageFileData is the on-disk shape.
+type satelliteUsageFileData struct {
+	Year  int        `json:"year"`
+	Month time.Month `json:"month"`
+	Count int        `json:"count"`
+}
+
+// LoadSatelliteUsage reads the persisted counter from dir. A missing file is
+// not an error: it means no tiles have been fetched yet this run, the same
+// starting state as config.LoadSettings gives a first-ever launch.
+func LoadSatelliteUsage(dir string) (*SatelliteUsage, error) {
+	now := time.Now().UTC()
+	usage := &SatelliteUsage{dir: dir, year: now.Year(), month: now.Month()}
+
+	data, err := os.ReadFile(filepath.Join(dir, satelliteUsageFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return usage, nil
+		}
+		return usage, err
+	}
+
+	var stored satelliteUsageFileData
+	if err := json.Unmarshal(data, &stored); err != nil {
+		// A corrupt file starts the count over rather than failing startup:
+		// losing track of a month's tile count is far less costly than the
+		// satellite basemap refusing to work at all.
+		log.Printf("Warning: satellite usage file is corrupt, resetting count: %v", err)
+		return usage, nil
+	}
+	if stored.Year == usage.year && stored.Month == usage.month {
+		usage.count = stored.Count
+	}
+	return usage, nil
+}
+
+// Increment records one upstream tile fetch, rolling the count over first if
+// the calendar month has changed since it was last touched. It returns the new
+// count and whether limit has been reached or exceeded.
+//
+// Persisted synchronously on every call. At desktop-app tile volumes an atomic
+// local write per tile is not a performance concern, and surviving an unclean
+// shutdown without losing count matters more than shaving milliseconds off a
+// tile fetch.
+func (u *SatelliteUsage) Increment(limit int) (count int, exceeded bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.rolloverLocked()
+	u.count++
+	u.saveLocked()
+	return u.count, u.count >= limit
+}
+
+// Snapshot reports the current count without incrementing it, applying the
+// same month rollover Increment does. Used to answer "is satellite imagery
+// still available" without counting the question as a tile fetch.
+func (u *SatelliteUsage) Snapshot(limit int) (count int, exceeded bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.rolloverLocked()
+	return u.count, u.count >= limit
+}
+
+func (u *SatelliteUsage) rolloverLocked() {
+	now := time.Now().UTC()
+	if now.Year() != u.year || now.Month() != u.month {
+		u.year = now.Year()
+		u.month = now.Month()
+		u.count = 0
+	}
+}
+
+// saveLocked persists the counter. A failure only means next month's count
+// might start from zero a little early after a crash; it is logged rather than
+// propagated so a full disk cannot break tile serving.
+func (u *SatelliteUsage) saveLocked() {
+	data, err := json.Marshal(satelliteUsageFileData{Year: u.year, Month: u.month, Count: u.count})
+	if err != nil {
+		log.Printf("Warning: could not encode satellite usage: %v", err)
+		return
+	}
+	if err := os.MkdirAll(u.dir, 0o755); err != nil {
+		log.Printf("Warning: could not create %s: %v", u.dir, err)
+		return
+	}
+	path := filepath.Join(u.dir, satelliteUsageFile)
+	if err := fsutil.WriteFileAtomic(path, data, 0o644); err != nil {
+		log.Printf("Warning: could not save satellite usage: %v", err)
+	}
+}

--- a/internal/config/satellitequota_test.go
+++ b/internal/config/satellitequota_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSatelliteUsageIncrementsAndReportsExceeded(t *testing.T) {
+	usage, err := LoadSatelliteUsage(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage: %v", err)
+	}
+
+	for i := 1; i <= 2; i++ {
+		count, exceeded := usage.Increment(3)
+		if count != i {
+			t.Errorf("count = %d, want %d", count, i)
+		}
+		if exceeded {
+			t.Errorf("exceeded = true at count %d, want false", count)
+		}
+	}
+
+	count, exceeded := usage.Increment(3)
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+	if !exceeded {
+		t.Error("exceeded = false at the limit, want true")
+	}
+}
+
+func TestSatelliteUsagePersistsAcrossLoad(t *testing.T) {
+	dir := t.TempDir()
+
+	usage, err := LoadSatelliteUsage(dir)
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage: %v", err)
+	}
+	usage.Increment(1_000_000)
+	usage.Increment(1_000_000)
+
+	reloaded, err := LoadSatelliteUsage(dir)
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage (reload): %v", err)
+	}
+	count, _ := reloaded.Snapshot(1_000_000)
+	if count != 2 {
+		t.Errorf("count after reload = %d, want 2", count)
+	}
+}
+
+func TestSatelliteUsageMissingFileStartsAtZero(t *testing.T) {
+	usage, err := LoadSatelliteUsage(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage: %v", err)
+	}
+
+	count, exceeded := usage.Snapshot(1)
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+	if exceeded {
+		t.Error("exceeded = true with zero usage and a limit of 1, want false")
+	}
+}
+
+func TestSatelliteUsageRollsOverOnMonthChange(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a count left over from a previous month.
+	stale := satelliteUsageFileData{Year: 2000, Month: time.January, Count: 999}
+	data, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatalf("marshal stale usage: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, satelliteUsageFile), data, 0o644); err != nil {
+		t.Fatalf("write stale usage: %v", err)
+	}
+
+	usage, err := LoadSatelliteUsage(dir)
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage: %v", err)
+	}
+
+	count, exceeded := usage.Snapshot(10)
+	if count != 0 {
+		t.Errorf("count = %d, want 0 for a stale month", count)
+	}
+	if exceeded {
+		t.Error("exceeded = true for a rolled-over count, want false")
+	}
+}
+
+func TestSatelliteUsageCorruptFileStartsOver(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, satelliteUsageFile), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt usage: %v", err)
+	}
+
+	usage, err := LoadSatelliteUsage(dir)
+	if err != nil {
+		t.Fatalf("LoadSatelliteUsage: %v", err)
+	}
+	count, _ := usage.Snapshot(10)
+	if count != 0 {
+		t.Errorf("count = %d, want 0 after a corrupt file", count)
+	}
+}

--- a/internal/server/satellite.go
+++ b/internal/server/satellite.go
@@ -1,0 +1,437 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+)
+
+// Satellite imagery, proxied.
+//
+// The browser used to fetch tiles directly from the configured provider. That
+// worked, but it meant the one thing standing between this deployment and a
+// provider's free-tier terms — a monthly tile count, see
+// config.DefaultSatelliteQuotaLimit — was invisible to the one process able to
+// enforce it, and (for a keyed provider like MapTiler) the key itself would
+// have to live in browser JavaScript.
+//
+// The upstream is now a whole style — MapTiler's Hybrid, satellite imagery
+// with OSM-derived roads and place labels already composited in — rather than
+// one raster tile template, so this file resolves and rewrites it: every
+// source's tiles, its sprite and its glyphs all end up pointing back at this
+// server, which is the only thing that ever holds the key.
+
+const (
+	// satelliteTileCacheLimit caps the in-process tile cache, mirroring the
+	// glyph cache's reasoning: panning back over the same area should not count
+	// against the monthly quota twice.
+	satelliteTileCacheLimit = 256 * 1024 * 1024
+
+	// satelliteUpstreamTimeout bounds a slow provider. MapLibre already renders
+	// gracefully with a missing raster tile, so failing fast beats holding the
+	// connection open.
+	satelliteUpstreamTimeout = 10 * time.Second
+
+	// satelliteMaxTileBytes bounds a single tile or sprite image response so a
+	// misbehaving upstream cannot make this process buffer without limit.
+	satelliteMaxTileBytes = 4 << 20
+
+	// satelliteMaxStyleBytes bounds the style and TileJSON documents, which are
+	// plain metadata and always small.
+	satelliteMaxStyleBytes = 1 << 20
+)
+
+type satelliteTile struct {
+	data            []byte
+	contentType     string
+	contentEncoding string
+}
+
+// satelliteTileProxy fetches, caches and quota-counts everything the Hybrid
+// style needs: the style document itself, each source's tiles (raster and
+// vector alike), and its sprite. Glyphs are deliberately excluded — see
+// buildStyle — and reuse the existing font proxy instead.
+type satelliteTileProxy struct {
+	cache      sync.Map // "source/z/x/y" -> satelliteTile
+	cacheSizeB atomic.Int64
+
+	client     *http.Client
+	styleURL   string
+	usage      *config.SatelliteUsage
+	quotaLimit int
+
+	// The rewritten /api/satellite-style.json, built once and cached for the
+	// process lifetime — MapTiler serves the same content to everyone, so
+	// there is nothing here that ever needs invalidating.
+	style styleCache
+
+	// Populated as the style, and each source's TileJSON, are resolved — see
+	// buildStyle and handleSatelliteTileJSON. A tile request for a source not
+	// yet resolved this way 404s; in practice MapLibre always fetches a
+	// source's style entry (and its TileJSON, if it has one) before ever
+	// requesting a tile from it.
+	tileUpstream     sync.Map // source id -> upstream {z}/{x}/{y} template
+	tileJSONUpstream sync.Map // source id -> upstream TileJSON URL
+	tileJSONCache    sync.Map // source id -> rewritten TileJSON bytes
+
+	// The sprite is one URL for the whole style, not per-source, hence a
+	// single pointer rather than a map. nil until buildStyle resolves it —
+	// which may never happen, since not every style has a sprite.
+	spriteUpstream atomic.Pointer[string]
+	spriteCache    sync.Map // variant (".png", "@2x.json", ...) -> satelliteTile
+}
+
+func newSatelliteTileProxy(cfg config.Config, usage *config.SatelliteUsage) *satelliteTileProxy {
+	styleURL, _ := cfg.Satellite()
+	return &satelliteTileProxy{
+		client: &http.Client{
+			Timeout: satelliteUpstreamTimeout,
+			// Vector tiles arrive gzip-compressed; the default Transport
+			// transparently decompresses a gzip response and strips
+			// Content-Encoding before this code ever sees it, which broke
+			// forwarding that header to the browser (and would have made this
+			// process do the decompress work for nothing, on every tile).
+			// Disabling it keeps bytes and headers exactly as upstream sent
+			// them — the browser decompresses, same as it would talking to
+			// MapTiler directly.
+			Transport: &http.Transport{DisableCompression: true},
+		},
+		styleURL:   styleURL,
+		usage:      usage,
+		quotaLimit: cfg.SatelliteQuota(),
+	}
+}
+
+// fetchUpstream performs one bounded GET. Shared by every route in this file
+// that talks to the provider directly (style, TileJSON, sprite) — only the
+// quota-checked, cached tile path (serve, below) needs its own version, since
+// it alone counts and caps what it fetches.
+func fetchUpstream(ctx context.Context, client *http.Client, url string, maxBytes int64) ([]byte, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, resp.Header, nil
+}
+
+// buildStyle fetches the upstream style once, resolving and rewriting every
+// source so the browser only ever talks to this server: a source with inline
+// tiles becomes a local /api/satellite-tile path, one with a TileJSON
+// reference becomes /api/satellite-tilejson, and the sprite becomes
+// /api/satellite-sprite. Every rewritten URL is absolute, not relative — a
+// relative one resolves against whatever fetched it, and MapLibre fetches
+// vector tiles from inside a Web Worker, whose location is its own script
+// (often a blob: URL), not the page. A relative vector tile URL therefore
+// fails there with "Failed to construct 'Request': Failed to parse URL",
+// silently dropping the whole source — raster tiles, the style and the
+// sprite are all fetched on the main thread and tolerate a relative URL fine,
+// which is exactly why this went unnoticed until roads (vector) were added.
+// Matches handleStyleJSON's existing baseURL(r)-based rewriting of the app's
+// own vector basemap, for the same reason.
+//
+// glyphs is the one exception: rewritten to the existing local font proxy
+// (handleGlyphProxy) rather than a new one of its own, and that traffic is
+// deliberately not folded into the satellite quota below — see the package
+// doc comment.
+func (p *satelliteTileProxy) buildStyle(base string) ([]byte, error) {
+	data, _, err := fetchUpstream(context.Background(), p.client, p.styleURL, satelliteMaxStyleBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var style map[string]interface{}
+	if err := json.Unmarshal(data, &style); err != nil {
+		return nil, err
+	}
+
+	if sources, ok := style["sources"].(map[string]interface{}); ok {
+		for id, raw := range sources {
+			src, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if tiles, ok := src["tiles"].([]interface{}); ok && len(tiles) > 0 {
+				if tmpl, ok := tiles[0].(string); ok {
+					p.tileUpstream.Store(id, tmpl)
+				}
+				src["tiles"] = []string{base + "/api/satellite-tile/" + id + "/{z}/{x}/{y}"}
+				delete(src, "url")
+			} else if tilejsonURL, ok := src["url"].(string); ok && tilejsonURL != "" {
+				p.tileJSONUpstream.Store(id, tilejsonURL)
+				src["url"] = base + "/api/satellite-tilejson/" + id
+			}
+
+			sources[id] = src
+		}
+	}
+
+	if spriteURL, ok := style["sprite"].(string); ok && spriteURL != "" {
+		p.spriteUpstream.Store(&spriteURL)
+		style["sprite"] = base + "/api/satellite-sprite"
+	}
+
+	if glyphsURL, ok := style["glyphs"].(string); ok && glyphsURL != "" {
+		style["glyphs"] = base + "/fonts/{fontstack}/{range}.pbf"
+	}
+
+	return json.Marshal(style)
+}
+
+// handleSatelliteStyle serves the rewritten Hybrid style document.
+func (s *Server) handleSatelliteStyle(w http.ResponseWriter, r *http.Request) {
+	base := baseURL(r)
+	styleBytes, err := s.satellite.style.get(func() ([]byte, error) {
+		return s.satellite.buildStyle(base)
+	})
+	if err != nil {
+		log.Printf("Satellite style proxy: upstream fetch failed: %v", err)
+		http.Error(w, "Satellite style unavailable", http.StatusBadGateway)
+		return
+	}
+
+	writeSatelliteJSON(w, styleBytes)
+}
+
+// handleSatelliteTileJSON resolves one source's TileJSON — the indirection
+// MapTiler's style sources use instead of an inline tile template. Rewriting
+// it is what lets handleSatelliteTile resolve that source's real upstream
+// template; mirrors handleTileJSON's job for the app's own vector basemap.
+//
+// The rewritten result is cached: MapLibre re-fetches a source's TileJSON for
+// every map instance that uses it (all twelve panes in grid view, for
+// example), and none of that is a "tile" the quota should count.
+func (s *Server) handleSatelliteTileJSON(w http.ResponseWriter, r *http.Request) {
+	source := mux.Vars(r)["source"]
+	p := s.satellite
+
+	if cached, ok := p.tileJSONCache.Load(source); ok {
+		writeSatelliteJSON(w, cached.([]byte))
+		return
+	}
+
+	upstreamRaw, ok := p.tileJSONUpstream.Load(source)
+	if !ok {
+		http.Error(w, "Unknown satellite source", http.StatusNotFound)
+		return
+	}
+
+	data, _, err := fetchUpstream(r.Context(), p.client, upstreamRaw.(string), satelliteMaxStyleBytes)
+	if err != nil {
+		log.Printf("Satellite tilejson proxy: upstream fetch failed for %s: %v", source, err)
+		http.Error(w, "Satellite tilejson unavailable", http.StatusBadGateway)
+		return
+	}
+
+	var tileJSON map[string]interface{}
+	if err := json.Unmarshal(data, &tileJSON); err != nil {
+		http.Error(w, "Satellite tilejson unavailable", http.StatusBadGateway)
+		return
+	}
+	if tiles, ok := tileJSON["tiles"].([]interface{}); ok && len(tiles) > 0 {
+		if tmpl, ok := tiles[0].(string); ok {
+			p.tileUpstream.Store(source, tmpl)
+		}
+	}
+	// Absolute, not relative — see buildStyle's doc comment: MapLibre fetches
+	// vector tiles from a Worker, where a relative URL cannot be resolved.
+	tileJSON["tiles"] = []string{baseURL(r) + "/api/satellite-tile/" + source + "/{z}/{x}/{y}"}
+
+	out, err := json.Marshal(tileJSON)
+	if err != nil {
+		http.Error(w, "Satellite tilejson unavailable", http.StatusInternalServerError)
+		return
+	}
+	p.tileJSONCache.Store(source, out)
+	writeSatelliteJSON(w, out)
+}
+
+// writeSatelliteJSON writes a JSON response (the style or a TileJSON
+// document) with the headers every such response needs: cacheable, and
+// CORS-open. The style and TileJSON documents now embed absolute URLs (see
+// buildStyle), so a dev setup that serves the frontend and this backend from
+// different origins — Vite on :5173 proxying everything else to :8080 — has
+// the browser fetch those URLs directly rather than through the proxy. Same
+// header the local vector tile route (handleTileRequest) already sets, for
+// the same reason.
+func writeSatelliteJSON(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Write(body)
+}
+
+// handleSatelliteTile serves one z/x/y tile from the named source, fetching
+// and caching it from the upstream provider on first request.
+func (s *Server) handleSatelliteTile(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	source := vars["source"]
+	// Rejected rather than defaulted: see handleTileRequest for why a malformed
+	// coordinate must not silently become tile 0/0/0.
+	z, zErr := strconv.Atoi(vars["z"])
+	x, xErr := strconv.Atoi(vars["x"])
+	y, yErr := strconv.Atoi(vars["y"])
+	if zErr != nil || xErr != nil || yErr != nil {
+		http.Error(w, "Invalid tile coordinate", http.StatusBadRequest)
+		return
+	}
+
+	s.satellite.serve(r.Context(), w, source, z, x, y)
+}
+
+func (p *satelliteTileProxy) serve(ctx context.Context, w http.ResponseWriter, source string, z, x, y int) {
+	upstreamRaw, ok := p.tileUpstream.Load(source)
+	if !ok {
+		// The style or TileJSON that names this source has not been resolved
+		// yet — or never will be, if the id is bogus. Either way there is no
+		// upstream to fetch from.
+		http.Error(w, "Unknown satellite source", http.StatusNotFound)
+		return
+	}
+	template := upstreamRaw.(string)
+
+	key := source + "/" + strconv.Itoa(z) + "/" + strconv.Itoa(x) + "/" + strconv.Itoa(y)
+
+	if v, ok := p.cache.Load(key); ok {
+		writeSatelliteTile(w, v.(satelliteTile))
+		return
+	}
+
+	// Checked before fetching, not only after: once the quota is spent, a cache
+	// miss must not reach the upstream at all, or the count keeps climbing past
+	// the limit it exists to enforce. This is a soft cap, not an exact one — a
+	// handful of requests already in flight when the limit is crossed can still
+	// land — which is the right trade for a monthly quota, not worth serialising
+	// every tile fetch over.
+	if _, exceeded := p.usage.Snapshot(p.quotaLimit); exceeded {
+		w.Header().Set("Retry-After", "86400")
+		http.Error(w, "Satellite imagery quota exceeded for this month", http.StatusTooManyRequests)
+		return
+	}
+
+	tile, err := p.fetch(ctx, template, z, x, y)
+	if err != nil {
+		log.Printf("Satellite tile proxy: upstream fetch failed for %s: %v", key, err)
+		http.Error(w, "Satellite tile unavailable", http.StatusBadGateway)
+		return
+	}
+
+	p.usage.Increment(p.quotaLimit)
+
+	if p.cacheSizeB.Load() < satelliteTileCacheLimit {
+		if _, loaded := p.cache.LoadOrStore(key, tile); !loaded {
+			p.cacheSizeB.Add(int64(len(tile.data)))
+		}
+	}
+
+	writeSatelliteTile(w, tile)
+}
+
+// fetch performs one upstream request for a single tile from the given
+// source's template.
+func (p *satelliteTileProxy) fetch(ctx context.Context, template string, z, x, y int) (satelliteTile, error) {
+	tileURL := strings.NewReplacer(
+		"{z}", strconv.Itoa(z),
+		"{x}", strconv.Itoa(x),
+		"{y}", strconv.Itoa(y),
+	).Replace(template)
+
+	data, header, err := fetchUpstream(ctx, p.client, tileURL, satelliteMaxTileBytes)
+	if err != nil {
+		return satelliteTile{}, err
+	}
+	return satelliteTile{
+		data:            data,
+		contentType:     header.Get("Content-Type"),
+		contentEncoding: header.Get("Content-Encoding"),
+	}, nil
+}
+
+func writeSatelliteTile(w http.ResponseWriter, tile satelliteTile) {
+	contentType := tile.contentType
+	if contentType == "" {
+		// World Imagery and most other providers serve JPEG; a sensible default
+		// for the rare response that arrives without a Content-Type header.
+		contentType = "image/jpeg"
+	}
+	w.Header().Set("Content-Type", contentType)
+	if tile.contentEncoding != "" {
+		// Vector tiles are typically gzip-compressed; raster tiles typically
+		// aren't. Forwarded rather than assumed, unlike the local vector tile
+		// route (handleTileRequest), which always serves gzip because it always
+		// reads from one gzip-compressed local file format.
+		w.Header().Set("Content-Encoding", tile.contentEncoding)
+	}
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	// See writeSatelliteJSON's comment: tile URLs are absolute, so a dev setup
+	// with the frontend and backend on different origins needs this.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Write(tile.data)
+}
+
+// handleSatelliteSprite serves the style's sprite sheet — the small set of
+// icon images MapLibre needs for symbol layers such as place labels. Cached
+// like a tile, but not counted against the quota: a style loads its sprite
+// once per session, not once per pan or zoom, so the volume is negligible —
+// the same treatment already given to glyphs.
+func (s *Server) handleSatelliteSprite(w http.ResponseWriter, r *http.Request) {
+	variant := mux.Vars(r)["variant"]
+	p := s.satellite
+
+	if v, ok := p.spriteCache.Load(variant); ok {
+		writeSatelliteTile(w, v.(satelliteTile))
+		return
+	}
+
+	base := p.spriteUpstream.Load()
+	if base == nil || *base == "" {
+		http.Error(w, "No sprite configured", http.StatusNotFound)
+		return
+	}
+
+	// The variant suffix (".json", "@2x.png", ...) must land on the path, not
+	// after the upstream's own "?key=..." query string, or naive concatenation
+	// produces "?key=secret.json" instead of "sprite.json?key=secret".
+	spriteURL, err := url.Parse(*base)
+	if err != nil {
+		http.Error(w, "Satellite sprite unavailable", http.StatusBadGateway)
+		return
+	}
+	spriteURL.Path += variant
+
+	data, header, err := fetchUpstream(r.Context(), p.client, spriteURL.String(), satelliteMaxTileBytes)
+	if err != nil {
+		log.Printf("Satellite sprite proxy: upstream fetch failed for %s: %v", variant, err)
+		http.Error(w, "Satellite sprite unavailable", http.StatusBadGateway)
+		return
+	}
+
+	tile := satelliteTile{data: data, contentType: header.Get("Content-Type")}
+	p.spriteCache.Store(variant, tile)
+	writeSatelliteTile(w, tile)
+}

--- a/internal/server/satellite.go
+++ b/internal/server/satellite.go
@@ -72,6 +72,14 @@ type satelliteTileProxy struct {
 	usage      *config.SatelliteUsage
 	quotaLimit int
 
+	// available mirrors config.Config.SatelliteAvailable(): false when the
+	// default MapTiler style would be used but no key is configured. Checked
+	// before ever attempting the upstream fetch, so a deployment with no key
+	// gets one clean 404 instead of repeatedly failing against MapTiler — a
+	// failed style build is not cached (see styleCache), so every request
+	// would otherwise retry the doomed fetch.
+	available bool
+
 	// The rewritten /api/satellite-style.json, built once and cached for the
 	// process lifetime — MapTiler serves the same content to everyone, so
 	// there is nothing here that ever needs invalidating.
@@ -111,6 +119,7 @@ func newSatelliteTileProxy(cfg config.Config, usage *config.SatelliteUsage) *sat
 		styleURL:   styleURL,
 		usage:      usage,
 		quotaLimit: cfg.SatelliteQuota(),
+		available:  cfg.SatelliteAvailable(),
 	}
 }
 
@@ -205,6 +214,15 @@ func (p *satelliteTileProxy) buildStyle(base string) ([]byte, error) {
 
 // handleSatelliteStyle serves the rewritten Hybrid style document.
 func (s *Server) handleSatelliteStyle(w http.ResponseWriter, r *http.Request) {
+	if !s.satellite.available {
+		// No point attempting the upstream fetch: without a key the default
+		// MapTiler style would just fail there. /api/info already reports this
+		// (satellite_available), so a well-behaved client never asks — this is
+		// the backstop for one that does anyway.
+		http.Error(w, "Satellite imagery is not configured", http.StatusNotFound)
+		return
+	}
+
 	base := baseURL(r)
 	styleBytes, err := s.satellite.style.get(func() ([]byte, error) {
 		return s.satellite.buildStyle(base)

--- a/internal/server/satellite_test.go
+++ b/internal/server/satellite_test.go
@@ -39,7 +39,7 @@ func newFakeMapTilerUpstream(t *testing.T) *fakeMapTilerUpstream {
 
 	mux := http.NewServeMux()
 	u.Server = httptest.NewServer(mux)
-	t.Cleanup(u.Server.Close)
+	t.Cleanup(u.Close)
 
 	mux.HandleFunc("/style.json", func(w http.ResponseWriter, r *http.Request) {
 		style := map[string]interface{}{

--- a/internal/server/satellite_test.go
+++ b/internal/server/satellite_test.go
@@ -1,0 +1,364 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kartoza/decision-theatre/internal/config"
+)
+
+// The browser used to fetch satellite tiles directly from the configured
+// provider, which meant the one thing standing between this deployment and a
+// provider's free-tier terms — a monthly tile count — was invisible to the one
+// process able to enforce it, and a keyed provider's key would have had to live
+// in browser JavaScript. The upstream is now a whole style (MapTiler's Hybrid:
+// satellite imagery plus OSM-derived roads and labels), not one raster tile
+// type, so these tests pin the resolve-and-rewrite chain — style, TileJSON,
+// tile, sprite — as well as the caching and quota-enforcement behaviour none of
+// which is visible from the outside once tiles are loading successfully.
+
+// fakeMapTilerUpstream serves a minimal Hybrid-shaped style: one raster source
+// with inline tiles, one vector source behind a TileJSON reference (MapTiler's
+// usual shape), plus a sprite and glyphs field.
+type fakeMapTilerUpstream struct {
+	*httptest.Server
+	rasterCalls   atomic.Int32
+	vectorCalls   atomic.Int32
+	tileJSONCalls atomic.Int32
+	spriteCalls   atomic.Int32
+	rasterFails   atomic.Bool
+}
+
+func newFakeMapTilerUpstream(t *testing.T) *fakeMapTilerUpstream {
+	t.Helper()
+	u := &fakeMapTilerUpstream{}
+
+	mux := http.NewServeMux()
+	u.Server = httptest.NewServer(mux)
+	t.Cleanup(u.Server.Close)
+
+	mux.HandleFunc("/style.json", func(w http.ResponseWriter, r *http.Request) {
+		style := map[string]interface{}{
+			"version": 8,
+			"sources": map[string]interface{}{
+				"satellite": map[string]interface{}{
+					"type":        "raster",
+					"tiles":       []string{u.URL + "/raster/{z}/{x}/{y}.jpg?key=secret"},
+					"tileSize":    256,
+					"attribution": "© Satellite Co",
+				},
+				"roads": map[string]interface{}{
+					"type": "vector",
+					"url":  u.URL + "/roads/tiles.json?key=secret",
+				},
+			},
+			"sprite": u.URL + "/sprites/sprite?key=secret",
+			"glyphs": u.URL + "/fonts/{fontstack}/{range}.pbf?key=secret",
+			"layers": []interface{}{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(style)
+	})
+
+	mux.HandleFunc("/roads/tiles.json", func(w http.ResponseWriter, r *http.Request) {
+		u.tileJSONCalls.Add(1)
+		tj := map[string]interface{}{
+			"tilejson": "2.2.0",
+			"tiles":    []string{u.URL + "/vector/{z}/{x}/{y}.pbf?key=secret"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tj)
+	})
+
+	mux.HandleFunc("/raster/", func(w http.ResponseWriter, r *http.Request) {
+		u.rasterCalls.Add(1)
+		if u.rasterFails.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("raster tile bytes"))
+	})
+
+	mux.HandleFunc("/vector/", func(w http.ResponseWriter, r *http.Request) {
+		u.vectorCalls.Add(1)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte("vector tile bytes"))
+	})
+
+	mux.HandleFunc("/sprites/sprite.json", func(w http.ResponseWriter, r *http.Request) {
+		u.spriteCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"marker":{"width":1,"height":1,"x":0,"y":0,"pixelRatio":1}}`))
+	})
+
+	return u
+}
+
+// newSatelliteServer builds a Server with the satellite proxy pointed at a
+// fake upstream style, and its quota set to limit.
+func newSatelliteServer(t *testing.T, styleURL string, limit int) *Server {
+	t.Helper()
+
+	srv, err := New(config.Config{
+		Port:                0,
+		DataDir:             t.TempDir(),
+		Version:             "test",
+		SatelliteQuotaLimit: limit,
+		SatelliteUsageDir:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.satellite.styleURL = styleURL
+	return srv
+}
+
+func getSatellite(t *testing.T, srv *Server, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	srv.currentRouter().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestSatelliteStyleIsRewrittenToLocalPaths(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	rec := getSatellite(t, srv, "/api/satellite-style.json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var style map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &style); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+
+	sources := style["sources"].(map[string]interface{})
+
+	// Absolute, not relative: MapLibre fetches vector tiles from inside a Web
+	// Worker, whose location is its own script, not the page. A relative URL
+	// resolved there throws "Failed to construct 'Request'" and silently drops
+	// the whole source — which is exactly how the vector (roads) source went
+	// missing while the raster one, fetched on the main thread, worked fine.
+	satellite := sources["satellite"].(map[string]interface{})
+	if got := satellite["tiles"].([]interface{})[0].(string); got != "http://example.com/api/satellite-tile/satellite/{z}/{x}/{y}" {
+		t.Errorf("satellite tiles = %q", got)
+	}
+	if _, hasURL := satellite["url"]; hasURL {
+		t.Error("an inline-tiles source kept a url field")
+	}
+
+	roads := sources["roads"].(map[string]interface{})
+	if got := roads["url"].(string); got != "http://example.com/api/satellite-tilejson/roads" {
+		t.Errorf("roads url = %q", got)
+	}
+
+	if got := style["sprite"].(string); got != "http://example.com/api/satellite-sprite" {
+		t.Errorf("sprite = %q", got)
+	}
+	if got := style["glyphs"].(string); got != "http://example.com/fonts/{fontstack}/{range}.pbf" {
+		t.Errorf("glyphs = %q, want the existing local font proxy, not a new one", got)
+	}
+
+	// The upstream key must never appear in what the browser receives.
+	if strings.Contains(rec.Body.String(), "secret") {
+		t.Error("upstream key leaked into the served style")
+	}
+}
+
+func TestSatelliteTileJSONIsRewrittenAndCached(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	getSatellite(t, srv, "/api/satellite-style.json") // registers the roads source's tilejson upstream
+
+	for i := 0; i < 3; i++ {
+		rec := getSatellite(t, srv, "/api/satellite-tilejson/roads")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status %d: %s", i, rec.Code, rec.Body.String())
+		}
+		var tj map[string]interface{}
+		if err := json.Unmarshal(rec.Body.Bytes(), &tj); err != nil {
+			t.Fatalf("body is not JSON: %v", err)
+		}
+		if got := tj["tiles"].([]interface{})[0].(string); got != "http://example.com/api/satellite-tile/roads/{z}/{x}/{y}" {
+			t.Errorf("tiles = %q", got)
+		}
+	}
+
+	if upstream.tileJSONCalls.Load() != 1 {
+		t.Errorf("upstream tilejson was fetched %d times, want 1 (cached)", upstream.tileJSONCalls.Load())
+	}
+}
+
+func TestSatelliteTileUnknownSourceIs404(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	rec := getSatellite(t, srv, "/api/satellite-tile/nonexistent/1/2/3")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for an unresolved source", rec.Code)
+	}
+}
+
+// Resolving both sources — the raster one via the style, the vector one via
+// its TileJSON — then fetching tiles from each must count against one shared
+// quota, cache independently, and pass through each source's own content type
+// and encoding.
+func TestSatelliteTilesAreFetchedCachedAndSharedQuotaCounted(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	getSatellite(t, srv, "/api/satellite-style.json")
+	getSatellite(t, srv, "/api/satellite-tilejson/roads")
+
+	rasterRec := getSatellite(t, srv, "/api/satellite-tile/satellite/5/2/3")
+	if rasterRec.Code != http.StatusOK || rasterRec.Body.String() != "raster tile bytes" {
+		t.Fatalf("raster tile: status %d, body %q", rasterRec.Code, rasterRec.Body.String())
+	}
+	if ct := rasterRec.Header().Get("Content-Type"); ct != "image/jpeg" {
+		t.Errorf("raster Content-Type = %q", ct)
+	}
+
+	vectorRec := getSatellite(t, srv, "/api/satellite-tile/roads/5/2/3")
+	if vectorRec.Code != http.StatusOK || vectorRec.Body.String() != "vector tile bytes" {
+		t.Fatalf("vector tile: status %d, body %q", vectorRec.Code, vectorRec.Body.String())
+	}
+	if ce := vectorRec.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("vector Content-Encoding = %q, want gzip forwarded from upstream", ce)
+	}
+
+	// Repeat requests for the same tiles must be served from cache.
+	getSatellite(t, srv, "/api/satellite-tile/satellite/5/2/3")
+	getSatellite(t, srv, "/api/satellite-tile/roads/5/2/3")
+
+	if upstream.rasterCalls.Load() != 1 {
+		t.Errorf("raster upstream called %d times, want 1", upstream.rasterCalls.Load())
+	}
+	if upstream.vectorCalls.Load() != 1 {
+		t.Errorf("vector upstream called %d times, want 1", upstream.vectorCalls.Load())
+	}
+
+	count, _ := srv.satellite.usage.Snapshot(1_000_000)
+	if count != 2 {
+		t.Errorf("usage count = %d, want 2 (one per source, cache hits don't recount)", count)
+	}
+}
+
+// Once the shared quota is spent, every source must be refused — the cap
+// covers the whole MapTiler key's traffic through this proxy, not one source.
+func TestSatelliteTileRefusedOnceSharedQuotaExceeded(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1)
+
+	getSatellite(t, srv, "/api/satellite-style.json")
+	getSatellite(t, srv, "/api/satellite-tilejson/roads")
+
+	first := getSatellite(t, srv, "/api/satellite-tile/satellite/1/1/1")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first tile: status %d", first.Code)
+	}
+
+	second := getSatellite(t, srv, "/api/satellite-tile/roads/2/2/2")
+	if second.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 once the shared quota is spent", second.Code)
+	}
+	if upstream.vectorCalls.Load() != 0 {
+		t.Errorf("vector upstream was called %d times, want 0 (refused before fetching)", upstream.vectorCalls.Load())
+	}
+}
+
+func TestSatelliteTileRejectsACoordinateThatOverflowsInt(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+	getSatellite(t, srv, "/api/satellite-style.json")
+
+	rec := getSatellite(t, srv, "/api/satellite-tile/satellite/5/2/99999999999999999999")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a coordinate too large for int", rec.Code)
+	}
+}
+
+func TestSatelliteTileUpstreamFailureReturnsBadGateway(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	upstream.rasterFails.Store(true)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+	getSatellite(t, srv, "/api/satellite-style.json")
+
+	rec := getSatellite(t, srv, "/api/satellite-tile/satellite/9/9/9")
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", rec.Code)
+	}
+}
+
+func TestSatelliteSpriteIsProxiedAndCached(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+	getSatellite(t, srv, "/api/satellite-style.json") // registers the sprite upstream
+
+	for i := 0; i < 3; i++ {
+		rec := getSatellite(t, srv, "/api/satellite-sprite.json")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status %d: %s", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	if upstream.spriteCalls.Load() != 1 {
+		t.Errorf("sprite upstream called %d times, want 1 (cached)", upstream.spriteCalls.Load())
+	}
+
+	// Sprite traffic is deliberately not part of the tile quota — see the
+	// package doc comment in satellite.go.
+	count, _ := srv.satellite.usage.Snapshot(1_000_000)
+	if count != 0 {
+		t.Errorf("usage count = %d, want 0 (sprite fetches must not count)", count)
+	}
+}
+
+func TestSatelliteSpriteWithoutAStyleIs404(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	rec := getSatellite(t, srv, "/api/satellite-sprite.json")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 before the style has ever been resolved", rec.Code)
+	}
+}
+
+// Every satellite response now embeds absolute URLs pointing back at this
+// server (see buildStyle's doc comment on why relative ones broke vector
+// tiles), which means a dev setup serving the frontend and this backend from
+// different origins — Vite on :5173 proxying everything else to :8080 — has
+// the browser fetch those URLs directly, cross-origin, rather than through
+// the proxy. Without this header the browser blocks every one of them.
+func TestSatelliteResponsesAreCORSOpen(t *testing.T) {
+	upstream := newFakeMapTilerUpstream(t)
+	srv := newSatelliteServer(t, upstream.URL+"/style.json", 1_000_000)
+
+	styleRec := getSatellite(t, srv, "/api/satellite-style.json")
+	if got := styleRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("style Access-Control-Allow-Origin = %q, want \"*\"", got)
+	}
+
+	tileJSONRec := getSatellite(t, srv, "/api/satellite-tilejson/roads")
+	if got := tileJSONRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("tilejson Access-Control-Allow-Origin = %q, want \"*\"", got)
+	}
+
+	tileRec := getSatellite(t, srv, "/api/satellite-tile/satellite/1/1/1")
+	if got := tileRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("tile Access-Control-Allow-Origin = %q, want \"*\"", got)
+	}
+
+	spriteRec := getSatellite(t, srv, "/api/satellite-sprite.json")
+	if got := spriteRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("sprite Access-Control-Allow-Origin = %q, want \"*\"", got)
+	}
+}

--- a/internal/server/satellite_test.go
+++ b/internal/server/satellite_test.go
@@ -109,13 +109,13 @@ func newSatelliteServer(t *testing.T, styleURL string, limit int) *Server {
 		Port:                0,
 		DataDir:             t.TempDir(),
 		Version:             "test",
+		SatelliteStyleURL:   styleURL,
 		SatelliteQuotaLimit: limit,
 		SatelliteUsageDir:   t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	srv.satellite.styleURL = styleURL
 	return srv
 }
 
@@ -319,6 +319,27 @@ func TestSatelliteSpriteIsProxiedAndCached(t *testing.T) {
 	count, _ := srv.satellite.usage.Snapshot(1_000_000)
 	if count != 0 {
 		t.Errorf("usage count = %d, want 0 (sprite fetches must not count)", count)
+	}
+}
+
+// Using the default MapTiler style with no key configured (SatelliteStyleURL
+// empty, DT_MAPTILER_API_KEY unset) must refuse cleanly rather than attempt —
+// and keep retrying — a fetch MapTiler would reject anyway.
+func TestSatelliteStyleUnavailableWithNoStyleURLOrKey(t *testing.T) {
+	srv, err := New(config.Config{
+		Port:                0,
+		DataDir:             t.TempDir(),
+		Version:             "test",
+		SatelliteQuotaLimit: 1_000_000,
+		SatelliteUsageDir:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	rec := getSatellite(t, srv, "/api/satellite-style.json")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when no style URL or key is configured", rec.Code)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,10 @@ type Server struct {
 	// is honoured once for the whole deployment; see geocode.go.
 	geocode *geocodeLimiter
 
+	// satellite fetches, caches and quota-limits satellite imagery tiles from
+	// the configured upstream provider; see satellite.go.
+	satellite *satelliteTileProxy
+
 	// stores and routes are swapped, never mutated in place: a datapack install
 	// replaces both from a background goroutine while requests are being served.
 	// See state.go for why this is a pointer swap rather than a set of fields.
@@ -91,6 +95,25 @@ func New(cfg config.Config) (*Server, error) {
 
 	s.geocode = newGeocodeLimiter(cfg.Version)
 
+	// Persisted alongside settings.json so a restart does not reset what most
+	// providers treat as a running monthly total. A failure to locate or read it
+	// is not fatal: LoadSatelliteUsage always returns a usable, if unpersisted,
+	// counter — see its doc comment.
+	settingsDir := cfg.SatelliteUsageDir
+	if settingsDir == "" {
+		var err error
+		settingsDir, err = config.SettingsDir()
+		if err != nil {
+			log.Printf("Warning: could not determine settings directory, satellite usage will not persist: %v", err)
+			settingsDir = os.TempDir()
+		}
+	}
+	satelliteUsage, err := config.LoadSatelliteUsage(settingsDir)
+	if err != nil {
+		log.Printf("Warning: could not load satellite usage: %v", err)
+	}
+	s.satellite = newSatelliteTileProxy(cfg, satelliteUsage)
+
 	s.setRouter(s.buildRouter())
 
 	// Pre-warm the tile cache in the background so that low-zoom tiles are
@@ -119,7 +142,7 @@ func (s *Server) buildRouter() *mux.Router {
 	cfg := s.cfg
 	cfg.DataDir = current.dataDir
 	cfg.ResourcesDir = current.resourcesDir
-	apiHandler := api.NewHandler(current.tiles, current.gpkg, current.sites, cfg)
+	apiHandler := api.NewHandler(current.tiles, current.gpkg, current.sites, cfg, s.satellite.usage)
 	apiHandler.RegisterRoutes(apiRouter)
 
 	// Data pack management routes. Serving the pack and the installers is the
@@ -133,6 +156,17 @@ func (s *Server) buildRouter() *mux.Router {
 	// Place-name search, proxied so the upstream usage policy can be met at all;
 	// see geocode.go. Public: both builds offer search.
 	router.HandleFunc("/api/geocode", s.handleGeocode).Methods("GET")
+
+	// Satellite imagery, proxied so every tile the Hybrid style references can
+	// be counted and quota-enforced, and so the MapTiler key stays server-side;
+	// see satellite.go. Public: both builds show the basemap.
+	router.HandleFunc("/api/satellite-style.json", s.handleSatelliteStyle).Methods("GET")
+	router.HandleFunc("/api/satellite-tilejson/{source:[a-zA-Z0-9_-]+}",
+		s.handleSatelliteTileJSON).Methods("GET")
+	router.HandleFunc("/api/satellite-tile/{source:[a-zA-Z0-9_-]+}/{z:[0-9]+}/{x:[0-9]+}/{y:[0-9]+}",
+		s.handleSatelliteTile).Methods("GET")
+	router.HandleFunc("/api/satellite-sprite{variant:(?:\\.json|\\.png|@2x\\.json|@2x\\.png)}",
+		s.handleSatelliteSprite).Methods("GET")
 
 	// Desktop-only. In server mode these paths are simply absent, so they 404
 	// through the SPA fallback rather than existing and refusing — there is
@@ -514,8 +548,8 @@ func (s *Server) handleGlyphProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	upstreamURL := fmt.Sprintf(
-		"https://api.maptiler.com/fonts/%s/%s.pbf?key=cc4PpmmWZP73LjU1nsw3",
-		fontstack, glyphRange,
+		"https://api.maptiler.com/fonts/%s/%s.pbf?key=%s",
+		fontstack, glyphRange, config.MapTilerAPIKey,
 	)
 	resp, err := glyphHTTPClient.Get(upstreamURL)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -549,7 +549,7 @@ func (s *Server) handleGlyphProxy(w http.ResponseWriter, r *http.Request) {
 
 	upstreamURL := fmt.Sprintf(
 		"https://api.maptiler.com/fonts/%s/%s.pbf?key=%s",
-		fontstack, glyphRange, config.MapTilerAPIKey,
+		fontstack, glyphRange, config.MapTilerAPIKey(),
 	)
 	resp, err := glyphHTTPClient.Get(upstreamURL)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,11 +30,15 @@ func main() {
 	dataDir := flag.String("data-dir", "", "Directory containing data files (mbtiles, geopackage)")
 	resourcesDir := flag.String("resources-dir", "", "Directory containing resource files (mbtiles, styles)")
 	headless := flag.Bool("headless", false, "Run in headless mode (no GUI window)")
-	satelliteTileURL := flag.String("satellite-tile-url", "",
-		"Raster tile template for satellite imagery. Defaults to the endpoint the "+
-			"application has always used; see issue #65.")
+	satelliteStyleURL := flag.String("satellite-style-url", "",
+		"MapLibre style document for satellite imagery (satellite tiles plus roads and "+
+			"labels). Defaults to the style the application has always used; see issue #65.")
 	satelliteAttribution := flag.String("satellite-attribution", "",
-		"Attribution shown for --satellite-tile-url. Required by most providers' licences.")
+		"Attribution shown for --satellite-style-url. Required by most providers' licences.")
+	satelliteQuotaLimit := flag.Int("satellite-quota-limit", 0,
+		"Monthly cap on satellite tiles fetched for --satellite-style-url before the "+
+			"client falls back to the built-in basemap. Defaults to the default provider's "+
+			"documented free-tier limit; set this when using a provider with a different one.")
 	bindAddress := flag.String("bind", config.DefaultBindAddress,
 		"Interface to listen on. Loopback by default; the API is unauthenticated, "+
 			"so use 0.0.0.0 only where something in front of it controls access.")
@@ -120,8 +124,9 @@ func main() {
 		ResourcesDir:         resolvedResourcesDir,
 		Version:              version,
 		BindAddress:          *bindAddress,
-		SatelliteTileURL:     *satelliteTileURL,
+		SatelliteStyleURL:    *satelliteStyleURL,
 		SatelliteAttribution: *satelliteAttribution,
+		SatelliteQuotaLimit:  *satelliteQuotaLimit,
 		// --headless is the server build; anything else opens the window below.
 		DesktopMode: !*headless,
 	}

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -38,6 +38,11 @@ set -euo pipefail
 #   DT_FORCE_BUILD=1 Rebuild frontend, docs and binary unconditionally.
 #   DT_HEADLESS=1    Deprecated spelling of DT_MODE=server.
 #   DT_WEBVIEW_DIAG=1  Same as --diag.
+#   DT_MAPTILER_API_KEY  Satellite basemap and font-glyph proxy key (see
+#                    internal/config.MapTilerAPIKey). Read directly by the
+#                    binary, not turned into a flag — a flag value is visible
+#                    to anyone who can run `ps` on the machine, which a key
+#                    should not be.
 #
 # Those knobs can also be set per-machine in a gitignored .dt-env file in the
 # project root — see .dt-env.example. Machine-specific choices belong there, not
@@ -75,6 +80,7 @@ DT_VARS=(
     DT_HEADLESS
     DT_SKIP_BUILD
     DT_FORCE_BUILD
+    DT_MAPTILER_API_KEY
 )
 
 # Load per-machine defaults from .dt-env. Anything already present in the
@@ -188,6 +194,13 @@ ARGS=()
 [ -n "${DT_DATA_DIR:-}" ] && ARGS+=(--data-dir "$DT_DATA_DIR")
 [ -n "${DT_RESOURCES_DIR:-}" ] && ARGS+=(--resources-dir "$DT_RESOURCES_DIR")
 [ "$DT_MODE" = "server" ] && ARGS+=(--headless)
+
+# Not a flag (see the comment on DT_MAPTILER_API_KEY above) — exported instead
+# so the exec'd binary picks it up via os.Getenv. `. "$env_file"` above sets
+# shell variables, not exported ones, so this is the step that actually makes
+# a value from .dt-env reach the process; a value already in the real
+# environment was exported by whatever set it and needs nothing here.
+[ -n "${DT_MAPTILER_API_KEY:-}" ] && export DT_MAPTILER_API_KEY
 
 # Caller arguments last so they override anything derived from the environment.
 ARGS+=("${PASSTHROUGH[@]}")


### PR DESCRIPTION
Replaces the satellite basemap with MapTiler Hybrid (satellite imagery + OSM roads/place labels), proxied entirely through the backend so the API key never reaches the browser and usage is capped against a monthly quota. Also fixes a data-loss bug found while testing: deleted sites could silently reappear in the browser runtime.

**Satellite basemap (MapTiler Hybrid)**
- Backend resolves and rewrites MapTiler's style document — every source's tiles (raster + vector), its sprite, and glyphs — into local /api/satellite-* proxy routes, so the key stays server-side and every fetch is cached and quota-counted (internal/server/satellite.go).
- Monthly cap defaults to 80,000 requests (below MapTiler's 100,000 hard limit, leaving headroom for the font-glyph proxy sharing the same key), persisted across restarts (internal/config/satellitequota.go), configurable via --satellite-quota-limit.
- Frontend polls quota status and auto-reverts to the built-in basemap with a toast if the cap is hit (MapView.tsx, SiteCreationMap.tsx, satelliteBasemap.ts).
- Fixed two bugs surfaced during verification: relative tile URLs failed inside MapLibre's Web Worker (vector tiles were silently never loading), and the new routes needed CORS headers for the Vite-dev-server-proxying-to-backend setup.

**Site deletion bug fix (browser runtime)**
- deleteSite was discarding the success/failure result of the underlying storage write, so a failed delete reported success anyway.
- A stale pre-migration dt-sites blob was being re-consulted as authoritative on every load whenever storage stayed over quota, resurrecting deleted sites.
- frontend/src/lib/siteStore.ts, frontend/src/hooks/useApi.ts.

Also: centralized the MapTiler API key to one constant shared by the glyph proxy and the new satellite proxy; renamed --satellite-tile-url → --satellite-style-url.