### PR TITLE
feat(map): stretch choropleth color scale to zone range; move zone range control to grid header

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -25,6 +25,10 @@ aa38bd4aa669babea620de9d9b65f1737741eea0:data/mbtiles/style.json:generic-api-key
 cd698f36e0c876fd1af77ab4efe835e490fdf0aa:resources/mbtiles/uow_tiles.json:generic-api-key:14
 062ff0a5d8650051c8e706c39374d31e3fe54b61:internal/server/server.go:generic-api-key:402
 
+# Same key, given a named constant (MapTilerAPIKey) in config.go so the
+# satellite style URL and the glyph proxy can't drift onto different keys.
+d7cd03dc8354e299cb946fd63ae85b3686cc2080:internal/config/config.go:generic-api-key:98
+
 # ---------------------------------------------------------------------------
 # TLS private key committed in 3ac8333 (2026-05-28) — ROTATED
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -364,7 +364,7 @@ function ContentArea({
             );
           })}
 
-          {(quadActiveMode === 'dial' || quadActiveMode === 'chart') && onRangeModeChange && (
+          {onRangeModeChange && (
             <HStack spacing={1} pl={2} ml={2} borderLeft="1px" borderColor="gray.600">
               {RANGE_MODE_CONFIG.map((mode) => {
                 const isActive = rangeMode === mode.id;

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -713,11 +713,18 @@ function ControlPanel({
   const leftZoneStats = applySiteIndicatorOverrides(leftZoneStatsRaw, comparison.leftScenario);
   const rightZoneStats = applySiteIndicatorOverrides(rightZoneStatsRaw, comparison.rightScenario);
 
-  // The color scale always reflects the attribute's global domain across every
-  // catchment, independent of the selected zone range (Full/Extent/Site).
+  // The color scale is stretched to whichever zone is selected (Full/Extent/Site):
+  // 'Full' uses the attribute's global domain across every catchment, while
+  // 'Extent'/'Site' stretch to that zone's local min/max so subtle local
+  // variation isn't washed out by the full dataset's range. MapView publishes
+  // whichever range it actually painted with as domainRange, so this always
+  // matches what's on the map.
   const combinedDomainRange: { min: number; max: number } | null = mapStatistics?.domainRange
     ? { min: mapStatistics.domainRange.min, max: mapStatistics.domainRange.max }
     : null;
+  const colorScaleRangeLabel = effectiveRangeMode === 'domain'
+    ? 'Full'
+    : effectiveRangeMode === 'extent' ? 'Extent' : 'Site';
   const [panelWidth, setPanelWidth] = useState(440);
   const [isResizing, setIsResizing] = useState(false);
   const resizeOriginX = useRef(0);
@@ -805,7 +812,7 @@ function ControlPanel({
 
           <Divider />
 
-          {viewMode !== 'dial' && onRangeModeChange && (
+          {!asModal && viewMode !== 'dial' && onRangeModeChange && (
             <Box>
               <HStack justify="space-between" align="center" mb={2}>
                 <Text fontSize="xs" fontWeight="600" color="gray.500">
@@ -1139,7 +1146,7 @@ function ControlPanel({
             <Box>
               <HStack justify="space-between" align="center" mb={2}>
                 <Text fontSize="xs" fontWeight="600" color="gray.500">
-                  COLOR SCALE (Domain Range)
+                  COLOR SCALE ({colorScaleRangeLabel})
                 </Text>
                 <ButtonGroup size="xs" isAttached variant="outline"> 
                   {/* <Button

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -4,7 +4,7 @@ import { FiSliders, FiMap, FiInfo, FiBox, FiTarget, FiPlus, FiMinus, FiColumns, 
 import maplibregl from 'maplibre-gl';
 import { bbox as turfBbox, featureCollection, union, difference, intersect, area as turfArea, simplify as turfSimplify } from '@turf/turf';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import type { ComparisonState, Scenario, IdentifyResult, MapExtent, MapStatistics, ZoneStats, BoundingBox, DomainRange, ColorScaleMode, ColorScaleType, SiteIndicators } from '../types';
+import type { ComparisonState, Scenario, IdentifyResult, MapExtent, MapStatistics, ZoneStats, BoundingBox, DomainRange, ColorScaleMode, ColorScaleType, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
 import { registerMap, unregisterMap, getLastMapView } from '../hooks/useMapSync';
 import { getSite, getSiteCatchments, getSiteAOIFractions, useAttributeColors, useAttributeDetails, loadLocalSite, saveLocalSite, clearSiteWhiskerCache } from '../hooks/useApi';
@@ -50,6 +50,8 @@ interface MapViewProps {
   onSwiperEnabledChange?: (enabled: boolean) => void;
   colorScaleMode: ColorScaleMode;
   colorScaleType: ColorScaleType;
+  /** Which zone's min/max the color scale (and legend) is stretched to. Defaults to 'domain'. */
+  rangeMode?: RangeMode;
   // Slider position synchronization
   swiperPosition?: number;
   onSwiperPositionChange?: (position: number) => void;
@@ -634,6 +636,45 @@ function resolveDomainRange(
   };
 }
 
+/** Combine left/right ZoneStats into one range, widest side wins on each end. */
+function combineStatsRange(
+  left: ZoneStats | null,
+  right: ZoneStats | null,
+): { min: number; max: number } | null {
+  const mins = [left?.min, right?.min].filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  const maxes = [left?.max, right?.max].filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  if (mins.length === 0 || maxes.length === 0) return null;
+  return { min: Math.min(...mins), max: Math.max(...maxes) };
+}
+
+/**
+ * The color scale actually painted onto the map. Unlike resolveDomainRange
+ * (the metadata cap, used verbatim for rangeMode 'domain'), 'extent' and
+ * 'site' stretch the scale to the min/max of whichever zone is selected, so
+ * local variation that is subtle against the full dataset's range still
+ * shows up as strong color contrast within that zone.
+ *
+ * Falls back down the chain (site → extent → domain) when the more local
+ * stats aren't available yet — e.g. the site-scoped fetch is still in
+ * flight the first time a site's map paints.
+ */
+function resolvePaintRange(
+  rangeMode: RangeMode,
+  domainRange: { min: number; max: number },
+  extentStats: { left: ZoneStats | null; right: ZoneStats | null },
+  siteStats: { left: ZoneStats | null; right: ZoneStats | null } | null,
+): { min: number; max: number } {
+  if (rangeMode === 'site') {
+    return combineStatsRange(siteStats?.left ?? null, siteStats?.right ?? null)
+      ?? combineStatsRange(extentStats.left, extentStats.right)
+      ?? domainRange;
+  }
+  if (rangeMode === 'extent') {
+    return combineStatsRange(extentStats.left, extentStats.right) ?? domainRange;
+  }
+  return domainRange;
+}
+
 /**
  * The vector-tile path's payload: catchment ids and their values for the
  * viewport, with no geometry. Mirrors CatchmentValuesResponse in
@@ -836,7 +877,7 @@ const EDIT_VERTICES_GLOW = 'edit-vertices-glow';
 const EDIT_VERTICES_OUTER = 'edit-vertices-outer';
 const EDIT_VERTICES_INNER = 'edit-vertices-inner';
 
-function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, onSwiperEnabledChange, colorScaleMode, colorScaleType, swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, on3DModeChange, refreshKey, onReady, siteIndicators }: MapViewProps) {
+function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, onSwiperEnabledChange, colorScaleMode, colorScaleType, rangeMode = 'domain', swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, on3DModeChange, refreshKey, onReady, siteIndicators }: MapViewProps) {
   const { colors: attributeColors, loading: attributeColorsLoading } = useAttributeColors();
   const { details: attributeDetails } = useAttributeDetails();
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -1195,13 +1236,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         // disagreeing with the controls.
         if (superseded()) return;
 
-        const { min, max } = resolveDomainRange([leftValues, rightValues]);
-        publishStats(
-          min,
-          max,
-          leftValues ? zoneStatsFromValues(leftValues.values) : null,
-          rightValues ? zoneStatsFromValues(rightValues.values) : null,
-        );
+        const domainRange = resolveDomainRange([leftValues, rightValues]);
+        const extentLeftStats = leftValues ? zoneStatsFromValues(leftValues.values) : null;
+        const extentRightStats = rightValues ? zoneStatsFromValues(rightValues.values) : null;
+        const { min, max } = resolvePaintRange(
+          rangeMode, domainRange, { left: extentLeftStats, right: extentRightStats }, siteZoneStatsRef.current);
+        publishStats(min, max, extentLeftStats, extentRightStats);
 
         const applySide = (
           // Nullable since the compare map is created only in compare mode:
@@ -1324,13 +1364,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       const leftDisplay = leftData;
       const rightDisplay = rightData;
 
-      const { min, max } = resolveDomainRange([leftData, rightData]);
-      publishStats(
-        min,
-        max,
-        leftData ? computeZoneStats(leftData, c.attribute) : null,
-        rightData ? computeZoneStats(rightData, c.attribute) : null,
-      );
+      const domainRange = resolveDomainRange([leftData, rightData]);
+      const extentLeftStats = leftData ? computeZoneStats(leftData, c.attribute) : null;
+      const extentRightStats = rightData ? computeZoneStats(rightData, c.attribute) : null;
+      const { min, max } = resolvePaintRange(
+        rangeMode, domainRange, { left: extentLeftStats, right: extentRightStats }, siteZoneStatsRef.current);
+      publishStats(min, max, extentLeftStats, extentRightStats);
 
       // Apply to left map - verify the map is ready
       if (leftDisplay && leftDisplay.features.length > 0) {
@@ -1378,7 +1417,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // rebuild this callback constantly — and it is one of the fifteen in the
   // tracking issue.
   // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing; see the tracking issue
-  }, [colorScaleMode, colorScaleType, siteId]);
+  }, [colorScaleMode, colorScaleType, rangeMode, siteId]);
 
   const applyColorsRef = useRef(applyColors);
   useEffect(() => {
@@ -3622,7 +3661,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     // Apply scenario-specific colours
     applyColors();
-  }, [comparison, applyColors, isSwiperEnabled, colorScaleMode, colorScaleType, attributeColors, attributeDetails]);
+  }, [comparison, applyColors, isSwiperEnabled, colorScaleMode, colorScaleType, rangeMode, attributeColors, attributeDetails]);
 
   // Highlight identified catchment with neon yellow glow effect
   useEffect(() => {

--- a/frontend/src/components/TourGuide.tsx
+++ b/frontend/src/components/TourGuide.tsx
@@ -81,7 +81,7 @@ const STEPS: TourStep[] = [
     icon: <FiActivity size={28} />,
     title: 'View Modes',
     description:
-      'Use these buttons to switch the pane between Map, Chart, Dial, and Table. In quad-pane mode all four views are shown at once.',
+      'Use these buttons to switch the pane between Map, Chart, Dial, and Table. In grid-view mode all four views are shown at once.',
     targetId: 'tour-view-modes',
     navigateTo: 'explore',
     image: tourViewModesImg,

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -600,6 +600,7 @@ function ViewPane({
           onSwiperEnabledChange={onSwiperEnabledChange}
           colorScaleMode={colorScaleMode}
           colorScaleType={colorScaleType}
+          rangeMode={rangeMode}
           is3DMode={is3DMode}
           on3DModeChange={on3DModeChange}
           swiperPosition={swiperPosition}


### PR DESCRIPTION
- The choropleth color scale (and its legend) now stretches to whichever Zone Range is selected — Full keeps today's global metadata-cap coloring, Extent stretches to the current viewport's min/max, Site stretches to the site-scoped min/max — so local variation that was previously washed out by the full dataset's range is now visible when zoomed into a study site.
- Moved the Zone Range control out of each pane's "Configure factor" modal (where it misleadingly looked per-pane) into the grid-view header, and extended it there to all four view modes — Map and Table now get it alongside Chart and Dial.

**Ticket ticket_167**