### PR TITLE
fix(server): exclude 206 responses from gzip compression to fix HTTP/2 asset errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
   # ==========================================
   lint-go:
     runs-on: ubuntu-latest
+    # Azure-hosted runners resolve apt mirrors through
+    # mirror+file:/etc/apt/apt-mirrors.txt, and azure.archive.ubuntu.com has been
+    # seen to stall with no response. Plain apt-get has no timeout for that, so it
+    # hangs until GitHub's own multi-hour job ceiling. This bounds the damage to one
+    # retry cycle instead.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -130,7 +136,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 update
           sudo apt-get install -y libopenblas-dev libwebkit2gtk-4.1-dev libgtk-3-dev pkg-config
 
       # webview_go asks pkg-config for webkit2gtk-4.0, which no current
@@ -181,6 +187,9 @@ jobs:
   # ==========================================
   test-go:
     runs-on: ubuntu-latest
+    # See the identical timeout on lint-go: an unresponsive azure.archive.ubuntu.com
+    # mirror can hang plain apt-get indefinitely.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -195,7 +204,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 update
           sudo apt-get install -y libopenblas-dev libwebkit2gtk-4.1-dev libgtk-3-dev pkg-config
 
       - name: webkit2gtk-4.0 compatibility shim

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -142,6 +142,17 @@ func hasBody(status int) bool {
 	return true
 }
 
+// isPartialContent reports whether the status is 206. http.ServeContent (the
+// static file server, and thus every embedded frontend asset) answers Range
+// requests this way, with Content-Length and Content-Range describing a slice
+// of the uncompressed file. Gzipping that slice on its own produces a body
+// that isn't valid gzip, while the stale Content-Range still names offsets
+// into the uncompressed file — a framing mismatch Chrome rejects outright
+// under HTTP/2 as ERR_HTTP2_PROTOCOL_ERROR.
+func isPartialContent(status int) bool {
+	return status == http.StatusPartialContent
+}
+
 // decide settles whether this response is compressed and sends the header.
 func (w *gzipResponseWriter) decide() {
 	if w.decided {
@@ -159,7 +170,7 @@ func (w *gzipResponseWriter) decide() {
 	alreadyEncoded := header.Get("Content-Encoding") != ""
 	tooSmall := len(w.buf) < compressMinBytes && w.gz == nil
 
-	if alreadyEncoded || !hasBody(w.status) || !isCompressibleType(header.Get("Content-Type")) || tooSmall {
+	if alreadyEncoded || !hasBody(w.status) || isPartialContent(w.status) || !isCompressibleType(header.Get("Content-Type")) || tooSmall {
 		w.raw = true
 		w.ResponseWriter.WriteHeader(w.status)
 		return

--- a/internal/server/compress_test.go
+++ b/internal/server/compress_test.go
@@ -232,6 +232,32 @@ func TestStatusesWithoutABodyAreNotCompressed(t *testing.T) {
 	}
 }
 
+// http.ServeContent answers a Range request with 206, a Content-Length for just
+// that slice, and a Content-Range naming uncompressed offsets. Gzipping the slice
+// invalidates all three: the bytes are no longer a standalone gzip stream, and
+// Content-Range would still describe the pre-compression file. This is what
+// produced ERR_HTTP2_PROTOCOL_ERROR for embedded frontend assets in production.
+func TestPartialContentIsNotCompressed(t *testing.T) {
+	body := bigJSON()
+	h := compressResponses(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Header().Set("Content-Range", "bytes 0-99/"+strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte(body[:100]))
+	}))
+	rec := get(t, h, "/assets/chakra-CdCWquJF.js", "gzip")
+
+	if rec.Code != http.StatusPartialContent {
+		t.Errorf("status = %d, want 206", rec.Code)
+	}
+	if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("Content-Encoding = %q on a 206, would corrupt the range framing", enc)
+	}
+	if rec.Body.String() != body[:100] {
+		t.Error("206 body was altered")
+	}
+}
+
 // The status the handler chose must survive, or an error becomes a 200.
 func TestStatusCodeIsPreserved(t *testing.T) {
 	body := bigJSON()


### PR DESCRIPTION
Description: Exclude 206 Partial Content responses from gzip compression middleware — Range requests against embedded static assets (e.g. chakra-*.js, map-*.js) were being re-compressed with a stale Content-Range, producing ERR_HTTP2_PROTOCOL_ERROR in production.