### PR TITLE
fix(security): take the MapTiler key from configuration, not from source

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -9,17 +9,28 @@
 # been dealt with by rotation, because git history cannot be edited.
 
 # ---------------------------------------------------------------------------
-# MapTiler client key — public by design, restricted at MapTiler
+# MapTiler client key committed until 2026-08 — MUST BE REVOKED
 # ---------------------------------------------------------------------------
 #
-# The key appears in a glyph URL that the browser fetches directly, so it is
-# necessarily visible to anyone using the dashboard; hiding it in the repository
-# would not make it secret. It is restricted to the deployment's own domains at
-# MapTiler, which is the control that actually protects it.
+# The argument that used to stand here — that the browser fetched the glyph URL
+# directly, so the key was public anyway — was wrong on its own terms. The
+# server proxies those fetches through /fonts/{fontstack}/{range}.pbf and the
+# browser never saw the key; it was disclosed by being committed, not by being
+# used. Being disclosed, it was also usable against the account from anywhere
+# the domain restriction did not reach.
 #
-# Still tracked, deliberately, in internal/server/server.go and the two
-# style.json files. If that restriction is ever lifted, this exemption stops
-# being valid and the key must move to runtime configuration instead.
+# The key is gone from the tree: it now comes from run-time configuration with
+# no default compiled in, and no tracked file carries one. See issue #31 and
+# NOTES-maptiler.md.
+#
+# Removing it from the tree does not undo the disclosure. It remains in this
+# repository's history, and in every release binary and data pack built before
+# the change, so the key itself must be revoked at MapTiler. Until someone with
+# access to that account confirms it has been, treat it as live.
+#
+# The fingerprints below pin the historical commits only. History cannot be
+# edited, and an entry here cannot become a blanket exemption: a new occurrence
+# in a new commit is still reported, which is the point.
 e5f0ac7a86649bbe302bc7823f2a33fdc793bc3e:data/mbtiles/style.json:generic-api-key:14
 aa38bd4aa669babea620de9d9b65f1737741eea0:data/mbtiles/style.json:generic-api-key:14
 cd698f36e0c876fd1af77ab4efe835e490fdf0aa:resources/mbtiles/uow_tiles.json:generic-api-key:14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,6 +484,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Saving one site cost as much as saving all of them.** The three bulk callers
+  loaded every stored site, changed one, and wrote them all back, so `JSON.parse`
+  and `JSON.stringify` ran across the whole store on the main thread for every
+  edit — and the cost grew with everything a user had ever saved rather than with
+  what changed.
+
+  A record cache now keeps, per site, the object last handed out and the exact
+  string it serialises to. Reads re-parse only when the stored string differs, an
+  untouched site is recognised by reference and never re-serialised, and the index
+  is rewritten only when membership or order actually changed.
+
+  Measured in jsdom, editing one site out of 200 with the store at 4,091,627
+  characters — 78% of this machine's measured 5,241,856-character localStorage
+  ceiling — **saving fell from 24.94 ms to 0.28 ms and reloading from 17.90 ms to
+  0.60 ms**. The figure that matters is that the new cost barely moves between a
+  807,000-character store (0.21 ms) and a 4.1-million one (0.28 ms): it is now
+  proportional to the edit, not to the store.
+
+  Nothing is deferred, debounced or batched, so no durability window is
+  introduced — these records are the user's only copy of their work. A cache entry
+  is written only when the underlying write succeeded and is dropped when it
+  failed, so a quota exception can never leave the application believing a site is
+  stored.
+
 - **The application held twelve WebGL contexts in grid view and never gave one
   back.** Each `MapView` built two MapLibre instances — left and right — whether or
   not the user was comparing anything, and a pane latched "has shown a map" on first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -535,6 +535,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance opens there rather than at the default world view, so a release and
   recreate does not move the map under the user.
 
+- **Panning the map re-asked questions whose answers could not have changed.**
+  `ViewPane` and `ChartView` both listed the map extent as an effect dependency
+  regardless of range mode, and the extent is a fresh object on every move — so a
+  pan re-issued full-domain queries that do not depend on the extent at all. At
+  4.77 seconds per full-domain `/api/aggregate` request, a scripted six-pane
+  session of one mount and five pans issued **216 chart-pane requests where 6 were
+  needed, and 72 dial-pane requests where 2 were** — roughly 1,030 seconds of
+  server work reduced to about 29.
+
+  Overlapping work is now ordered as well as reduced. `applyColors` is called from
+  sixteen places and is asynchronous throughout, so runs routinely overlapped and
+  nothing sequenced them: whichever response arrived last painted the map,
+  regardless of which viewport, scenario or attribute the user had asked for. Each
+  run now carries a monotonic ticket that is checked after every await, and
+  superseding a run aborts the requests it no longer needs.
+
+  A shared-request primitive replaces two hand-rolled promise caches. It shares one
+  in-flight request per key, cancels it when nothing wants it, and counts
+  subscribers — so one pane navigating away cannot cancel a request the other
+  eleven are waiting on.
+
+  The choropleth request count is deliberately unchanged: the existing cache
+  already deduplicated those across panes. What changed there is that superseded
+  requests are now cancelled rather than merely ignored, which frees the
+  connection instead of leaving both ends busy.
+
+- **A transient server error was cached as "no data" for a full minute.** The
+  choropleth cache stored a promise that swallowed its own errors and resolved to
+  `null`, so a single 500 response left the map blank for the whole 60-second TTL
+  even after the server recovered. Rejections are no longer cached.
+
 - **The choropleth is served as vector tiles instead of a GeoJSON source.** The tile
   pipeline already carried the catchment polygons — `gpkg_to_mbtiles.sh` tiles
   `catchments_lev12` alongside the basemap layers — but the layer users actually look

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A client that gave up did not stop the work it had started.** No database call
+  took a `context.Context`, so when a user closed a tab, panned the map again, or
+  a proxy timed out, the query ran to completion against SQLite — holding a
+  connection and CPU for an answer nobody would read. The most expensive query in
+  the application takes over four seconds and the map issues one on every pan, so
+  abandoned work accumulated exactly when the server was already busy.
+
+  Every SQLite-touching method now takes a context and uses the `Context` query
+  variants, and a cancelled request is logged as cancelled rather than as a
+  failure. Cancellation is detected from both shapes it arrives in: `database/sql`
+  reports `context.Canceled`, while go-sqlite3 reports its own `SQLITE_INTERRUPT`
+  when a statement is stopped mid-flight. A blown deadline is deliberately *not*
+  treated as a cancellation — that is a real failure.
+
+  Some work is deliberately not cancellable, because it is started on behalf of
+  one request and serves all of them: the grid geometry cache build is guarded by
+  a `sync.Once`, so a cancellation would tear it down and nothing would restart
+  it, leaving the aggregated map path broken for the life of the process. What is
+  now cancellable there is the *wait*, not the build.
+
+  Ten result loops gained the `rows.Err()` check they lacked. This was required
+  rather than tidy: a cancelled scan ends iteration early, so without it a partial
+  choropleth or a partial statistics set would have been returned as complete —
+  threading a context would have created a new silent-failure path while closing
+  another.
+
 - **The container images built against a different WebKit than everything else ships.**
   `deployments/Dockerfile`, `deployments/Dockerfile.cross` and
   `deployments/Dockerfile.builder` all installed `libwebkit2gtk-4.0-dev`, while the

--- a/NOTES-maptiler.md
+++ b/NOTES-maptiler.md
@@ -1,0 +1,270 @@
+# MapTiler key — issue #31
+
+Working notes for the code half of "Rotate the MapTiler API key committed to
+source". The key is out of the tree and now comes from run-time configuration.
+**It has not been rotated, and only the MapTiler account holder can do that.**
+
+---
+
+## 1. Every occurrence of the key
+
+The key is written here as `cc4Ppmm…` — the first seven characters, which
+is enough to pick it out of the list in the MapTiler console. The full
+literal is deliberately not repeated in this file: it would put the secret
+back into a tracked file and fail the repository's own gitleaks gate. Read
+it from any of the historical commits listed below, or from the MapTiler
+account itself.
+
+### In the working tree, before this change (three, all now removed)
+
+| File | Line | What it was |
+|---|---|---|
+| `internal/server/server.go` | 517 | `"https://api.maptiler.com/fonts/%s/%s.pbf?key=cc4Ppmm…"` — the only occurrence that was actually used |
+| `resources/mbtiles/style.json` | 14 | `"glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=…"` |
+| `data/mbtiles/style.json` | 14 | byte-identical file (`diff` reports no difference) |
+
+Both `style.json` files are **tracked**. `data/` is mostly gitignored, but
+`.gitignore:72` carries an explicit `!data/mbtiles/style.json` exception, so that
+copy is committed too. `git ls-files` confirms both.
+
+After the change, grepping the tree for the key returns nothing outside this
+file.
+
+### In git history (permanent — not rewritten, as instructed)
+
+`git log --all -S"<the key>"` finds seven commits:
+
+| Commit | Date | File | Note |
+|---|---|---|---|
+| `cd698f3` | 2026-01-28 | `internal/server/server.go`, `resources/mbtiles/uow_tiles.json` | initial commit; the key has been public since day one |
+| `aa38bd4` | 2026-02-16 | `data/mbtiles/style.json` | added |
+| `3ac8333` | 2026-05-28 | `data/mbtiles/style.json` | deleted (also the commit that leaked `deployments/certs/tls.key`) |
+| `e5f0ac7` | 2026-06-01 | `data/mbtiles/style.json` | re-added |
+| `062ff0a` | 2026-05-26 | `internal/server/server.go` | moved during the performance rework |
+| `d7cd03d` | 2026-08-19 | `internal/server/server.go` | **on `origin/ticket_174` only** — replaced the literal with `%s`; see §5 |
+| `ceee4ea` | 2026-08-19 | `internal/server/server.go` | **on `origin/ticket_174` only** |
+
+### Outside the repository
+
+- **Every released binary.** The literal was compiled into `decision-theatre`,
+  so every desktop package ever published contains it. `strings` finds it.
+- **Every data pack.** `scripts/pack-data.sh` builds the pack from the local
+  `data/` directory via `decision-theatre pack-data`, and `data/mbtiles/style.json`
+  is part of what it packs. Every `decision-theatre-data-v*.zip` distributed so
+  far carries the key.
+- **The public GitHub repository**, in all of the above commits.
+
+### Related, and already known
+
+`.gitleaksignore` carried four fingerprints exempting these findings, with a
+comment arguing the key was "public by design". That argument was wrong on its
+own terms — the server proxies the glyph fetches, so the browser never saw the
+key; it was disclosed by being committed. I rewrote that comment block to say so
+and to record that the key must be revoked. The fingerprints stay: they pin
+historical commits, which cannot be edited.
+
+---
+
+## 2. What the key actually does
+
+Less than it looks like. MapTiler supplies **the fonts the map labels are drawn
+with, and nothing else**. Vector tiles come from the local `.mbtiles` file,
+catchment geometry from the local GeoPackage, every number in the interface from
+the local data pack. The application is designed to run offline.
+
+The browser never sees the key, before or after this change:
+
+1. The client loads `/data/style.json`.
+2. `handleStyleJSON` (`internal/server/server.go`) rewrites the style's `glyphs`
+   field to `<base>/fonts/{fontstack}/{range}.pbf` — **unconditionally**, whatever
+   the file on disk said. The style cache in `internal/server/state.go` holds the
+   rewritten bytes.
+3. The browser asks the server for glyphs; `handleGlyphProxy` fetches them from
+   `api.maptiler.com` with the key attached, and caches them in-process.
+
+So the key in the two `style.json` files was **dead data** — never served,
+never used. Only `server.go` mattered. That is why there is exactly one
+injection point now, and it is the proxy.
+
+---
+
+## 3. What changed
+
+**`internal/config/config.go`**
+
+- `Config.MapTilerKey` — new field, no default, nothing compiled in. Documented
+  alongside `SatelliteTileURL`, which is the pattern this follows.
+- `Config.MapTilerGlyphURL(fontstack, glyphRange) (string, bool)` — builds the
+  upstream URL, returning `false` when no key is set. `fontstack` and `range`
+  come off the request path and are now `url.PathEscape`d, so a crafted font
+  name cannot append its own query parameters; the key is `url.QueryEscape`d.
+- `ResolveMapTilerKey(flag, settings)` — flag, then `DT_MAPTILER_API_KEY`, then
+  `settings.json`. Trims whitespace, because a key pasted into a `.env` or a JSON
+  file picks up a newline easily and MapTiler rejects that exactly like a wrong key.
+- `Settings.MapTilerKey` (`"maptiler_key"`, `omitempty`) — the only route
+  available to a desktop install that was launched by double-clicking an icon.
+
+**`internal/server/server.go`**
+
+- The literal is gone; `handleGlyphProxy` asks `MapTilerGlyphURL` for the URL.
+- No key ⇒ **no request is made at all**, one log line via `sync.Once`, and the
+  same empty-`200` response the proxy already returns when the CDN is
+  unreachable. See §4.
+- `writeEmptyGlyphs` — the empty-`200` response was written out four times; now
+  once, with the reasoning attached.
+
+**`main.go`** — `--maptiler-key` flag; `config.LoadSettings()` now runs
+unconditionally (it was inside an `if` that only cared about the data pack path)
+so the saved key is read whether or not `--data-dir` was given.
+
+**`resources/mbtiles/style.json`, `data/mbtiles/style.json`** — `glyphs` is now
+the relative `/fonts/{fontstack}/{range}.pbf`, which is what the server rewrites
+it to anyway. A `kartoza:glyphs` note in the style's `metadata` block says why,
+and says not to put a key back — that file is copied into every data pack.
+
+**Deployment and docs** — `DT_MAPTILER_API_KEY` in `deployments/.env.example`
+and passed through `docker-compose.yaml` as an `environment:` entry (not a
+`command:` flag: the compose file is tracked, and a flag is visible in `ps`).
+Documented in `docs/developer-guide/server-deployment.md` (new variable section
+plus a troubleshooting entry for "the map has no labels"),
+`docs/advanced/install-the-application.md` (desktop, three ways),
+`docs/developer-guide/api.md` and `SPECIFICATION.md`. `frontend/.env.example`
+gained a comment saying the key must **not** go there, since every `VITE_`
+variable is compiled into the bundle.
+
+---
+
+## 4. The judgement call: what happens with no key
+
+**Chosen: start normally, disable glyph fetching, say so once.** Not "refuse to
+start", and definitely not "send `key=` with nothing after it".
+
+- Refusing to start would be wrong for what this application is. It is an
+  offline desktop tool for a data pack; place labels on the basemap are a
+  cosmetic layer over data that is entirely local. Making an optional font CDN
+  a startup requirement would mean an existing user who upgrades gets an
+  application that will not open.
+- Sending an empty key would be the worst option and is what the naive fix does.
+  MapTiler answers `403`, the proxy already swallows non-`200` into an empty
+  response, and the operator sees a map with no labels and no clue that a
+  setting is missing. `MapTilerGlyphURL` returning `(string, bool)` exists
+  specifically to make that unrepresentable.
+- The empty-`200` response is not new behaviour. It is exactly what the proxy
+  already did when the machine had no internet, and MapLibre handles it: it
+  treats it as "no glyphs in this range" and draws the map without those labels.
+  An error status would make it retry.
+
+The log line names all three places the key can be set:
+
+```
+Glyph proxy: no MapTiler key configured, so map labels will not be drawn.
+Set DT_MAPTILER_API_KEY, pass --maptiler-key, or add "maptiler_key" to
+settings.json. Everything else works without it.
+```
+
+Once per process, not per request — a single map pane asks for a dozen ranges
+and grid view multiplies that by four.
+
+---
+
+## 5. ⚠️ Overlapping work already on the remote: `origin/ticket_174`
+
+Found while searching history. **This needs a decision before either branch
+merges.** `origin/ticket_174` (commits `d7cd03d`, `ceee4ea`, both 2026-08-19)
+already removes the same literal from `server.go`, and goes further: it points
+the satellite basemap at MapTiler too, with a request quota
+(`internal/config/satellitequota.go`).
+
+| | this branch | `origin/ticket_174` |
+|---|---|---|
+| Env var | `DT_MAPTILER_API_KEY` (renamed to match theirs) | `DT_MAPTILER_API_KEY` |
+| Mechanism | `Config.MapTilerKey` field + `ResolveMapTilerKey` | package-level `config.MapTilerAPIKey()` reading `os.Getenv` at each call |
+| Other sources | flag, `settings.json` | none |
+| Scope of the key | glyphs only | glyphs **and** the satellite basemap style |
+| `style.json` files | key removed | not addressed (still committed there) |
+
+I named my variable `DT_MAPTILER_API_KEY` **to match theirs**, so whichever
+merges first the operator-facing name is the same and the documentation stays
+true. The Go APIs still conflict and `internal/server/server.go` will conflict
+textually. My preference, for what it is worth: keep the `Config` field (it is
+testable without touching the process environment, and it is the only shape that
+can serve the desktop build's `settings.json`) and port ticket_174's satellite
+work onto it. But this is the owner's call, and it is the one thing here I would
+not decide alone.
+
+---
+
+## 6. 🔴 Handover — what only the account holder can do
+
+### The one thing that matters
+
+**Revoke the key beginning `cc4Ppmm` in the MapTiler console** (Account → API keys)
+and issue a replacement. Removing it from the tree does not un-leak it: it is in
+the public git history, in every published binary and in every published data
+pack. Anyone can still use it, and it bills the Kartoza/Wits MapTiler account.
+
+Before revoking, check the account's usage graph. Anomalous traffic against this
+key is the evidence of whether it has been abused, and it disappears once the
+key is deleted.
+
+### Then set the new key in each place the application runs
+
+| How it runs | Where the key goes | Effect if not set |
+|---|---|---|
+| **Hosted deployment** (`deployments/docker-compose.yaml` + nginx) | `DT_MAPTILER_API_KEY=…` in `deployments/.env` — gitignored — then `docker compose up -d --force-recreate app`. Compose only reads `.env` when the container is created; `restart` is not enough. | Public dashboard maps draw with no place labels. Nothing else breaks. |
+| **Container, run directly** | `docker run -e DT_MAPTILER_API_KEY=… …` | as above |
+| **Desktop, launched from an icon** | `"maptiler_key": "…"` in `settings.json` — `~/.config/decision-theatre/` (Linux), `~/Library/Application Support/decision-theatre/` (macOS), `%APPDATA%\decision-theatre\` (Windows). Restart afterwards. | Labels missing for every desktop user. **This is the regression to weigh**: released builds had the key baked in, so desktop users who upgrade lose labels until they do this, and there is no UI for it (see below). |
+| **Desktop, from a terminal** | `DT_MAPTILER_API_KEY=… ./decision-theatre`, or `--maptiler-key …` | as above |
+| **Developer checkout** | either of the above | labels missing while developing; tests do not need a key |
+
+### Restrict the new key
+
+In the MapTiler console, restrict it to the deployment's own domains. The
+server proxies the font requests so the key is not exposed to browsers, but a
+restricted key limits the damage if it leaks again. Note that a domain
+restriction only helps for browser-originated requests — this server sends them
+itself, so confirm with MapTiler support that the restriction does not block the
+proxy's own traffic before relying on it. **I have not verified this.**
+
+### Do not
+
+- Rewrite git history to remove the key. Every clone and fork keeps it, every
+  commit hash downstream changes, and the key is disclosed either way. Revoke
+  instead.
+- Put the key in `frontend/.env`. `VITE_` variables are substituted into the
+  JavaScript bundle and would publish it again, to everyone, permanently.
+- Re-add it to either `style.json`. It is never used from there, and
+  `data/mbtiles/style.json` is copied into every data pack you distribute.
+
+### Also outstanding from the same commits
+
+`3ac8333` leaked `deployments/certs/tls.key` as well. `.gitleaksignore` records
+it as rotated. That claim predates me and I have not verified it.
+
+---
+
+## 7. What I would not vouch for
+
+- **Whether the key was abused.** Only the MapTiler usage graph can say, and I
+  cannot see it.
+- **Whether the domain restriction the old `.gitleaksignore` comment claimed
+  exists actually exists.** I have no console access. Treat the key as
+  unrestricted until someone checks.
+- **The desktop upgrade path.** There is no UI for entering the key — the
+  frontend was out of scope for this change — so a desktop user's only option is
+  to hand-edit `settings.json`. That is a poor experience and probably wants a
+  follow-up issue (a field in the settings panel, which is where the Kartoza
+  credit triplet already lives). What I would *not* do is inject the key at
+  build time via `-ldflags`: that puts it back in the binary, which is how it
+  leaked in the first place.
+- **Whether any other published artefact embeds the key.** I checked the tree,
+  the history, the data pack path and the release build path. I have not
+  inspected the actual published binaries or the contents of already-distributed
+  `.zip` packs, or any copy of the style hosted elsewhere (Google Drive is used
+  for data distribution — see `scripts/check-drive-updates.sh`).
+- **`origin/ticket_174`.** I read its diff for the key handling only. I have not
+  reviewed its satellite quota work, and I do not know its merge status or
+  intent.
+- **The frontend.** `frontend/src/` was another agent's territory. I confirmed by
+  grep that nothing there references MapTiler or a key — the components fetch
+  `/data/style.json` and nothing else — but I did not change or test any of it.

--- a/NOTES-refetch.md
+++ b/NOTES-refetch.md
@@ -1,0 +1,175 @@
+# Issue #60 — frontend re-render and refetch storms on map interaction
+
+Branch `perf/map-refetch-storms`.
+
+## What changed
+
+### `frontend/src/lib/sharedRequest.ts` (new)
+
+One primitive replacing the two hand-rolled promise caches in `MapView.tsx`. It
+does three things that have to be done together to be correct:
+
+- **Shares** one in-flight request per key, so N panes asking the same question
+  make one request. (The old caches already did this.)
+- **Cancels** a request via `AbortController` once nothing wants it, so the
+  connection is freed and the server can stop, rather than the response merely
+  being ignored. The backend does not honour cancellation yet — that is
+  `fix/db-context-cancellation` — so this gets better, it does not get worse.
+- **Counts subscribers**, so one caller losing interest never cancels a request
+  the other eleven panes are still waiting for. This is the part that makes the
+  first two safe to combine and the easiest to break by accident.
+
+There is a 50 ms grace period before the abort actually fires. `applyColors`
+supersedes its own previous run before it knows whether any parameter changed,
+so an immediate abort would cancel a request the very next tick wants back and
+cost a second round trip. 50 ms is nothing against a 4-second query.
+
+Rejections are never cached. The old `_choroplethCache` swallowed errors inside
+the cached promise and resolved to `null`, so a transient failure was cached as
+"no data" for the full 60-second TTL and the `promise.catch(...)` cleanup beside
+it was dead code. That is fixed as a side effect.
+
+### `frontend/src/hooks/useApi.ts`
+
+New `fetchAggregate(params, signal)` — the single deduplicated, cancellable
+entry point to `/api/aggregate`, 5-minute TTL. Three call sites used to issue
+that endpoint independently with no coordination at all.
+
+Caching by full query string is safe here specifically because
+`handleAggregateData` reads scenario, attributes, bbox and bound and nothing
+else — no site, no user state. The choropleth caches keep their existing and
+deliberate bypass when site ideal overrides are present, where the same URL
+means different things to different users; both are now commented so the next
+person does not "optimise" it away.
+
+### `frontend/src/components/MapView.tsx`
+
+- **Run tickets.** `applyColors` is invoked from sixteen places and is
+  asynchronous throughout, so two runs are routinely in flight together. Nothing
+  ordered them: whichever response landed last painted the map. Each run now
+  takes a monotonic ticket and checks it after every await and inside every
+  deferred `once('idle')` apply; only the newest ticket may publish statistics or
+  touch a layer. Superseding a run aborts its requests.
+- Abort controllers on the full-domain and site-scoped statistics effects, which
+  issue `valuesOnly` requests over the whole dataset and previously ran to
+  completion after the attribute they were for had changed.
+- `onMapExtentChange` no longer reports an extent identical to the last one it
+  reported. Every report lands in App state and re-renders the whole pane tree;
+  `moveend` fires for compare-map sync, resizes, style reloads and re-fits onto
+  the bounds already shown.
+
+### `frontend/src/components/ViewPane.tsx` and `ChartView.tsx`
+
+Both listed `mapExtent` — a fresh object on every map move — as an effect
+dependency regardless of range mode. In Full-domain mode the extent is never
+read, so every pan re-issued queries whose answers could not have changed. Both
+now depend on `aggregateExtentQuery`, a string that is empty unless the extent
+is genuinely part of the question, and both route through `fetchAggregate` with
+an abort on cleanup.
+
+ChartView's retry-with-backoff is preserved and now sits outside `fetchAggregate`
+(a rejected shared request is dropped from the cache, so each attempt is a
+genuinely fresh one). A cancellation is not retried.
+
+## What I measured, and how
+
+Request counts under a scripted interaction, run against the code before and
+after with everything else held fixed: six panes, mount plus five pans, jsdom
+with a counting `fetch`. Throwaway harnesses; the assertions that survive are in
+the test files listed below.
+
+| Scenario | Endpoint | Before | After |
+|---|---|---|---|
+| 6 dial panes, Full-domain range, mount + 5 pans | `/api/aggregate` | 72 | **2** |
+| 6 dial panes, Extent range, mount + 5 pans | `/api/aggregate` | 72 | **12** |
+| 6 chart panes, Full-domain range, mount + 5 pans | `/api/aggregate` | 216 | **6** |
+| 6 chart panes, Extent range, mount + 5 pans | `/api/aggregate` | 216 | **36** |
+| 6 map panes, mount + 5 pans | `/api/choropleth` | 12 | 12 (10 now aborted) |
+
+Against the 4.77 s per full-domain aggregate quoted in the issue, the chart-view
+row is roughly 1030 s of server work reduced to roughly 29 s for that
+interaction. I did not re-measure server-side timings myself; the per-request
+figures are the ones given to me.
+
+The choropleth row is the honest one: the count does not change, because the
+existing promise cache already deduplicated across panes. What changes there is
+that ten of the twelve are now genuinely cancelled instead of running to
+completion into a discarded result, and that responses can no longer be applied
+out of order. Those are the two things the map-side tests assert.
+
+Suite: **127 tests / 19 files before, 148 / 22 after, all passing**
+(`cd frontend && npx vitest run`). `npx tsc --noEmit` and `npm run lint`
+(`--max-warnings 0`) are both clean.
+
+### Tests, and that they fail without the change
+
+- `src/test/aggregateFanout.test.tsx` — 4 of its 5 fail against the original
+  `ViewPane.tsx` (verified by stashing it): fan-out, the two irrelevant-re-run
+  cases, and cancellation.
+- `src/test/mapRefetchStorms.test.tsx` — 3 of its 5 fail against the original
+  `MapView.tsx`: cancellation of a superseded request, the out-of-order case
+  (old viewport answers last and must not paint), and extent-report deduping.
+  The other two pass before and after; the pane fan-out one documents behaviour
+  the old cache already had, and is there so the rewrite cannot lose it.
+- `src/test/sharedRequest.test.ts` — the primitive itself, including the case
+  that matters most: one caller leaving must not cancel the request for the
+  others.
+
+`src/test/choroplethRenderPath.test.ts` asserts the render path by matching
+source, and one assertion had to change: the values fetch now carries a signal,
+so the call no longer ends immediately after the URL. The regex was tightened to
+require the signal rather than loosened to ignore it.
+
+## What I deliberately left alone
+
+- **The 300 ms `moveend` debounce.** It is doing its job; the storm was
+  downstream of it.
+- **The GeoJSON vs vector-tile decision** and everything about how layers are
+  painted. Not this issue.
+- **`lib/siteStore.ts` and `lib/storage.ts`** — another agent's territory, and
+  nothing here needed them.
+- **Backend cancellation.** Aborting is right regardless, and
+  `fix/db-context-cancellation` is the other half.
+- **`CHANGELOG.md` and the version bump**, as instructed, to avoid conflicting
+  with the other two branches at integration. The version bump for this is a
+  minor (`0.4.0` → `0.5.0`) if you want one — behaviour-preserving performance
+  work with new internal API.
+
+## Found along the way, outside this issue
+
+- **`ChartView.tsx` is outside the territory I was given.** I changed it anyway,
+  because it is where the largest measured cost lives (216 requests → 6) and the
+  brief called it out explicitly. The change is confined to the two aggregate
+  effects and their imports. Flagging it so you can check it against whatever
+  else is in flight.
+- **Failures were being cached as data.** Described above; a fixed side effect,
+  but it means a user who hit a transient 500 saw an empty map for a full minute
+  with no way to retry but to pan somewhere else and back.
+- **`applyColors` is called from sixteen places**, several of them in bursts
+  during mount. The ticket makes that harmless rather than expensive, but the
+  call graph is still worth untangling; it is not something to do under a
+  performance issue.
+- **`mapViewDeps.test.ts` exists because the repo has no working
+  `react-hooks/exhaustive-deps` enforcement.** `mapExtent`-shaped dependency bugs
+  are exactly what that rule catches, and this issue is the second instance. The
+  eslint config is there but the rule is evidently not biting; worth its own
+  issue.
+
+## What I would not vouch for
+
+- **The 50 ms abort grace is a judgement, not a measurement.** It is chosen to
+  survive a same-key re-subscribe across a microtask boundary. If a caller
+  re-subscribes across a *real* network round trip instead, the abort fires and
+  the next run pays for a fresh request — no worse than the old behaviour, but
+  not free either.
+- **The measurements are jsdom request counts, not a browser profile.** They
+  count what goes on the wire and are accurate for that. I did not run the real
+  application against a real datapack, so I have not watched a frame-time graph
+  or confirmed what any of this feels like to a user.
+- **The chart view's grouped series is not exercised by a test.** Standing it up
+  needs plotly plus grouping-metadata fixtures. Its measured numbers above come
+  from the summary series path; the grouped effect got the same treatment and I
+  am reasoning by symmetry that it behaves the same way.
+- **`superseded()` covers `applyColors`. It does not cover every asynchronous
+  path in `MapView.tsx`** — the boundary-layer and identify paths have their own
+  timing and I did not audit them.

--- a/NOTES-sitestore.md
+++ b/NOTES-sitestore.md
@@ -1,0 +1,159 @@
+# Notes — issue #70, site store save cost
+
+Branch `perf/site-store-off-main-thread`. Touches `frontend/src/lib/siteStore.ts`
+and `frontend/src/test/siteStore.test.ts` only.
+
+## What the state was
+
+The per-record split had already landed (commit `2dfe378`): sites live at
+`dt-site:{id}` with a `dt-site-index`, and the per-catchment breakdown is no
+longer persisted. That fixed the *write*.
+
+It did not fix the work around the write. The three bulk callers in
+`hooks/useApi.ts` — `createSite`, `updateSite`, `deleteSite` — still do
+load-everything, change one entry, hand the whole list back. Against per-site
+records that meant `loadSites` parsed all N records on the way in, and
+`saveSites` re-serialised all N on the way out and read all N back from storage
+to work out which one differed. Same O(store) main-thread cost as the old single
+blob, just spread over more keys.
+
+## What changed
+
+A module-level **record cache** in `siteStore.ts`: for each id, the object the
+module last handed out or wrote, and the exact string that object serialises to.
+
+- `readRecord` re-parses only when the stored string differs from the one it
+  already parsed, and returns the cached object rather than a fresh copy.
+- `saveSites` recognises an unchanged site by **reference identity** — it is the
+  very object the cache handed out — and skips serialising it entirely. A site
+  it does not recognise is serialised and compared against the string the cache
+  knows is on disk, so an unfamiliar-but-identical object still does not reach
+  storage.
+- The index is cached too, and rewritten only when membership or order actually
+  changed. It used to be rewritten on every bulk save.
+- The removed-records sweep in `saveSites` used `Array.includes` inside a loop
+  over the index; it is a `Set` now.
+- A `storage` event listener drops cached entries another tab replaced. Without
+  it a second tab would serve its own stale copy, and — worse — the identity
+  shortcut would decide a record needed no write when the other tab had already
+  replaced it.
+- `getSiteStoreStats` / `resetSiteStoreStats` count serialisations, parses,
+  record reads and writes, and index writes, so the tests can assert the *amount*
+  of work rather than the outcome.
+- `invalidateSiteCache(id?)` is the documented escape hatch.
+
+## Measured
+
+jsdom, this machine, one site edited out of a store of 200:
+
+| store | operation | before | after |
+| --- | --- | --- | --- |
+| 4,091,627 chars (78% of the 5,241,856 ceiling) | bulk save | 24.94 ms | 0.28 ms |
+| same | reload for the next save | 17.90 ms | 0.60 ms |
+| 806,903 chars, 40 sites | bulk save | 3.95 ms | 0.21 ms |
+
+The point is not the ratio, it is that the "after" column barely moves between
+807 k chars and 4.1 M: 0.21 ms → 0.28 ms. The cost is now proportional to the
+edit, not to the store. (The benchmark was a throwaway; it is not committed.)
+
+## Durability
+
+**No durability window was introduced.** Nothing is debounced, batched, deferred
+or queued. Writes are still synchronous `setItem` calls made during the save. If
+`saveSite`/`saveSites` returns true, the bytes are in localStorage; close the tab
+on the next tick and the work is there. Making saves *cheaper* was the fix;
+making them *later* would have traded the user's only copy for smoothness.
+
+Quota failures still surface, and the cache is built so it cannot hide one:
+
+- `writeRecord` sets the cache entry only when `safeSetItem` returned true, and
+  **deletes** it when it returned false. A failed write can therefore never leave
+  the module believing a site is stored, and the next attempt with the same
+  object really writes. There is a test for exactly this.
+- `writeIndex` nulls the index cache on failure.
+- `saveSites` still returns false if any record or the index failed, and the
+  callers in `useApi.ts` still turn that into "Browser storage is full".
+
+## Deliberately not done
+
+- **No IndexedDB.** That is issue #72.
+- **No Web Worker.** Web Storage is not exposed to workers, so the branch name is
+  aspirational: this reduces main-thread work rather than moving it off-thread.
+  Genuinely off-thread requires #72.
+- **No npm dependency.**
+- **No change to `hooks/useApi.ts` or `components/MapView.tsx`** — another agent's
+  territory this round. See "outside this issue" below for what I would do there.
+- **`storage.ts` unchanged.** `estimateStorageChars` is O(everything stored), but
+  it runs once at startup from `App.tsx` and measuring everything is the point of
+  it.
+- **Legacy migration retry semantics left alone.** I tried a once-per-session
+  flag and backed it out: `sessionSites.test.ts` writes `dt-sites` part-way
+  through a file and expects it picked up, and more generally an import or
+  restore path could legitimately write that key later. So every read and write
+  still probes `dt-sites`. After a successful migration that is a null lookup and
+  costs nothing.
+
+## Things I found that are outside this issue
+
+- **The bulk API is the real problem and it is in `useApi.ts`.** `createSite`,
+  `updateSite` and `deleteSite` all round-trip the entire list to change one
+  site, and `saveLocalSite`/`loadLocalSite` already exist. `updateSite` in
+  particular could be `loadSite(id)` → spread → `saveSite`, which needs no cache
+  at all to be O(1). The cache exists to make the *existing* shape cheap; the
+  shape itself is still wrong. Worth a follow-up issue.
+- `sortSitesByCreatedAtDesc(sites)` is called on every bulk save and sorts the
+  whole list. Cheap next to what it used to sit beside, less cheap now that
+  everything else is 0.3 ms.
+- A failed migration (quota exhausted with a legacy blob present) re-reads and
+  re-parses the whole blob on every single save until it succeeds. Documented in
+  the module. It only happens in a state where the user is already being told
+  storage is full, and each retry is a chance to rescue the blob, so I left it.
+
+## What I would not vouch for
+
+- **The immutability contract.** The identity shortcut in `saveSites` assumes no
+  caller mutates a site returned by the store in place. I grepped for in-place
+  property assignment on sites across `frontend/src` and found none — every
+  update is a spread, which is what React state requires anyway — and the
+  contract is documented at the top of the module. But it is a convention, not
+  something the type system enforces, and a future caller that mutates in place
+  and then calls `saveSites` would have its change silently dropped.
+  Two things limit the blast radius: `saveSite` (the single-site path every
+  interactive editor uses — `App.tsx`, `IndicatorEditorPage.tsx`, `MapView.tsx`)
+  **never** takes the shortcut and always writes; and `invalidateSiteCache` is
+  exported. If someone wants belt and braces, the next step would be a dev-mode
+  assertion that re-serialises and compares on the skip path — I left it out
+  because it would restore exactly the O(store) cost in development and make dev
+  unrepresentative of production.
+- **Same-tab external mutation of localStorage.** `storage` events only fire in
+  *other* tabs. If something in this tab writes `dt-site:*` or clears
+  localStorage without going through this module, the cache goes stale.
+  `clearSiteStore()` handles the test path; nothing else in the app does this
+  today.
+- **Serialisation stability.** The "unfamiliar but identical" comparison assumes
+  `JSON.stringify(normaliseForStorage(JSON.parse(raw))) === raw`. That holds
+  because `JSON.parse` and object spread both preserve source key order for
+  string keys, and site objects have string keys. It would not hold for
+  integer-like top-level keys. Not a case that occurs, but it is an assumption.
+- The benchmark numbers are jsdom, not a browser. The ratio and the flatness are
+  what matter; the absolute milliseconds will differ.
+
+## Tests
+
+`npx vitest run` in `frontend/`:
+
+- before: 19 files, 127 tests, all passing
+- after: 19 files, 143 tests, all passing
+
+`npx tsc --noEmit` and `npx eslint` clean.
+
+16 new tests in `src/test/siteStore.test.ts`, under `what a save actually costs`,
+`what a save touches, observed from outside`, and `the cache never outlives what
+it describes`. I checked they fail against the previous implementation: stubbing
+the new exports onto `HEAD`'s `siteStore.ts` and running the file gives 8
+failures, including the spy-based one that observes reads and writes from outside
+the module and so does not depend on the new counters.
+
+Note `frontend/node_modules` in this worktree is a symlink to the one in the main
+checkout, so the suite could be run without an install. Remove it before doing
+anything that writes to `node_modules`.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -446,6 +446,17 @@ Violet → Indigo → Blue → Cyan → Green → Yellow → Orange → Red
 ## Performance Considerations
 
 - GeoJSON caching with 300ms debounce
+- One shared, cancellable request per distinct question (`frontend/src/lib/sharedRequest.ts`):
+  every pane asking the same thing at the same moment produces one request, and a
+  request the user's next interaction has made pointless is aborted rather than
+  merely ignored. Applies to `/api/choropleth`, `/api/catchment-values` and
+  `/api/aggregate`. Requests carrying site ideal overrides are deliberately
+  excluded — the URL is not the whole of the question for those.
+- Choropleth responses are applied in request order: a run superseded by a later
+  one never paints, so an out-of-order completion cannot leave the map showing a
+  viewport, scenario or attribute the user has left
+- Aggregate fetches are scoped to the range mode, so panning does not re-request
+  full-domain values that cannot have changed
 - Viewport-limited choropleth queries (max 2000 features)
 - Pre-computed geojson column in GeoPackage
 - R-tree spatial index for fast bbox queries

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -264,7 +264,7 @@ Each pane supports three visualization modes, cycled via toolbar button:
 - `GET /data/tiles.json` - TileJSON metadata
 
 ### Fonts
-- `GET /fonts/{fontstack}/{range}.pbf` - Glyph proxy (fetched from CDN once, then served locally)
+- `GET /fonts/{fontstack}/{range}.pbf` - Glyph proxy (fetched from CDN once, then served locally). The MapTiler key is supplied at run time (`--maptiler-key`, `DT_MAPTILER_API_KEY`, or `maptiler_key` in `settings.json`) and attached here, server-side; it never reaches the client and no key is compiled in. With no key configured the route answers `200` with an empty body and the map draws without labels.
 
 ### Data
 - `GET /api/scenarios` - Available scenarios

--- a/data/mbtiles/style.json
+++ b/data/mbtiles/style.json
@@ -1,7 +1,10 @@
 {
   "version": 8,
   "name": "UoW Tiles",
-  "metadata": {"maputnik:renderer": "mbgljs"},
+  "metadata": {
+    "maputnik:renderer": "mbgljs",
+    "kartoza:glyphs": "Relative on purpose, and rewritten to an absolute URL by the server before this style reaches a browser. It points at the application's own /fonts proxy, which fetches from MapTiler using the key supplied at run time (DT_MAPTILER_API_KEY, --maptiler-key, or maptiler_key in settings.json). Do not put a key in this file: it is tracked in git and copied into every data pack. See issue #31."
+  },
   "center": [32.7, 4.65],
   "zoom": 2.75,
   "sources": {
@@ -11,7 +14,7 @@
     }
   },
   "sprite": "",
-  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=cc4PpmmWZP73LjU1nsw3",
+  "glyphs": "/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "Country Boundaries",

--- a/deployments/.env.example
+++ b/deployments/.env.example
@@ -10,3 +10,12 @@ DT_RESOURCES_DIR=../resources
 # Use a full certificate chain file if Wits/Sectigo provides one.
 TLS_CERT_FILE=./certs/tls.crt
 TLS_KEY_FILE=./certs/tls.key
+
+# MapTiler API key, used only to fetch the fonts the map labels are drawn with.
+# Leave it blank and everything works except those labels — the tiles and all of
+# the data come from this deployment's own files.
+#
+# Get a key from https://cloud.maptiler.com and restrict it to this deployment's
+# domain. Nothing here is committed: this file's real counterpart, .env, is
+# gitignored, and no key is compiled into the application.
+DT_MAPTILER_API_KEY=

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -25,6 +25,15 @@ services:
       - /app/data
       - --resources-dir
       - /app/resources
+    environment:
+      # MapTiler key for map font glyphs, read from deployments/.env, which is
+      # gitignored. Passed as an environment variable rather than appended to
+      # `command` above on purpose: this file is tracked, and a flag value is
+      # also visible in `ps` to every user on the host.
+      #
+      # Leave it unset and the deployment still works — the maps simply draw
+      # without place labels. See docs/developer-guide/server-deployment.md.
+      DT_MAPTILER_API_KEY: ${DT_MAPTILER_API_KEY:-}
     expose:
       - "8080"
       - "8081"

--- a/docs/advanced/install-the-application.md
+++ b/docs/advanced/install-the-application.md
@@ -97,10 +97,55 @@ A native window opens. To run without a window and use your browser instead:
 | `--data-dir` | *(auto)* | Where the map tiles, GeoPackage, metadata and lookups live |
 | `--port` | `8080` | HTTP port |
 | `--headless` | `false` | No desktop window |
+| `--maptiler-key` | *(none)* | Key for the fonts map labels are drawn with; see below |
 | `--version` | | Print the version and exit |
 
 With no `--data-dir`, the application looks for a previously installed data pack recorded
 in its settings file.
+
+### Map labels
+
+The place names on the map are drawn with fonts fetched from MapTiler, which
+needs an API key. Everything else — the tiles, the catchments, every number in
+the interface — comes from your data pack and works offline, so the application
+runs perfectly well without one. What you get without a key is a map with no
+labels on it, and one line in the log saying so.
+
+No key is shipped with the application. If you want labels, get one from
+[cloud.maptiler.com](https://cloud.maptiler.com) (the free tier is enough) and
+give it to the application in whichever of these suits how you start it:
+
+=== "Saved in settings"
+
+    The option for an installation you launch by clicking its icon. Add one line
+    to the settings file listed below, next to whatever is already in it:
+
+    ```json
+    {
+      "maptiler_key": "your-key-here"
+    }
+    ```
+
+    Restart the application afterwards; the file is read once at startup.
+
+=== "Environment variable"
+
+    ```bash
+    export DT_MAPTILER_API_KEY=your-key-here
+    ./decision-theatre
+    ```
+
+=== "Command line"
+
+    ```bash
+    ./decision-theatre --maptiler-key your-key-here
+    ```
+
+    Convenient for a one-off, but on a shared machine the key is visible to
+    anyone who can run `ps`.
+
+The most specific instruction wins: the flag overrides the environment variable,
+which overrides the settings file.
 
 !!! note "Where settings are kept"
     | Platform | Path |

--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -525,6 +525,19 @@ Returns TileJSON for the loaded tileset.
 Proxies MapLibre font glyphs, fetching from the upstream CDN once and serving locally
 thereafter. This avoids repeated external requests from each map instance in grid view.
 
+This is the only route that talks to MapTiler, and the only place the MapTiler
+key is used. It is attached server-side and never appears in `/data/style.json`,
+which is why the browser is handed this path rather than a MapTiler URL.
+
+When no key is configured the route still answers `200` with an empty body, and
+the server logs the reason once. That is the same answer it gives when the CDN
+is unreachable: MapLibre treats an empty response as "no glyphs in this range"
+and draws the map without those labels, whereas an error status makes it retry.
+No request is sent to MapTiler at all in that case — a URL with an empty `key=`
+would earn a `403` that looks exactly like a font that failed to load.
+
+See [`DT_MAPTILER_API_KEY`](server-deployment.md#dt_maptiler_api_key) for how to supply it.
+
 ## Static Data
 
 | Prefix | Serves from | Contents |

--- a/docs/developer-guide/server-deployment.md
+++ b/docs/developer-guide/server-deployment.md
@@ -221,6 +221,42 @@ TLS_KEY_FILE=/etc/ssl/private/decision-theatre.key
 
 ---
 
+### `DT_MAPTILER_API_KEY`
+
+**Optional, but the deployment looks wrong without it.** The MapTiler API key
+used to fetch the font glyphs that map labels are drawn with.
+
+Nothing else depends on it. The vector tiles, the catchment geometries and every
+number in the interface come from this deployment's own files; MapTiler supplies
+only the fonts. So a deployment with no key starts normally and works normally,
+and its maps are drawn without place labels.
+
+The application refuses to contact MapTiler at all when the key is missing,
+rather than sending a request with an empty key and receiving a 403 that would
+be indistinguishable from a font that failed to load. It says so once, on the
+first map the first visitor opens:
+
+```text
+Glyph proxy: no MapTiler key configured, so map labels will not be drawn.
+```
+
+Get a key from [cloud.maptiler.com](https://cloud.maptiler.com) and restrict it
+to this deployment's domains in the MapTiler console. The key travels to the
+browser in no form at all — the server proxies the font requests through
+`/fonts/{fontstack}/{range}.pbf` and attaches the key itself — but a restricted
+key is still the right default.
+
+```env
+DT_MAPTILER_API_KEY=your-key-here
+```
+
+!!! warning "Do not put it in `frontend/.env`"
+    A `VITE_`-prefixed variable is substituted into the JavaScript bundle at
+    build time, which publishes it to every visitor and bakes it into every
+    release artefact. This is a backend setting.
+
+---
+
 ## Example `.env` for Production
 
 ```env
@@ -235,6 +271,9 @@ DT_RESOURCES_DIR=/srv/decision-theatre/resources
 # TLS — full chain required for Wits/Sectigo certificates
 TLS_CERT_FILE=/etc/ssl/certs/decision-theatre-fullchain.pem
 TLS_KEY_FILE=/etc/ssl/private/decision-theatre.key
+
+# MapTiler key for map label fonts. Blank is supported; see above.
+DT_MAPTILER_API_KEY=your-key-here
 ```
 
 ---
@@ -610,6 +649,34 @@ Use a full chain certificate file. Combine the leaf certificate with any interme
 ```bash
 cat leaf.crt intermediate.crt root.crt > certs/tls.crt
 ```
+
+### The map draws, but has no place labels
+
+The MapTiler key is missing or wrong. Check the app log:
+
+```bash
+docker compose logs app | grep -i glyph
+```
+
+`no MapTiler key configured` means `DT_MAPTILER_API_KEY` never reached the
+container — set it in `deployments/.env` and recreate the app service, since
+compose only reads that file when the container is created:
+
+```bash
+docker compose up -d --force-recreate app
+```
+
+`upstream returned 403` means the key arrived but MapTiler rejected it. Either
+it has been revoked, or the domain restriction in the MapTiler console does not
+list the hostname this deployment is served on. Confirm what the container
+actually has:
+
+```bash
+docker compose exec app printenv DT_MAPTILER_API_KEY
+```
+
+`upstream fetch failed` means the container has no route to
+`api.maptiler.com` — an egress firewall rather than a key problem.
 
 ### Container fails to write to `/app/data`
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,9 @@
 # URL of the Google Form used to collect user feedback, linked from the
 # footer. Leave blank to hide the feedback link.
 VITE_FEEDBACK_FORM_URL=
+
+# The MapTiler key does NOT belong here. Every VITE_ variable is substituted
+# into the JavaScript bundle at build time, so putting a credential in this file
+# publishes it to every visitor and bakes it into every release. The server
+# holds that key and proxies the font requests itself; set DT_MAPTILER_API_KEY on
+# the backend instead. See docs/developer-guide/server-deployment.md.

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -20,8 +20,9 @@ function Plot(props: PlotProps) {
     </Suspense>
   );
 }
-import { getSiteCatchments, getSiteWhiskerBounds, useAttributeAxisLabels, useAttributeGroupingVariables, useAttributeVariableTypes, useColumns, useAttributeUnits, useAttributeXAxisLabels, useAttributeChartTypes } from '../hooks/useApi';
+import { fetchAggregate, getSiteCatchments, getSiteWhiskerBounds, useAttributeAxisLabels, useAttributeGroupingVariables, useAttributeVariableTypes, useColumns, useAttributeUnits, useAttributeXAxisLabels, useAttributeChartTypes } from '../hooks/useApi';
 import type { WhiskerBoundsResponse } from '../hooks/useApi';
+import { isAbortError } from '../lib/sharedRequest';
 import type { SiteIndicators, MapExtent, MapStatistics, RangeMode, Scenario, ZoneStats, CatchmentIndicators } from '../types';
 import { computeAOIWeightedScenarioValues } from '../utils/indicators';
 
@@ -537,6 +538,28 @@ function ChartView({
     return () => { cancelled = true; whiskerCancelled = true; };
   }, [siteIndicators, siteId, visible, rangeMode]);
 
+  /**
+   * The bbox these aggregates are scoped to, as a string, or '' when the range
+   * mode does not use one.
+   *
+   * Both effects below listed mapExtent, which is a new object on every map
+   * move. Each issues six /api/aggregate requests; a full-domain one measures
+   * around 4.8 seconds. In Full-domain mode the extent is never read, so every
+   * pan was firing six seconds-long queries per pane whose answers were
+   * identical to the ones already held. This is the single largest piece of
+   * wasted work on the interaction path.
+   */
+  const aggregateExtentQuery = useMemo(() => {
+    if (rangeMode !== 'extent' || !mapExtent?.bounds) return '';
+    const [minx, miny, maxx, maxy] = mapExtent.bounds;
+    return new URLSearchParams({
+      minx: String(minx),
+      miny: String(miny),
+      maxx: String(maxx),
+      maxy: String(maxy),
+    }).toString();
+  }, [rangeMode, mapExtent]);
+
   useEffect(() => {
     if (!visible || !chartGroup || !chartAxisLabelFilter) {
       setGroupedRangeData(null);
@@ -557,24 +580,31 @@ function ChartView({
       return;
     }
 
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setGroupedRangeData(null);
       setGroupedRangeLoading(false);
       return;
     }
 
     let cancelled = false;
+    const abort = new AbortController();
     setGroupedRangeLoading(true);
 
-    const fetchWithRetry = async (url: string): Promise<Response> => {
+    /**
+     * Retry kept from the original: these are long queries and a transient
+     * failure used to lose the whole chart. It sits outside fetchAggregate
+     * rather than inside it because a rejected shared request is dropped from
+     * the cache, so each attempt is a genuinely fresh one. A cancellation is
+     * not retried — nobody is waiting for the answer.
+     */
+    const aggregateWithRetry = async (params: URLSearchParams): Promise<Record<string, number>> => {
       const maxAttempts = 3;
       let lastErr: unknown;
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         try {
-          const resp = await fetch(url);
-          if (resp.ok) return resp;
-          lastErr = new Error(`HTTP ${resp.status}`);
+          return await fetchAggregate(params, abort.signal);
         } catch (err) {
+          if (isAbortError(err)) throw err;
           lastErr = err;
         }
         if (attempt < maxAttempts) {
@@ -595,24 +625,12 @@ function ChartView({
 
       const merged: Record<string, number> = {};
       for (const batch of batches) {
-        const params = new URLSearchParams({
-          scenario,
-          attributes: batch.join(','),
-        });
+        const params = new URLSearchParams(aggregateExtentQuery);
+        params.set('scenario', scenario);
+        params.set('attributes', batch.join(','));
         if (bound) params.set('bound', bound);
 
-        if (rangeMode === 'extent' && mapExtent?.bounds) {
-          const [minx, miny, maxx, maxy] = mapExtent.bounds;
-          params.set('minx', String(minx));
-          params.set('miny', String(miny));
-          params.set('maxx', String(maxx));
-          params.set('maxy', String(maxy));
-        }
-
-        const resp = await fetchWithRetry(`/api/aggregate?${params.toString()}`);
-
-        const payload = await resp.json() as Record<string, number>;
-        Object.assign(merged, payload);
+        Object.assign(merged, await aggregateWithRetry(params));
       }
 
       return merged;
@@ -642,8 +660,9 @@ function ChartView({
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
-  }, [visible, chartGroup, chartAxisLabelFilter, rangeMode, mapExtent, groupedDisplayColumns]);
+  }, [visible, chartGroup, chartAxisLabelFilter, rangeMode, aggregateExtentQuery, groupedDisplayColumns]);
 
   // Fetch aggregate ref/cur for the single selected attribute in extent/domain mode.
   // The grouped chart has its own equivalent (groupedRangeData); this covers the summary chart.
@@ -653,37 +672,32 @@ function ChartView({
       setSummaryRangeLoading(false);
       return;
     }
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setSummaryRangeData(null);
       setSummaryRangeLoading(false);
       return;
     }
 
     let cancelled = false;
+    const abort = new AbortController();
     setSummaryRangeLoading(true);
 
-    const fetchAggregate = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
-      const params = new URLSearchParams({ scenario, attributes: attribute });
+    const summaryAggregate = async (scenario: Scenario, bound?: 'lower' | 'upper'): Promise<Record<string, number>> => {
+      const params = new URLSearchParams(aggregateExtentQuery);
+      params.set('scenario', scenario);
+      params.set('attributes', attribute);
       if (bound) params.set('bound', bound);
-      if (rangeMode === 'extent' && mapExtent?.bounds) {
-        const [minx, miny, maxx, maxy] = mapExtent.bounds;
-        params.set('minx', String(minx));
-        params.set('miny', String(miny));
-        params.set('maxx', String(maxx));
-        params.set('maxy', String(maxy));
-      }
-      const resp = await fetch(`/api/aggregate?${params.toString()}`);
-      if (!resp.ok) return {};
-      return resp.json() as Promise<Record<string, number>>;
+      // An empty object on failure, as before — the chart draws what it has.
+      return fetchAggregate(params, abort.signal).catch(() => ({} as Record<string, number>));
     };
 
     Promise.all([
-      fetchAggregate('reference'),
-      fetchAggregate('current'),
-      fetchAggregate('reference', 'lower'),
-      fetchAggregate('reference', 'upper'),
-      fetchAggregate('current', 'lower'),
-      fetchAggregate('current', 'upper'),
+      summaryAggregate('reference'),
+      summaryAggregate('current'),
+      summaryAggregate('reference', 'lower'),
+      summaryAggregate('reference', 'upper'),
+      summaryAggregate('current', 'lower'),
+      summaryAggregate('current', 'upper'),
     ])
       .then(([reference, current, referenceLower, referenceUpper, currentLower, currentUpper]) => {
         if (cancelled) return;
@@ -696,8 +710,8 @@ function ChartView({
         setSummaryRangeLoading(false);
       });
 
-    return () => { cancelled = true; };
-  }, [visible, attribute, rangeMode, mapExtent]);
+    return () => { cancelled = true; abort.abort(); };
+  }, [visible, attribute, rangeMode, aggregateExtentQuery]);
 
   // Build summary chart data (existing behavior)
   const summaryData = useMemo(() => {

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -11,7 +11,7 @@ import { getSite, getSiteCatchments, getSiteAOIFractions, useAttributeColors, us
 import { getAppRuntime } from '../types/runtime';
 import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
-import { evictExpired } from '../lib/ttlCache';
+import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
 import { satelliteAttribution, satelliteTileUrl } from '../lib/satelliteBasemap';
 import {
   PRISM_STOPS,
@@ -587,7 +587,7 @@ export function formatNumber(n: number): string {
 // Module-level cache for pure (no site overrides) choropleth requests.
 // Multiple panes requesting the same scenario+attribute+bbox share one in-flight
 // fetch instead of firing N identical HTTP requests simultaneously.
-const _choroplethCache = new Map<string, { promise: Promise<ChoroplethData | null>; ts: number }>();
+const _choroplethCache: SharedCache<ChoroplethData> = new Map();
 const CHOROPLETH_CACHE_TTL_MS = 60_000;
 
 // Module-level caches for the two expensive synchronous intersection routines.
@@ -651,7 +651,7 @@ interface ChoroplethValues {
 // Companion to _choroplethCache for the values endpoint. Six panes x two
 // scenarios ask for the same viewport at the same moment; one fetch serves all
 // of them.
-const _choroplethValuesCache = new Map<string, { promise: Promise<ChoroplethValues | null>; ts: number }>();
+const _choroplethValuesCache: SharedCache<ChoroplethValues> = new Map();
 
 /**
  * Fetch the attribute values for the current viewport, for the vector-tile
@@ -668,6 +668,7 @@ async function fetchChoroplethValues(
   bounds: maplibregl.LngLatBounds,
   siteId?: string | null,
   idealOverrides?: Map<number, number>,
+  signal?: AbortSignal,
 ): Promise<ChoroplethValues | null> {
   const sw = bounds.getSouthWest();
   const ne = bounds.getNorthEast();
@@ -686,45 +687,49 @@ async function fetchChoroplethValues(
     params.set('siteId', siteId);
   }
 
+  // The same URL means different things once site ideal overrides are in play,
+  // so those requests are never shared or cached. This is deliberate; do not
+  // "optimise" it away without putting the overrides in the key.
   const canCache = !hasSiteOverride && (!idealOverrides || idealOverrides.size === 0);
   const key = params.toString();
-  const now = Date.now();
 
-  if (canCache) {
-    const hit = _choroplethValuesCache.get(key);
-    if (hit && now - hit.ts < CHOROPLETH_CACHE_TTL_MS) return hit.promise;
-    evictExpired(_choroplethValuesCache, CHOROPLETH_CACHE_TTL_MS, now);
-  }
+  const run = async (requestSignal?: AbortSignal): Promise<ChoroplethValues> => {
+    const resp = await fetch(`/api/catchment-values?${params}`, { signal: requestSignal });
+    if (!resp.ok) throw new Error(`catchment values request failed: HTTP ${resp.status}`);
+    return await resp.json() as ChoroplethValues;
+  };
 
-  const promise = (async (): Promise<ChoroplethValues | null> => {
-    try {
-      const resp = await fetch(`/api/catchment-values?${params}`);
-      if (!resp.ok) return null;
-      const data = await resp.json() as ChoroplethValues;
+  try {
+    const data = canCache
+      ? await sharedRequest(_choroplethValuesCache, key, CHOROPLETH_CACHE_TTL_MS, run, signal)
+      : await run(signal);
 
-      if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
-        for (let i = 0; i < data.ids.length; i++) {
-          const override = idealOverrides.get(data.ids[i]);
-          if (override !== undefined) data.values[i] = override;
-        }
+    if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
+      // Only reachable on the uncached path (overrides imply !canCache), which
+      // matters: this mutates the payload in place and a shared one has other
+      // readers.
+      for (let i = 0; i < data.ids.length; i++) {
+        const override = idealOverrides.get(data.ids[i]);
+        if (override !== undefined) data.values[i] = override;
       }
-
-      return data;
-    } catch (err) {
-      console.error('Failed to fetch catchment values:', err);
-      return null;
     }
-  })();
 
-  if (canCache) {
-    promise.catch(() => _choroplethValuesCache.delete(key));
-    _choroplethValuesCache.set(key, { promise, ts: now });
+    return data;
+  } catch (err) {
+    // A cancelled request is not a failure and must not be reported as "no
+    // data" — that would repaint the map as empty for a viewport the user has
+    // already left. Let the caller's staleness check deal with it.
+    if (isAbortError(err)) throw err;
+    console.error('Failed to fetch catchment values:', err);
+    return null;
   }
-  return promise;
 }
 
 /**
  * Fetch choropleth GeoJSON data for the current viewport.
+ *
+ * The expensive one: a full-domain request is seconds and megabytes, so a
+ * superseded one is cancelled rather than merely ignored.
  */
 async function fetchChoroplethData(
   scenario: Scenario,
@@ -733,7 +738,8 @@ async function fetchChoroplethData(
   zoom: number,
   siteId?: string | null,
   idealOverrides?: Map<number, number>,
-  valuesOnly = false
+  valuesOnly = false,
+  signal?: AbortSignal,
 ): Promise<ChoroplethData | null> {
   const sw = bounds.getSouthWest();
   const ne = bounds.getNorthEast();
@@ -760,42 +766,26 @@ async function fetchChoroplethData(
     params.set('siteId', siteId);
   }
 
-  // Deduplicate concurrent requests for pure (non-site-specific) fetches.
+  // Deduplicate concurrent requests for pure (non-site-specific) fetches. As
+  // above, a site override makes the URL an incomplete description of the
+  // question, so those are neither shared nor cached.
   const canCache = !hasSiteOverride && (!idealOverrides || idealOverrides.size === 0);
-  if (canCache) {
-    const key = params.toString();
-    const now = Date.now();
-    const hit = _choroplethCache.get(key);
-    if (hit && now - hit.ts < CHOROPLETH_CACHE_TTL_MS) return hit.promise;
+  const key = params.toString();
 
-    // Keys embed the viewport bbox, which changes on nearly every pan/zoom -
-    // sweep stale entries so this cache doesn't grow unbounded for the life
-    // of the tab (see evictExpired).
-    evictExpired(_choroplethCache, CHOROPLETH_CACHE_TTL_MS, now);
-
-    const promise = (async (): Promise<ChoroplethData | null> => {
-      try {
-        const resp = await fetch(`/api/choropleth?${params}`);
-        if (!resp.ok) return null;
-        return await resp.json() as ChoroplethData;
-      } catch (err) {
-        console.error('Failed to fetch choropleth data:', err);
-        return null;
-      }
-    })();
-
-    promise.catch(() => _choroplethCache.delete(key));
-    _choroplethCache.set(key, { promise, ts: now });
-    return promise;
-  }
+  const run = async (requestSignal?: AbortSignal): Promise<ChoroplethData> => {
+    const resp = await fetch(`/api/choropleth?${params}`, { signal: requestSignal });
+    if (!resp.ok) throw new Error(`choropleth request failed: HTTP ${resp.status}`);
+    return await resp.json() as ChoroplethData;
+  };
 
   try {
-    const resp = await fetch(`/api/choropleth?${params}`);
-    if (!resp.ok) return null;
-    const data: ChoroplethData = await resp.json();
+    const data = canCache
+      ? await sharedRequest(_choroplethCache, key, CHOROPLETH_CACHE_TTL_MS, run, signal)
+      : await run(signal);
 
     // In browser mode the backend store is never updated, so apply per-catchment
-    // ideal overrides client-side for the future scenario.
+    // ideal overrides client-side for the future scenario. Uncached path only,
+    // so the mutation below cannot be seen by another caller.
     if (scenario === 'future' && idealOverrides && idealOverrides.size > 0) {
       for (const feature of data.features) {
         if (feature.properties.HYBAS_ID === undefined) continue;
@@ -808,6 +798,7 @@ async function fetchChoroplethData(
 
     return data;
   } catch (err) {
+    if (isAbortError(err)) throw err;
     console.error('Failed to fetch choropleth data:', err);
     return null;
   }
@@ -921,6 +912,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   onIdentifyRef.current = onIdentify;
 
   // Store map extent change callback in ref
+  const lastExtentSignatureRef = useRef<string>('');
   const onMapExtentChangeRef = useRef(onMapExtentChange);
   onMapExtentChangeRef.current = onMapExtentChange;
 
@@ -1017,6 +1009,24 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Debounce timer for choropleth fetching
   const fetchTimerRef = useRef<number | null>(null);
 
+  /**
+   * Ordering and cancellation for the choropleth pipeline.
+   *
+   * applyColors is invoked from sixteen places and is asynchronous throughout,
+   * so two runs are routinely in flight together — a pan while the previous
+   * pan's values are still on the wire, an attribute change during a scenario
+   * change. Nothing previously ordered them, so whichever response happened to
+   * land last painted the map, and the map could settle showing the values of a
+   * viewport, scenario or attribute the user had already left. That is the bug
+   * worth fixing here; the wasted work is secondary.
+   *
+   * Every run takes a ticket. Only the holder of the newest ticket is allowed
+   * to publish statistics or touch a layer, and superseding a run aborts its
+   * requests so the connection is freed rather than merely ignored.
+   */
+  const applyColorsRunRef = useRef(0);
+  const applyColorsAbortRef = useRef<AbortController | null>(null);
+
   // Whether the served tileset carries catchment geometry, and from which zoom.
   // Null until resolved, and null for good on a datapack whose tiles predate
   // catchment tiling — in which case every zoom uses the GeoJSON path, exactly
@@ -1034,6 +1044,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // right-side call below either takes a nullable map or is guarded.
     if (!leftMap) return;
     if (!mapsReady.current.left || !mapsReady.current.right) return;
+
+    // Taken only once the run is certain to do something: an early bail on a
+    // map that is not there yet must not cancel a run that is.
+    applyColorsAbortRef.current?.abort();
+    const abort = new AbortController();
+    applyColorsAbortRef.current = abort;
+    const run = ++applyColorsRunRef.current;
+    /** True once a later run has taken over; nothing may be painted after that. */
+    const superseded = () => run !== applyColorsRunRef.current;
 
     if (!isChoroplethEnabledRef.current) {
       removeChoroplethLayers(leftMap, 'left');
@@ -1111,6 +1130,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (getAppRuntime() === 'browser' && siteId &&
         (c.leftScenario === 'future' || c.rightScenario === 'future')) {
       const catchments = await getSiteCatchments(siteId).catch(() => []);
+      if (superseded()) return;
       if (catchments.length > 0 && c.attribute) {
         browserIdealOverrides = new Map();
         for (const cat of catchments) {
@@ -1165,9 +1185,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (tileset && currentZoom >= tileset.minzoom) {
       try {
         const [leftValues, rightValues] = await Promise.all([
-          fetchChoroplethValues(c.leftScenario, c.attribute, bounds, siteId, browserIdealOverrides),
-          fetchChoroplethValues(c.rightScenario, c.attribute, bounds, siteId, browserIdealOverrides),
+          fetchChoroplethValues(c.leftScenario, c.attribute, bounds, siteId, browserIdealOverrides, abort.signal),
+          fetchChoroplethValues(c.rightScenario, c.attribute, bounds, siteId, browserIdealOverrides, abort.signal),
         ]);
+
+        // These answers describe the viewport, scenario and attribute captured
+        // when this run started. If a later run has begun, they describe the
+        // past — publishing them would leave the map and the statistics panel
+        // disagreeing with the controls.
+        if (superseded()) return;
 
         const { min, max } = resolveDomainRange([leftValues, rightValues]);
         publishStats(
@@ -1200,8 +1226,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             // cleared when what it means changes — scenario or attribute.
             stateKey: `${scenario}|${c.attribute}`,
           };
-          const apply = () => applyChoroplethLayer(
-            map, side, layerSource, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          const apply = () => {
+            // The deferred branch below can fire long after the map goes idle,
+            // by which time a later run may own the map.
+            if (superseded()) return;
+            applyChoroplethLayer(
+              map, side, layerSource, c.attribute, min, max, extruded, attributeColor, colorScaleType);
+          };
           if (map.loaded()) {
             apply();
           } else {
@@ -1212,7 +1243,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         applySide(leftMap, 'left', leftValues, c.leftScenario);
         applySide(rightMap, 'right', rightValues, c.rightScenario);
       } catch (err) {
-        console.error('Failed to apply choropleth:', err);
+        // A superseded run cancels its own requests; that is the design, not a
+        // failure to report.
+        if (!isAbortError(err)) console.error('Failed to apply choropleth:', err);
       }
       return;
     }
@@ -1220,9 +1253,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     try {
       // Fetch data for both scenarios in parallel
       const [leftData, rightData] = await Promise.all([
-        fetchChoroplethData(c.leftScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides),
-        fetchChoroplethData(c.rightScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides),
+        fetchChoroplethData(c.leftScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides, false, abort.signal),
+        fetchChoroplethData(c.rightScenario, c.attribute, bounds, currentZoom, siteId, browserIdealOverrides, false, abort.signal),
       ]);
+
+      if (superseded()) return;
 
       let siteCatchmentIds = siteId ? siteCatchmentIdsRef.current : null;
 
@@ -1303,6 +1338,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           leftMap.once('idle', () => {
+            if (superseded()) return;
             applyChoroplethLayer(leftMap, 'left', { kind: 'geojson', data: leftDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
@@ -1316,6 +1352,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
         } else {
           rightMap.once('idle', () => {
+            if (superseded()) return;
             applyChoroplethLayer(rightMap, 'right', { kind: 'geojson', data: rightDisplay }, c.attribute, min, max, extruded, attributeColor, colorScaleType);
           });
         }
@@ -1323,7 +1360,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         removeChoroplethLayers(rightMap, 'right');
       }
     } catch (err) {
-      console.error('Failed to apply choropleth:', err);
+      if (!isAbortError(err)) console.error('Failed to apply choropleth:', err);
     }
   // siteId belongs here: the body reads it in ten places — the choropleth fetch
   // for both panes, the browser-runtime ideal overrides, and three per-site
@@ -1388,6 +1425,10 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // Compute full-dataset stats so "Full" range has stable values.
   useEffect(() => {
     let cancelled = false;
+    // Full-domain valuesOnly requests are the biggest payload the client asks
+    // for. When the attribute or scenario changes, the previous pair is dead
+    // weight — cancel it rather than let it finish into a discarded result.
+    const abort = new AbortController();
     const c = comparisonRef.current;
 
     if (!c.attribute) {
@@ -1405,8 +1446,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         // sample/aggregate, so fetch every catchment's raw value regardless of
         // viewport zoom (zoom argument is ignored server-side in this mode).
         const [leftData, rightData] = await Promise.all([
-          fetchChoroplethData(c.leftScenario, c.attribute, fullBounds, 0, undefined, undefined, true),
-          fetchChoroplethData(c.rightScenario, c.attribute, fullBounds, 0, undefined, undefined, true),
+          fetchChoroplethData(c.leftScenario, c.attribute, fullBounds, 0, undefined, undefined, true, abort.signal),
+          fetchChoroplethData(c.rightScenario, c.attribute, fullBounds, 0, undefined, undefined, true, abort.signal),
         ]);
 
         if (cancelled) return;
@@ -1425,7 +1466,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
           });
         }
       } catch (err) {
-        if (!cancelled) {
+        if (!cancelled && !isAbortError(err)) {
           console.error('Failed to compute full zone statistics:', err);
         }
       }
@@ -1435,6 +1476,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [comparison.leftScenario, comparison.rightScenario, comparison.attribute]);
 
@@ -1564,6 +1606,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // not on global dataset extrema, once a site exists.
   useEffect(() => {
     let cancelled = false;
+    // Site-scoped valuesOnly requests are per-catchment over the site bbox and
+    // re-issued on every scenario, attribute, boundary and refresh change.
+    const abort = new AbortController();
 
     const updateSiteDomainRange = async () => {
       const c = comparisonRef.current;
@@ -1660,8 +1705,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         // the grid-aggregated render path can supply neither, so fetch true
         // per-catchment values regardless of viewport zoom.
         const [leftData, rightData, siteCatchments] = await Promise.all([
-          fetchChoroplethData(c.leftScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true),
-          fetchChoroplethData(c.rightScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true),
+          fetchChoroplethData(c.leftScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true, abort.signal),
+          fetchChoroplethData(c.rightScenario, c.attribute, siteBoundsLL, 0, siteId, siteIdealOverrides, true, abort.signal),
           getSiteAOIFractions(siteId).catch(() => []),
         ]);
 
@@ -1771,7 +1816,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         }
         applyColors();
       } catch (err) {
-        if (!cancelled) {
+        if (!cancelled && !isAbortError(err)) {
           console.error('Failed to compute site zone stats:', err);
           siteZoneStatsRef.current = null;
           siteCatchmentIdsRef.current = null;
@@ -1784,6 +1829,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [siteId, siteBounds, siteGeometry, comparison.leftScenario, comparison.rightScenario, comparison.attribute, applyColors, refreshKey]);
 
@@ -2991,11 +3037,18 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // Fetch new choropleth data when map moves (debounced)
     leftMap.on('moveend', () => {
       debouncedApplyColors();
-      // Report map extent changes
+      // Report map extent changes.
+      //
+      // This lands in App state, so every emission re-renders the whole pane
+      // tree and re-runs every effect that lists mapExtent — in quad view, six
+      // panes' worth of dial and chart aggregate fetches. moveend fires for
+      // plenty of things that leave the viewport exactly where it was
+      // (compare-map sync, a resize, a style reload, a re-fit onto the bounds
+      // already shown), so an unchanged extent is not reported at all.
       if (onMapExtentChangeRef.current) {
         const center = leftMap.getCenter();
         const bounds = leftMap.getBounds();
-        onMapExtentChangeRef.current({
+        const extent: MapExtent = {
           center: [center.lng, center.lat],
           zoom: leftMap.getZoom(),
           bounds: [
@@ -3004,7 +3057,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
             bounds.getEast(),
             bounds.getNorth(),
           ],
-        });
+        };
+        const signature = `${extent.center.join(',')}|${extent.zoom}|${extent.bounds?.join(',') ?? ''}`;
+        if (signature !== lastExtentSignatureRef.current) {
+          lastExtentSignatureRef.current = signature;
+          onMapExtentChangeRef.current(extent);
+        }
       }
     });
     leftMap.on('zoomend', () => debouncedApplyColors());
@@ -3250,6 +3308,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       if (fetchTimerRef.current) {
         clearTimeout(fetchTimerRef.current);
       }
+      // A pane closing (leaving quad view, switching a pane to a chart) must
+      // not leave its choropleth requests running for a map that no longer
+      // exists. Bumping the ticket too, so a response already on its way back
+      // cannot paint a removed layer.
+      applyColorsRunRef.current += 1;
+      applyColorsAbortRef.current?.abort();
+      applyColorsAbortRef.current = null;
       unregisterMap(syncId);
       slider.removeEventListener('pointerdown', onSliderPointerDown);
       slider.removeEventListener('pointermove', onSliderPointerMove);

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -13,7 +13,7 @@ import DialChart from './DialChart';
 import AggregateTable from './AggregateTable';
 import type { ComparisonState, LayoutMode, QuadColumns, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, ViewMode, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
-import { getSiteCatchments, useAttributeDetails, useAttributeDial0Middle, useAttributeUnits } from '../hooks/useApi';
+import { fetchAggregate, getSiteCatchments, useAttributeDetails, useAttributeDial0Middle, useAttributeUnits } from '../hooks/useApi';
 import type { FullDomainData } from '../hooks/useApi';
 import { COLUMN_FORMULAS, getTriggeredWorkflows } from '../constants/calculationFormulas';
 import { computeAOIWeightedAttributeValue } from '../utils/indicators';
@@ -226,6 +226,29 @@ function ViewPane({
     return () => { cancelled = true; };
   }, [comparison.attribute, siteId, viewMode]);
 
+  /**
+   * The bbox this pane's aggregates are scoped to, as a string, or '' when the
+   * range mode does not use one.
+   *
+   * mapExtent is a fresh object on every map move, and it was a dependency of
+   * the effect below regardless of range mode — so panning the map re-ran the
+   * aggregate fetch even in Full-domain mode, where the extent is not read at
+   * all and the answer cannot change. Six panes, two scenarios, a 4.8-second
+   * full-domain query each. Depending on a string that is only non-empty when
+   * the extent actually matters removes both the identity churn and the
+   * irrelevant re-runs.
+   */
+  const aggregateExtentQuery = useMemo(() => {
+    if (rangeMode !== 'extent' || !mapExtent?.bounds) return '';
+    const [minx, miny, maxx, maxy] = mapExtent.bounds;
+    return new URLSearchParams({
+      minx: String(minx),
+      miny: String(miny),
+      maxx: String(maxx),
+      maxy: String(maxy),
+    }).toString();
+  }, [rangeMode, mapExtent]);
+
   useEffect(() => {
     if (viewMode !== 'dial' || !comparison.attribute) {
       setDialRangeValues(null);
@@ -239,7 +262,7 @@ function ViewPane({
       return;
     }
 
-    if (rangeMode === 'extent' && !mapExtent?.bounds) {
+    if (rangeMode === 'extent' && !aggregateExtentQuery) {
       setDialRangeValues(null);
       setDialRangeLoading(false);
       return;
@@ -259,32 +282,29 @@ function ViewPane({
     }
 
     let cancelled = false;
+    // Cancels the requests, not just their effect: a pan supersedes the
+    // previous extent's aggregates immediately, and every pane is asking.
+    const abort = new AbortController();
     setDialRangeLoading(true);
 
-    const fetchAggregate = async (scenario: string): Promise<number | undefined> => {
-      const params = new URLSearchParams({
-        scenario,
-        attributes: comparison.attribute || '',
-      });
+    const attribute = comparison.attribute || '';
 
-      if (rangeMode === 'extent' && mapExtent?.bounds) {
-        const [minx, miny, maxx, maxy] = mapExtent.bounds;
-        params.set('minx', String(minx));
-        params.set('miny', String(miny));
-        params.set('maxx', String(maxx));
-        params.set('maxy', String(maxy));
-      }
+    const aggregateFor = async (scenario: string): Promise<number | undefined> => {
+      const params = new URLSearchParams(aggregateExtentQuery);
+      params.set('scenario', scenario);
+      params.set('attributes', attribute);
 
-      const resp = await fetch(`/api/aggregate?${params.toString()}`);
-      if (!resp.ok) return undefined;
-      const payload = await resp.json() as Record<string, number>;
-      const value = payload[comparison.attribute || ''];
+      // Shared with every other pane asking the same question, and with the
+      // chart view's summary series. A failure or a cancellation reads as "no
+      // value", exactly as the non-2xx case did before.
+      const payload = await fetchAggregate(params, abort.signal).catch(() => ({} as Record<string, number>));
+      const value = payload[attribute];
       return typeof value === 'number' && !isNaN(value) ? value : undefined;
     };
 
     Promise.all([
-      fetchAggregate(comparison.leftScenario),
-      fetchAggregate(comparison.rightScenario),
+      aggregateFor(comparison.leftScenario),
+      aggregateFor(comparison.rightScenario),
     ]).then(([referenceValue, currentValue]) => {
       if (cancelled) return;
       setDialRangeValues({ referenceValue, currentValue });
@@ -293,14 +313,14 @@ function ViewPane({
       if (!cancelled) { setDialRangeValues(null); setDialRangeLoading(false); }
     });
 
-    return () => { cancelled = true; };
+    return () => { cancelled = true; abort.abort(); };
   }, [
     viewMode,
     rangeMode,
     comparison.attribute,
     comparison.leftScenario,
     comparison.rightScenario,
-    mapExtent,
+    aggregateExtentQuery,
     fullDomainData,
   ]);
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -5,6 +5,7 @@ import { getAppRuntime } from '../types/runtime';
 import { WALKTHROUGH_SITE_IDS } from '../constants/walkthroughSites';
 import { applyAOIWeightedIndicators } from '../utils/indicators';
 import { evictExpired } from '../lib/ttlCache';
+import { sharedRequest, type SharedCache } from '../lib/sharedRequest';
 import { loadSite, loadSites, saveSite, saveSites } from '../lib/siteStore';
 
 const API_BASE = '/api';
@@ -1068,6 +1069,74 @@ export async function getSiteAOIFractions(siteId: string): Promise<{ id: string;
   evictExpired(_aOIFractionsCache, CACHE_TTL_MS, now);
   _aOIFractionsCache.set(siteId, { promise, ts: now });
   return promise;
+}
+
+/**
+ * `/api/aggregate` is the most expensive thing the client asks for — a
+ * full-domain aggregate for a single attribute measures around 4.8 seconds
+ * server-side — and it was the least coordinated. Three call sites issue it
+ * (the dial's range values, and the chart view's grouped and summary series,
+ * the latter two six requests at a time), once per pane, and every one of them
+ * re-ran whenever the map extent object changed identity, whether or not the
+ * range mode even used the extent.
+ *
+ * Routing all of them through one deduplicated, cancellable cache means twelve
+ * panes asking the same question in the same tick produce one request, and a
+ * pan cancels the answer nobody is waiting for any more.
+ *
+ * Caching by the full query string is safe here in a way it is not for the
+ * choropleth: the handler reads scenario, attributes, bbox and bound and
+ * nothing else — no site, no user state — so the URL really is the whole of
+ * the question. (Compare fetchChoroplethValues in MapView, which deliberately
+ * refuses to cache when site ideal overrides are in play, because there the
+ * same URL means different things to different users.)
+ *
+ * Five minutes, because the underlying GeoPackage does not change within a
+ * session; the ceiling is really "how long until the user notices a stale
+ * number", and nothing in this dataset can go stale.
+ */
+const AGGREGATE_CACHE_TTL_MS = 5 * 60_000;
+
+const _aggregateCache: SharedCache<Record<string, number>> = new Map();
+
+/** Test seam: the caches are module state and must not leak between tests. */
+export function __clearAggregateCache(): void {
+  _aggregateCache.clear();
+}
+
+/** Test seam: how many distinct aggregate requests are live. */
+export function __aggregateCacheSize(): number {
+  return _aggregateCache.size;
+}
+
+/**
+ * Fetch area-weighted aggregates, sharing one request per distinct question.
+ *
+ * Abort `signal` when the answer stops being wanted; the underlying request is
+ * only cancelled once no caller wants it. Rejects rather than returning an
+ * empty object on a non-2xx, so a transient failure is not cached as "no data"
+ * for the rest of the TTL window.
+ */
+export function fetchAggregate(
+  params: URLSearchParams,
+  signal?: AbortSignal,
+): Promise<Record<string, number>> {
+  // Sorted so that two call sites building the same question in a different
+  // order still share one request.
+  const key = new URLSearchParams(params);
+  key.sort();
+
+  return sharedRequest(
+    _aggregateCache,
+    key.toString(),
+    AGGREGATE_CACHE_TTL_MS,
+    async (requestSignal) => {
+      const resp = await fetch(`${API_BASE}/aggregate?${key.toString()}`, { signal: requestSignal });
+      if (!resp.ok) throw new Error(`aggregate request failed: HTTP ${resp.status}`);
+      return await resp.json() as Record<string, number>;
+    },
+    signal,
+  );
 }
 
 // FullDomainData holds precomputed area-weighted means for all attributes

--- a/frontend/src/lib/sharedRequest.ts
+++ b/frontend/src/lib/sharedRequest.ts
@@ -1,0 +1,171 @@
+/**
+ * One in-flight request per key, shared by every caller, cancelled once the last
+ * caller has walked away.
+ *
+ * Three separate problems on the map's interaction path, all of which the
+ * existing `Map<string, {promise, ts}>` caches solved only halfway:
+ *
+ *  1. **Fan-out.** Twelve panes ask for the same aggregate or the same viewport's
+ *     catchment values in the same tick. A promise cache collapses those to one
+ *     request — that part already worked.
+ *
+ *  2. **Supersession.** A pan makes the previous viewport's request pointless
+ *     before it lands. Ignoring the answer still leaves the connection and the
+ *     server working on it, so the caller passes an `AbortSignal` and the
+ *     request is really cancelled.
+ *
+ *  3. **The collision between the two.** A shared request has several owners, so
+ *     one owner losing interest must not cancel it for the rest. Subscribers are
+ *     counted, and the abort only fires when the count reaches zero.
+ *
+ * The grace period exists because callers routinely release and re-subscribe to
+ * the same key across an await — MapView's applyColors supersedes its own
+ * previous run before it knows whether the parameters changed. Aborting
+ * immediately would cancel a request the very next tick wants back. Waiting a
+ * few milliseconds costs nothing against a 4-second query and makes the common
+ * "recompute with identical parameters" path free.
+ */
+
+const DEFAULT_ABORT_GRACE_MS = 50;
+
+export interface SharedEntry<T> {
+  promise: Promise<T>;
+  /** Start time, for TTL eviction — see evictExpired. */
+  ts: number;
+  controller: AbortController;
+  subscribers: number;
+  settled: boolean;
+  abortTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export type SharedCache<T> = Map<string, SharedEntry<T>>;
+
+/** True for the rejection an aborted fetch produces, in either shape. */
+export function isAbortError(err: unknown): boolean {
+  if (err instanceof DOMException) return err.name === 'AbortError';
+  return typeof err === 'object' && err !== null && (err as { name?: string }).name === 'AbortError';
+}
+
+function abortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+function subscribe<T>(entry: SharedEntry<T>): void {
+  entry.subscribers += 1;
+  if (entry.abortTimer !== null) {
+    clearTimeout(entry.abortTimer);
+    entry.abortTimer = null;
+  }
+}
+
+function release<T>(cache: SharedCache<T>, key: string, entry: SharedEntry<T>, graceMs: number): void {
+  entry.subscribers -= 1;
+  if (entry.subscribers > 0 || entry.settled || entry.abortTimer !== null) return;
+
+  entry.abortTimer = setTimeout(() => {
+    entry.abortTimer = null;
+    // Someone re-subscribed, or the answer arrived, during the grace period.
+    if (entry.subscribers > 0 || entry.settled) return;
+    entry.controller.abort();
+    if (cache.get(key) === entry) cache.delete(key);
+  }, graceMs);
+}
+
+/**
+ * Reject as soon as this caller's own signal aborts, without disturbing the
+ * shared request that other callers may still be waiting on.
+ */
+function rejectOnAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    const done = () => signal.removeEventListener('abort', onAbort);
+    promise.then(
+      (value) => { done(); resolve(value); },
+      (err) => { done(); reject(err); },
+    );
+  });
+}
+
+/**
+ * Run `work` for `key`, or join the run already under way for it.
+ *
+ * `work` receives the shared `AbortSignal`; pass it to fetch. `signal` is the
+ * caller's own — abort it when this caller's result stops being wanted.
+ *
+ * Rejections are never cached: a failed request must not poison the key for the
+ * rest of the TTL window.
+ */
+export function sharedRequest<T>(
+  cache: SharedCache<T>,
+  key: string,
+  ttlMs: number,
+  work: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+  abortGraceMs: number = DEFAULT_ABORT_GRACE_MS,
+): Promise<T> {
+  if (signal?.aborted) return Promise.reject(abortError());
+
+  const now = Date.now();
+  let entry = cache.get(key);
+
+  // A settled entry is only reusable inside its TTL. An unsettled one is always
+  // reusable — that is the fan-out case, and a slow request should gather
+  // callers rather than spawn duplicates of itself.
+  if (entry && entry.settled && now - entry.ts >= ttlMs) {
+    cache.delete(key);
+    entry = undefined;
+  }
+
+  if (!entry) {
+    // Sweep before inserting: keys embed viewport bounds, so a session of
+    // panning would otherwise grow this map without bound.
+    for (const [otherKey, other] of cache) {
+      if (other.settled && now - other.ts >= ttlMs) cache.delete(otherKey);
+    }
+
+    const controller = new AbortController();
+    const created: SharedEntry<T> = {
+      promise: undefined as unknown as Promise<T>,
+      ts: now,
+      controller,
+      subscribers: 0,
+      settled: false,
+      abortTimer: null,
+    };
+    created.promise = work(controller.signal).then(
+      (value) => {
+        created.settled = true;
+        return value;
+      },
+      (err) => {
+        created.settled = true;
+        if (cache.get(key) === created) cache.delete(key);
+        throw err;
+      },
+    );
+    // Nobody may be awaiting the shared promise directly (every caller awaits
+    // its own rejectOnAbort wrapper), so keep it from counting as unhandled.
+    created.promise.catch(() => undefined);
+    cache.set(key, created);
+    entry = created;
+  }
+
+  if (!signal) {
+    // A caller with no signal never leaves, so the request can never be
+    // abandoned out from under it.
+    subscribe(entry);
+    return entry.promise;
+  }
+
+  const joined = entry;
+  subscribe(joined);
+  const onAbort = () => release(cache, key, joined, abortGraceMs);
+  signal.addEventListener('abort', onAbort, { once: true });
+  joined.promise.then(
+    () => signal.removeEventListener('abort', onAbort),
+    () => signal.removeEventListener('abort', onAbort),
+  );
+
+  return rejectOnAbort(joined.promise, signal);
+}

--- a/frontend/src/lib/siteStore.ts
+++ b/frontend/src/lib/siteStore.ts
@@ -24,6 +24,64 @@ import { safeSetItem, safeRemoveItem } from './storage';
  * costs the size of that record rather than the size of the store. Sites are
  * normalised on the way in: the breakdown is dropped, and so is the duplicated
  * id list if an old document still carries it.
+ *
+ * ## Why one key per site was not enough on its own
+ *
+ * Splitting the keys fixed the *write*, not the work around it. The three bulk
+ * callers in hooks/useApi.ts — create, update, delete a site — still do
+ * load-everything, change one entry, write-everything-back, because that is the
+ * shape the API has always had. Against per-site records that became: parse all
+ * N records on the way in, then re-serialise all N on the way out to work out
+ * which one differed. Same O(store) main-thread cost as the blob, spread over
+ * more keys.
+ *
+ * So this module keeps a **record cache**: for each id, the object it last
+ * handed out or wrote, and the exact string that object serialises to. That
+ * buys two things.
+ *
+ *   - A read whose stored string is unchanged returns the cached object without
+ *     parsing.
+ *   - A bulk write can recognise an unchanged site by **reference identity** —
+ *     it is the very object the cache handed out — and skip serialising it
+ *     entirely. One changed site out of N costs one `JSON.stringify`, not N.
+ *
+ * ## The contract that makes that sound
+ *
+ * **Sites handed out by this module are values. Do not mutate one in place.**
+ * Change a site by building a new object (`{ ...site, title }`), which is what
+ * React state requires anyway and what every caller in this codebase already
+ * does. A site mutated in place is indistinguishable, cheaply, from one that
+ * was not, and the bulk path would skip writing it.
+ *
+ * Two things keep that from being a trap:
+ *
+ *   - `saveSite` — the explicit single-site write, and the one every interactive
+ *     editor uses — **never** takes the identity shortcut. If a caller says a
+ *     site changed, it is written. The shortcut applies only to `saveSites`,
+ *     whose whole job is to work out which of a list changed.
+ *   - `invalidateSiteCache` is exported for anything that needs to opt out.
+ *
+ * ## What is not deferred
+ *
+ * Writes are still synchronous and still happen on the call. Nothing is
+ * debounced, batched or queued, so there is **no window in which an accepted
+ * save has not reached disk** — close the tab immediately after a save returns
+ * true and the work is there. Making saves cheaper was the fix; making them
+ * later would have traded the user's only copy of their work for smoothness.
+ *
+ * Moving the work off the main thread proper is not possible here: Web Storage
+ * is not exposed to workers. Storing in IndexedDB, which is, is issue #72.
+ *
+ * ## One cost left, on purpose
+ *
+ * Every read and write still probes the legacy `dt-sites` key first. Once it has
+ * been migrated the key is gone and the probe is a null lookup, so it costs
+ * nothing worth caching — and not caching it means a `dt-sites` written later,
+ * by an import or a restore, is still picked up. In the one state where the
+ * probe is expensive, a migration that failed because storage was full, the blob
+ * is re-read and re-parsed on every save; that is deliberate, because in that
+ * state the blob is still the user's only copy and every attempt is a chance to
+ * rescue it.
  */
 
 const INDEX_KEY = 'dt-site-index';
@@ -45,6 +103,107 @@ function recordKey(id: string): string {
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && !!window.localStorage;
+}
+
+/**
+ * How much work the store has done, in the units that actually cost something.
+ *
+ * Exists because "a save is proportional to what changed" is only a claim until
+ * it is counted. The tests assert on these: saving one site out of fifty must
+ * serialise one site, not fifty.
+ */
+export interface SiteStoreStats {
+  /** Sites put through `JSON.stringify`. */
+  serialised: number;
+  /** Records put through `JSON.parse`. */
+  parsed: number;
+  /** `getItem` calls for site records. */
+  recordReads: number;
+  /** `setItem` calls for site records. */
+  recordWrites: number;
+  /** `setItem` calls for the index. */
+  indexWrites: number;
+}
+
+const stats: SiteStoreStats = {
+  serialised: 0,
+  parsed: 0,
+  recordReads: 0,
+  recordWrites: 0,
+  indexWrites: 0,
+};
+
+export function getSiteStoreStats(): SiteStoreStats {
+  return { ...stats };
+}
+
+export function resetSiteStoreStats(): void {
+  stats.serialised = 0;
+  stats.parsed = 0;
+  stats.recordReads = 0;
+  stats.recordWrites = 0;
+  stats.indexWrites = 0;
+}
+
+/**
+ * One entry per known record: the object callers hold, and the string that is
+ * in storage for it.
+ *
+ * `raw` is only ever set from a read that succeeded or a write that succeeded,
+ * so it is what is on disk, never what we hoped was.
+ */
+interface CachedRecord {
+  site: Site;
+  raw: string;
+}
+
+const recordCache = new Map<string, CachedRecord>();
+
+/** The index, when it is known to match storage. Null means "go and read it". */
+let indexCache: string[] | null = null;
+
+function forgetEverything(): void {
+  recordCache.clear();
+  indexCache = null;
+}
+
+/**
+ * Drop cached knowledge of a record, or of all of them.
+ *
+ * The escape hatch for the immutability contract above: anything that has
+ * changed a site in place, or changed storage behind this module's back, calls
+ * this and the next read or write goes to storage.
+ */
+export function invalidateSiteCache(id?: string): void {
+  if (id === undefined) {
+    forgetEverything();
+    return;
+  }
+  recordCache.delete(id);
+}
+
+/**
+ * Another tab wrote to our storage, so what we have cached may be stale.
+ *
+ * `storage` events fire in every tab *except* the one that wrote, which is
+ * exactly the set of tabs whose caches are now wrong. Without this, two tabs
+ * open on the same sites would each keep serving their own stale copy — and
+ * worse, the identity shortcut in `saveSites` would decide a record needed no
+ * write when the other tab had already replaced it.
+ */
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('storage', (event: StorageEvent) => {
+    // A null key means the whole area was cleared.
+    if (event.key === null) {
+      forgetEverything();
+      return;
+    }
+    if (event.key === INDEX_KEY) {
+      indexCache = null;
+    } else if (event.key.startsWith(RECORD_PREFIX)) {
+      recordCache.delete(event.key.slice(RECORD_PREFIX.length));
+    }
+  });
 }
 
 /**
@@ -73,29 +232,109 @@ export function normaliseForStorage(site: Site): Site {
   return copy as unknown as Site;
 }
 
+/** The one place a site becomes a string, so the cost has somewhere to be counted. */
+function serialise(site: Site): string {
+  stats.serialised++;
+  return JSON.stringify(normaliseForStorage(site));
+}
+
+function getRecordRaw(id: string): string | null {
+  if (!isBrowser()) return null;
+  try {
+    stats.recordReads++;
+    return window.localStorage.getItem(recordKey(id));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a record and remember it.
+ *
+ * The cache entry is set only when the write succeeded, and cleared when it did
+ * not — so a quota failure can never leave this module believing a site is
+ * stored when it is not. That is the whole point of `safeSetItem` returning a
+ * boolean, and losing it here would recreate the silent-loss bug one level up.
+ */
+function writeRecord(site: Site, raw: string): boolean {
+  stats.recordWrites++;
+  if (!safeSetItem(recordKey(site.id), raw)) {
+    recordCache.delete(site.id);
+    return false;
+  }
+  recordCache.set(site.id, { site, raw });
+  return true;
+}
+
 function readIndex(): string[] {
   if (!isBrowser()) return [];
+  if (indexCache) return indexCache;
   try {
     const raw = window.localStorage.getItem(INDEX_KEY);
-    if (!raw) return [];
+    if (!raw) {
+      indexCache = [];
+      return indexCache;
+    }
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+    indexCache = Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : [];
+    return indexCache;
   } catch {
     return [];
   }
 }
 
-function writeIndex(ids: string[]): boolean {
-  return safeSetItem(INDEX_KEY, JSON.stringify(ids));
+function sameIds(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
+/**
+ * Write the index, unless it already says this.
+ *
+ * The bulk path used to rewrite the index on every save even when membership
+ * and order were unchanged, which is most saves.
+ */
+function writeIndex(ids: string[]): boolean {
+  if (indexCache && sameIds(indexCache, ids)) return true;
+  stats.indexWrites++;
+  if (!safeSetItem(INDEX_KEY, JSON.stringify(ids))) {
+    indexCache = null;
+    return false;
+  }
+  indexCache = ids.slice();
+  return true;
+}
+
+/**
+ * Read one record, parsing only when the stored string is not the one already
+ * parsed.
+ *
+ * Returns the cached object itself, not a copy — see the immutability contract
+ * at the top of this file. Handing out a stable reference is what lets a later
+ * `saveSites` recognise an untouched site for free.
+ */
 function readRecord(id: string): Site | null {
   if (!isBrowser()) return null;
+
+  const raw = getRecordRaw(id);
+  if (!raw) {
+    recordCache.delete(id);
+    return null;
+  }
+
+  const cached = recordCache.get(id);
+  if (cached && cached.raw === raw) return cached.site;
+
   try {
-    const raw = window.localStorage.getItem(recordKey(id));
-    if (!raw) return null;
+    stats.parsed++;
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as Site) : null;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const site = parsed as Site;
+    recordCache.set(id, { site, raw });
+    return site;
   } catch {
     return null;
   }
@@ -134,9 +373,9 @@ export function migrateLegacyStore(): Site[] | null {
   const sites = (parsed as Site[]).filter((s) => s && typeof s.id === 'string');
 
   for (const site of sites) {
-    if (!safeSetItem(recordKey(site.id), JSON.stringify(normaliseForStorage(site)))) {
-      return sites;
-    }
+    // Deliberately not retried on failure: the blob below is still the user's
+    // copy, and a reload will try again once there is room.
+    if (!writeRecord(site, serialise(site))) return sites;
   }
   if (!writeIndex(sites.map((s) => s.id))) return sites;
 
@@ -168,6 +407,10 @@ export function loadSite(id: string): Site | null {
 
 /**
  * Write one site. Touches one record, and the index only when the site is new.
+ *
+ * Always writes, even if the site looks unchanged: a caller reaching for this
+ * function is asserting that it changed, and second-guessing that is how work
+ * gets lost. Costs one serialisation regardless of how much is stored.
  */
 export function saveSite(site: Site): boolean {
   if (!isBrowser()) return true;
@@ -175,9 +418,7 @@ export function saveSite(site: Site): boolean {
 
   migrateLegacyStore();
 
-  if (!safeSetItem(recordKey(site.id), JSON.stringify(normaliseForStorage(site)))) {
-    return false;
-  }
+  if (!writeRecord(site, serialise(site))) return false;
 
   const ids = readIndex();
   if (!ids.includes(site.id)) {
@@ -188,11 +429,14 @@ export function saveSite(site: Site): boolean {
 
 /**
  * Write a whole list, as the old whole-store save did — but only the records
- * that actually changed.
+ * that actually changed, and only serialising the ones that might have.
  *
- * Callers overwhelmingly pass the full list back with one site modified. The
- * comparison is against the serialised record, so an unchanged site costs a
- * read and a string compare rather than a write to disk.
+ * Callers overwhelmingly pass the full list back with one site modified, having
+ * got the list from `loadSites`. Every site they did not touch is still the
+ * object this module handed them, so it is recognised by reference and costs
+ * nothing at all. A site that is not recognised is serialised and compared
+ * against what is stored, so an unfamiliar object that happens to be identical
+ * still does not reach disk.
  */
 export function saveSites(sites: Site[]): boolean {
   if (!isBrowser()) return true;
@@ -201,27 +445,37 @@ export function saveSites(sites: Site[]): boolean {
 
   let ok = true;
   const ids: string[] = [];
+  const kept = new Set<string>();
 
   for (const site of sites) {
     if (!site || typeof site.id !== 'string') continue;
     ids.push(site.id);
+    kept.add(site.id);
 
-    const next = JSON.stringify(normaliseForStorage(site));
-    let current: string | null = null;
-    try {
-      current = window.localStorage.getItem(recordKey(site.id));
-    } catch {
-      current = null;
+    // The object we handed out, unchanged. Nothing to serialise, nothing to
+    // write. This is the case that makes a save proportional to the edit.
+    const cached = recordCache.get(site.id);
+    if (cached && cached.site === site) continue;
+
+    const next = serialise(site);
+    // Prefer what the cache knows is on disk over re-reading it; getItem copies
+    // the whole record string, which for a continent-scale site is ~2 M chars.
+    const current = cached ? cached.raw : getRecordRaw(site.id);
+    if (current === next) {
+      recordCache.set(site.id, { site, raw: next });
+      continue;
     }
-    if (current === next) continue;
 
-    if (!safeSetItem(recordKey(site.id), next)) ok = false;
+    if (!writeRecord(site, next)) ok = false;
   }
 
   // Records dropped from the list are deleted, so the store cannot accumulate
   // sites the caller believes it removed.
   for (const id of readIndex()) {
-    if (!ids.includes(id)) safeRemoveItem(recordKey(id));
+    if (!kept.has(id)) {
+      safeRemoveItem(recordKey(id));
+      recordCache.delete(id);
+    }
   }
 
   if (!writeIndex(ids)) ok = false;
@@ -232,14 +486,19 @@ export function deleteSite(id: string): boolean {
   if (!isBrowser()) return true;
   migrateLegacyStore();
   const removed = safeRemoveItem(recordKey(id));
+  recordCache.delete(id);
   const ids = readIndex().filter((entry) => entry !== id);
   return writeIndex(ids) && removed;
 }
 
 /** Test seam: forget everything this module owns. */
 export function clearSiteStore(): void {
-  if (!isBrowser()) return;
+  if (!isBrowser()) {
+    forgetEverything();
+    return;
+  }
   for (const id of readIndex()) safeRemoveItem(recordKey(id));
   safeRemoveItem(INDEX_KEY);
   safeRemoveItem(LEGACY_KEY);
+  forgetEverything();
 }

--- a/frontend/src/test/aggregateFanout.test.tsx
+++ b/frontend/src/test/aggregateFanout.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * /api/aggregate fan-out on map interaction (issue #60).
+ *
+ * The most expensive request the client makes — a full-domain aggregate for a
+ * single attribute measures around 4.8 seconds server-side — and the least
+ * coordinated. Every pane issued its own, none were shared, none were
+ * cancelled, and the effects that issued them listed the map extent object as a
+ * dependency whether or not the range mode used it. So a pan re-asked, per
+ * pane, a question whose answer could not have changed.
+ *
+ * The panes are real ViewPanes; MapView, ChartView and DialChart are stubbed
+ * (WebGL and plotly do not run in jsdom), which leaves the dial's range fetch —
+ * the same effect shape the chart view uses six at a time.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState, MapExtent } from '../types';
+
+vi.mock('../components/MapView', () => ({ default: () => <div data-testid="map-view" /> }));
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+interface Call {
+  url: string;
+  signal?: AbortSignal;
+  settle: () => void;
+}
+
+let calls: Call[] = [];
+
+const aggregateCalls = () => calls.filter((c) => c.url.startsWith('/api/aggregate?'));
+
+beforeEach(() => {
+  // The aggregate cache is module state; every test here asks the same
+  // question, so each needs a fresh one.
+  vi.resetModules();
+  calls = [];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    return new Promise<Response>((resolve, reject) => {
+      const body = JSON.stringify({ water_yield: 42 });
+      const call: Call = {
+        url,
+        signal: init?.signal ?? undefined,
+        settle: () => resolve(new Response(body, { headers: { 'content-type': 'application/json' } })),
+      };
+      calls.push(call);
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }, { once: true });
+      if (!url.startsWith('/api/aggregate?')) call.settle();
+    });
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'reference',
+  rightScenario: 'current',
+  attribute: 'water_yield',
+};
+
+const extentAt = (minx: number): MapExtent => ({
+  center: [minx + 0.5, 0],
+  zoom: 6,
+  bounds: [minx, 0, minx + 1, 1],
+});
+
+async function renderPanes(count: number, props: Record<string, unknown>) {
+  const ViewPane = (await import('../components/ViewPane')).default;
+
+  const tree = (overrides: Record<string, unknown>) => (
+    <ChakraProvider theme={theme}>
+      {Array.from({ length: count }, (_, i) => (
+        <ViewPane
+          key={i}
+          comparison={comparison}
+          paneIndex={i}
+          layoutMode="quad"
+          viewMode="dial"
+          onViewModeChange={() => {}}
+          onFocusPane={() => {}}
+          onGoQuad={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          {...props}
+          {...overrides}
+        />
+      ))}
+    </ChakraProvider>
+  );
+
+  const utils = await act(async () => render(tree({})));
+  return { ...utils, tree };
+}
+
+describe('aggregate requests across panes', () => {
+  it('asks once for a question every pane is asking', async () => {
+    await renderPanes(6, { rangeMode: 'extent', mapExtent: extentAt(0) });
+
+    const urls = aggregateCalls().map((c) => c.url);
+    // Two scenarios over one extent: two questions, however many panes want
+    // the answer. Six panes previously meant twelve requests.
+    expect(new Set(urls).size).toBe(2);
+    expect(urls).toHaveLength(2);
+  });
+
+  it('does not re-ask when the extent changes but the range mode ignores it', async () => {
+    // Full-domain mode. The extent is not part of the question, so panning
+    // cannot change the answer — and these are the seconds-long requests.
+    const { rerender, tree } = await renderPanes(6, { rangeMode: 'domain', mapExtent: extentAt(0) });
+    const before = aggregateCalls().length;
+    expect(before).toBeGreaterThan(0);
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(10) })); });
+    await act(async () => { rerender(tree({ mapExtent: extentAt(20) })); });
+
+    expect(aggregateCalls()).toHaveLength(before);
+  });
+
+  it('does not re-ask when the extent object is new but the extent is not', async () => {
+    // mapExtent is rebuilt on every report, so identity churn alone used to
+    // re-run the effect.
+    const { rerender, tree } = await renderPanes(1, { rangeMode: 'extent', mapExtent: extentAt(0) });
+    const before = aggregateCalls().length;
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(0) })); });
+
+    expect(aggregateCalls()).toHaveLength(before);
+  });
+
+  it('cancels the aggregates a pan has superseded', async () => {
+    const { rerender, tree } = await renderPanes(1, { rangeMode: 'extent', mapExtent: extentAt(0) });
+    const first = aggregateCalls();
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.every((c) => c.signal !== undefined)).toBe(true);
+
+    await act(async () => { rerender(tree({ mapExtent: extentAt(10) })); });
+
+    const second = aggregateCalls().filter((c) => !first.includes(c));
+    expect(second.length).toBeGreaterThan(0);
+    // The grace period is there so a re-subscribe in the next tick keeps the
+    // request; nothing re-subscribes to the old extent.
+    await act(async () => { await new Promise((r) => setTimeout(r, 120)); });
+
+    expect(first.every((c) => c.signal!.aborted)).toBe(true);
+    expect(second.every((c) => c.signal!.aborted)).toBe(false);
+  });
+
+  it('keeps a site-scoped range mode off the aggregate endpoint entirely', async () => {
+    await renderPanes(6, { rangeMode: 'site', mapExtent: extentAt(0) });
+    expect(aggregateCalls()).toHaveLength(0);
+  });
+});

--- a/frontend/src/test/choroplethRenderPath.test.ts
+++ b/frontend/src/test/choroplethRenderPath.test.ts
@@ -33,7 +33,10 @@ describe('choropleth vector-tile render path', () => {
   });
 
   it('fetches values, not geometry, once the tiled zoom range is in use', () => {
-    expect(mapView).toMatch(/fetch\(`\/api\/catchment-values\?\$\{params\}`\)/);
+    // The request options now carry an AbortSignal, so this no longer asserts
+    // the call ends immediately after the URL — only that the URL is the
+    // values endpoint and that a signal is threaded through it.
+    expect(mapView).toMatch(/fetch\(`\/api\/catchment-values\?\$\{params\}`, \{ signal: requestSignal \}\)/);
     // The values request carries no zoom: the server's detailed-vs-aggregated
     // choice does not apply when geometry comes from tiles.
     const valuesFetch = mapView.slice(

--- a/frontend/src/test/mapRefetchStorms.test.tsx
+++ b/frontend/src/test/mapRefetchStorms.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * Refetch storms on map interaction (issue #60).
+ *
+ * A pan fires choropleth requests that the next pan immediately obsoletes.
+ * Nothing ordered the responses, so whichever landed last painted the map — and
+ * the map could settle showing a viewport the user had already left. Nothing
+ * cancelled them either, so the connection and the server stayed busy on
+ * answers no one would read.
+ *
+ * MapLibre is stubbed (as in webglContextBudget.test.tsx — WebGL cannot run in
+ * jsdom) with a movable viewport, so a pan is a real 'moveend' with real new
+ * bounds and the requests it produces are the real ones.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import type { ComparisonState } from '../types';
+
+// --- MapLibre stand-in --------------------------------------------------------
+
+const constructed: FakeMap[] = [];
+
+class FakeMap {
+  removed = false;
+  west = 0;
+  south = 0;
+  east = 1;
+  north = 1;
+  private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  private canvas = document.createElement('canvas');
+
+  constructor() {
+    constructed.push(this);
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler);
+    this.handlers.set(event, existing);
+    return this;
+  }
+
+  once(event: string, handler: (...args: unknown[]) => void) {
+    return this.on(event, handler);
+  }
+
+  off() {
+    return this;
+  }
+
+  fire(event: string) {
+    for (const handler of [...(this.handlers.get(event) ?? [])]) handler({ point: { x: 0, y: 0 } });
+  }
+
+  /** Move the viewport, exactly as a drag would, and end the movement. */
+  panTo(west: number) {
+    this.west = west;
+    this.east = west + 1;
+    this.fire('moveend');
+  }
+
+  addControl() { return this; }
+  getCenter() { return { lng: (this.west + this.east) / 2, lat: 0 }; }
+  getZoom() { return 6; }
+  getBearing() { return 0; }
+  getPitch() { return 0; }
+
+  getBounds() {
+    return {
+      getWest: () => this.west,
+      getSouth: () => this.south,
+      getEast: () => this.east,
+      getNorth: () => this.north,
+      getSouthWest: () => ({ lng: this.west, lat: this.south }),
+      getNorthEast: () => ({ lng: this.east, lat: this.north }),
+    };
+  }
+
+  getCanvas() { return this.canvas; }
+  getStyle() { return { sources: {} }; }
+  getSource() { return undefined; }
+  getLayer() { return undefined; }
+  get style() { return undefined; }
+  loaded() { return false; }
+  isStyleLoaded() { return false; }
+  jumpTo() {}
+  easeTo() {}
+  fitBounds() {}
+  setStyle() {}
+  resize() {}
+  triggerRepaint() {}
+  setMaxBounds() {}
+  setMinZoom() {}
+  setMaxZoom() {}
+  queryRenderedFeatures() { return []; }
+  project() { return { x: 0, y: 0 }; }
+  dragPan = { enable() {}, disable() {} };
+  remove() { this.removed = true; }
+}
+
+class FakeLngLatBounds {
+  constructor(private sw: [number, number], private ne: [number, number]) {}
+  getSouthWest() { return { lng: this.sw[0], lat: this.sw[1] }; }
+  getNorthEast() { return { lng: this.ne[0], lat: this.ne[1] }; }
+  getWest() { return this.sw[0]; }
+  getSouth() { return this.sw[1]; }
+  getEast() { return this.ne[0]; }
+  getNorth() { return this.ne[1]; }
+  extend() { return this; }
+}
+
+vi.mock('maplibre-gl', () => {
+  class NavigationControl {}
+  const api = { Map: FakeMap, NavigationControl, LngLatBounds: FakeLngLatBounds };
+  return { ...api, default: api };
+});
+
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+// --- Network stand-in ---------------------------------------------------------
+
+interface Call {
+  url: string;
+  signal?: AbortSignal;
+  settle: (body: unknown) => void;
+}
+
+let calls: Call[] = [];
+
+/**
+ * The viewport's own choropleth requests.
+ *
+ * Deliberately not the full-domain and site-scoped `valuesOnly` requests: those
+ * feed the Full and Site range statistics, do not depend on the viewport, and
+ * are correctly left alone by a pan.
+ */
+function choroplethCalls(): Call[] {
+  return calls.filter((c) => c.url.startsWith('/api/choropleth?') && !c.url.includes('valuesOnly'));
+}
+
+function boundsOf(call: Call): string {
+  const params = new URLSearchParams(call.url.slice(call.url.indexOf('?') + 1));
+  return `${params.get('minx')},${params.get('maxx')}`;
+}
+
+/** One catchment carrying `value` for `attribute`, in the shape /api/choropleth returns. */
+function featureCollection(attribute: string, value: number) {
+  return {
+    type: 'FeatureCollection',
+    domain_min: value,
+    domain_max: value,
+    features: [{
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { HYBAS_ID: 1, [attribute]: value },
+    }],
+  };
+}
+
+beforeEach(() => {
+  // The choropleth caches are module state with a 60-second TTL, and every test
+  // here pans over the same bounds. Without a fresh module the second test
+  // would be served from the first test's cache and make no requests at all —
+  // which is the right behaviour in the application and useless in a test.
+  vi.resetModules();
+  constructed.length = 0;
+  calls = [];
+  vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+    return new Promise<Response>((resolve, reject) => {
+      const call: Call = {
+        url,
+        signal: init?.signal ?? undefined,
+        settle: (body: unknown) =>
+          resolve(new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })),
+      };
+      calls.push(call);
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }, { once: true });
+      // Anything the test does not care about answers with an empty object as
+      // soon as it is asked, so mount-time metadata requests do not hang.
+      if (!url.startsWith('/api/choropleth?') && !url.startsWith('/api/catchment-values?')) {
+        call.settle({});
+      }
+    });
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const comparison: ComparisonState = {
+  leftScenario: 'reference',
+  rightScenario: 'current',
+  attribute: 'water_yield',
+};
+
+async function mountMap(props: Record<string, unknown> = {}) {
+  const MapView = (await import('../components/MapView')).default;
+  const stats: Array<{ domainRange: { min: number; max: number } | null }> = [];
+
+  await act(async () => {
+    render(
+      <ChakraProvider theme={theme}>
+        <MapView
+          comparison={comparison}
+          onOpenSettings={() => {}}
+          colorScaleMode="rainbow"
+          colorScaleType="linear"
+          isSwiperEnabled={false}
+          onStatisticsChange={(s) => stats.push(s as { domainRange: { min: number; max: number } | null })}
+          {...props}
+        />
+      </ChakraProvider>,
+    );
+  });
+
+  const map = constructed[0];
+  // 'load' is what marks the map ready and triggers the first paint.
+  await act(async () => { map.fire('load'); });
+  return { map, stats };
+}
+
+/** Let the moveend debounce elapse and the resulting work start. */
+async function settle(ms = 400) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+describe('choropleth requests during a pan', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('cancels the request a further pan has made pointless', async () => {
+    const { map } = await mountMap();
+    await settle();
+
+    const first = choroplethCalls();
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.every((c) => c.signal !== undefined)).toBe(true);
+    expect(first.every((c) => c.signal!.aborted)).toBe(false);
+
+    // Pan away before the first viewport's answer arrives.
+    await act(async () => { map.panTo(10); });
+    await settle();
+
+    const second = choroplethCalls().filter((c) => !first.includes(c));
+    expect(second.length).toBeGreaterThan(0);
+    expect(boundsOf(second[0])).not.toBe(boundsOf(first[0]));
+
+    // The superseded requests are really cancelled, not merely ignored: the
+    // connection is freed and the server is free to stop.
+    expect(first.every((c) => c.signal!.aborted)).toBe(true);
+    expect(second.every((c) => c.signal!.aborted)).toBe(false);
+  });
+
+  it('paints the current viewport even when the old one answers last', async () => {
+    // The out-of-order case. The first viewport's request is allowed to finish
+    // after the second's, with a different domain, and must not be the one that
+    // reaches the statistics panel.
+    const { map, stats } = await mountMap();
+    await settle();
+
+    const first = choroplethCalls();
+    await act(async () => { map.panTo(10); });
+    await settle();
+    const second = choroplethCalls().filter((c) => !first.includes(c));
+
+    await act(async () => {
+      second.forEach((c) => c.settle(featureCollection('water_yield', 222)));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      first.forEach((c) => c.settle(featureCollection('water_yield', 111)));
+      await Promise.resolve();
+    });
+
+    const published = stats.filter((s) => s.domainRange !== null).map((s) => s.domainRange!.max);
+    expect(published).toContain(222);
+    expect(published).not.toContain(111);
+    expect(published[published.length - 1]).toBe(222);
+  });
+
+  it('does not re-request a viewport it never left', async () => {
+    // moveend fires for plenty of things that leave the viewport where it was.
+    const { map } = await mountMap();
+    await settle();
+    const before = choroplethCalls().length;
+
+    await act(async () => { map.fire('moveend'); });
+    await settle();
+
+    expect(choroplethCalls()).toHaveLength(before);
+  });
+
+  it('reports an unchanged extent to the application once, not once per moveend', async () => {
+    // Every report lands in App state and re-renders the whole pane tree.
+    const extents: unknown[] = [];
+    const { map } = await mountMap({ onMapExtentChange: (e: unknown) => extents.push(e) });
+    await settle();
+
+    await act(async () => { map.fire('moveend'); });
+    await act(async () => { map.fire('moveend'); });
+    const afterRepeats = extents.length;
+
+    await act(async () => { map.panTo(42); });
+    expect(extents.length).toBe(afterRepeats + 1);
+    expect(afterRepeats).toBeLessThanOrEqual(1);
+  });
+
+  it('makes one request per question when several panes ask together', async () => {
+    // Quad view: every pane holds its own MapView over the same viewport.
+    const MapView = (await import('../components/MapView')).default;
+    await act(async () => {
+      render(
+        <ChakraProvider theme={theme}>
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <MapView
+              key={i}
+              comparison={comparison}
+              onOpenSettings={() => {}}
+              colorScaleMode="rainbow"
+              colorScaleType="linear"
+              isSwiperEnabled={false}
+            />
+          ))}
+        </ChakraProvider>,
+      );
+    });
+
+    await act(async () => { constructed.forEach((m) => m.fire('load')); });
+    await settle();
+
+    const urls = choroplethCalls().map((c) => c.url);
+    // Two scenarios, one viewport: two distinct questions, and no duplicates of
+    // either however many panes are asking.
+    expect(new Set(urls).size).toBe(2);
+    expect(urls).toHaveLength(2);
+  });
+});

--- a/frontend/src/test/sharedRequest.test.ts
+++ b/frontend/src/test/sharedRequest.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared, cancellable requests (issue #60).
+ *
+ * The three behaviours the map's interaction path depends on, and which the
+ * plain promise caches it replaces got only partly right:
+ *
+ *   - twelve panes asking the same question make one request,
+ *   - a superseded request is really cancelled, not merely ignored,
+ *   - and one caller losing interest never cancels a request the others are
+ *     still waiting for.
+ *
+ * The third is the one that makes the first two safe to combine, and is the
+ * easiest to break by accident.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
+
+const TTL = 10_000;
+const GRACE = 50;
+
+/** A request whose completion the test controls. */
+function deferredWork() {
+  const signals: AbortSignal[] = [];
+  const resolvers: Array<(value: string) => void> = [];
+  const rejecters: Array<(err: unknown) => void> = [];
+
+  const work = (signal: AbortSignal) => {
+    signals.push(signal);
+    return new Promise<string>((resolve, reject) => {
+      resolvers.push(resolve);
+      rejecters.push(reject);
+      signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true });
+    });
+  };
+
+  return {
+    work,
+    signals,
+    calls: () => signals.length,
+    resolve: (value: string, index = 0) => resolvers[index](value),
+    reject: (err: unknown, index = 0) => rejecters[index](err),
+  };
+}
+
+let cache: SharedCache<string>;
+
+beforeEach(() => {
+  cache = new Map();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('request sharing', () => {
+  it('makes one request for callers that ask the same question at once', async () => {
+    const w = deferredWork();
+    const controllers = Array.from({ length: 12 }, () => new AbortController());
+
+    const promises = controllers.map((c) =>
+      sharedRequest(cache, 'viewport-a', TTL, w.work, c.signal, GRACE));
+
+    expect(w.calls()).toBe(1);
+
+    w.resolve('values');
+    await expect(Promise.all(promises)).resolves.toEqual(Array(12).fill('values'));
+    expect(w.calls()).toBe(1);
+  });
+
+  it('asks separately for different questions', () => {
+    const w = deferredWork();
+    void sharedRequest(cache, 'viewport-a', TTL, w.work, undefined, GRACE);
+    void sharedRequest(cache, 'viewport-b', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+
+  it('serves a settled result from cache inside its TTL, and refetches after', async () => {
+    const w = deferredWork();
+    const first = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    w.resolve('one');
+    await expect(first).resolves.toBe('one');
+
+    vi.advanceTimersByTime(TTL - 1);
+    await expect(sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE)).resolves.toBe('one');
+    expect(w.calls()).toBe(1);
+
+    vi.advanceTimersByTime(2);
+    void sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+
+  it('does not cache a failure', async () => {
+    const w = deferredWork();
+    const first = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    w.reject(new Error('HTTP 500'));
+    await expect(first).rejects.toThrow('HTTP 500');
+
+    void sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    expect(w.calls()).toBe(2);
+  });
+});
+
+describe('cancellation', () => {
+  it('aborts the request once the last caller has gone', async () => {
+    const w = deferredWork();
+    const caller = new AbortController();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, caller.signal, GRACE);
+
+    caller.abort();
+    await expect(promise).rejects.toSatisfy(isAbortError);
+    expect(w.signals[0].aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.signals[0].aborted).toBe(true);
+  });
+
+  it('keeps the request alive for the callers that remain', async () => {
+    const w = deferredWork();
+    const leaving = new AbortController();
+    const staying = new AbortController();
+
+    const leavingPromise = sharedRequest(cache, 'k', TTL, w.work, leaving.signal, GRACE);
+    const stayingPromise = sharedRequest(cache, 'k', TTL, w.work, staying.signal, GRACE);
+    expect(w.calls()).toBe(1);
+
+    leaving.abort();
+    await expect(leavingPromise).rejects.toSatisfy(isAbortError);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.signals[0].aborted).toBe(false);
+
+    w.resolve('values');
+    await expect(stayingPromise).resolves.toBe('values');
+  });
+
+  it('never abandons a caller that gave no signal', async () => {
+    const w = deferredWork();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, undefined, GRACE);
+    const leaving = new AbortController();
+    void sharedRequest(cache, 'k', TTL, w.work, leaving.signal, GRACE).catch(() => undefined);
+
+    leaving.abort();
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+
+    expect(w.signals[0].aborted).toBe(false);
+    w.resolve('values');
+    await expect(promise).resolves.toBe('values');
+  });
+
+  it('does not cancel a request the next tick asks for again', async () => {
+    // applyColors supersedes its own previous run before it knows whether the
+    // parameters changed. Cancelling on the spot would throw away a request
+    // that is about to be wanted back, and cost a second round trip.
+    const w = deferredWork();
+    const first = new AbortController();
+    void sharedRequest(cache, 'k', TTL, w.work, first.signal, GRACE).catch(() => undefined);
+
+    first.abort();
+    const second = new AbortController();
+    const promise = sharedRequest(cache, 'k', TTL, w.work, second.signal, GRACE);
+
+    await vi.advanceTimersByTimeAsync(GRACE + 1);
+    expect(w.calls()).toBe(1);
+    expect(w.signals[0].aborted).toBe(false);
+
+    w.resolve('values');
+    await expect(promise).resolves.toBe('values');
+  });
+
+  it('rejects immediately for a caller whose signal is already aborted', async () => {
+    const w = deferredWork();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(sharedRequest(cache, 'k', TTL, w.work, controller.signal, GRACE))
+      .rejects.toSatisfy(isAbortError);
+    expect(w.calls()).toBe(0);
+  });
+});
+
+describe('bookkeeping', () => {
+  it('drops expired entries rather than growing for the life of the tab', async () => {
+    // Keys embed the viewport bounds, so a minute of panning is a new key per
+    // moveend.
+    for (let i = 0; i < 5; i++) {
+      const w = deferredWork();
+      const p = sharedRequest(cache, `viewport-${i}`, TTL, w.work, undefined, GRACE);
+      w.resolve('v');
+      await p;
+    }
+    expect(cache.size).toBe(5);
+
+    vi.advanceTimersByTime(TTL + 1);
+    const w = deferredWork();
+    void sharedRequest(cache, 'viewport-new', TTL, w.work, undefined, GRACE);
+    expect(cache.size).toBe(1);
+  });
+
+  it('recognises an abort rejection in either shape', () => {
+    expect(isAbortError(new DOMException('x', 'AbortError'))).toBe(true);
+    expect(isAbortError({ name: 'AbortError' })).toBe(true);
+    expect(isAbortError(new Error('boom'))).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+  });
+});

--- a/frontend/src/test/siteStore.test.ts
+++ b/frontend/src/test/siteStore.test.ts
@@ -3,10 +3,13 @@ import {
   LEGACY_KEY,
   clearSiteStore,
   deleteSite,
+  getSiteStoreStats,
+  invalidateSiteCache,
   loadSite,
   loadSites,
   migrateLegacyStore,
   normaliseForStorage,
+  resetSiteStoreStats,
   saveSite,
   saveSites,
 } from '../lib/siteStore';
@@ -45,6 +48,7 @@ function countWrites() {
 beforeEach(() => {
   window.localStorage.clear();
   clearSiteStore();
+  resetSiteStoreStats();
 });
 
 afterEach(() => {
@@ -225,5 +229,262 @@ describe('reading and writing', () => {
 
   it('refuses a site with no id rather than writing a broken key', () => {
     expect(saveSite({ title: 'no id' } as unknown as Site)).toBe(false);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// The cost of a save
+//
+// Splitting the blob into one key per site fixed the write but not the work
+// around it: the bulk callers still load every site, change one and hand the
+// whole list back, so the store parsed N records on the way in and re-serialised
+// N on the way out to find the one that differed. These tests count that work,
+// because "proportional to what changed" is a claim until it is a number.
+// ---------------------------------------------------------------------------
+
+function manySites(n: number): Site[] {
+  return Array.from({ length: n }, (_, i) => site(`s${i}`, { title: `site ${i}` }));
+}
+
+describe('what a save actually costs', () => {
+  it('serialises one site when one site of fifty changed', () => {
+    saveSites(manySites(50));
+    const loaded = loadSites();
+
+    const changed = [...loaded];
+    changed[17] = { ...loaded[17], title: 'edited' } as Site;
+
+    resetSiteStoreStats();
+    expect(saveSites(changed)).toBe(true);
+    const cost = getSiteStoreStats();
+
+    expect(cost.serialised).toBe(1);
+    expect(cost.recordWrites).toBe(1);
+    // Membership and order did not change, so the index does not need rewriting.
+    expect(cost.indexWrites).toBe(0);
+    // And nothing had to be read back to work out which record differed.
+    expect(cost.recordReads).toBe(0);
+    expect(cost.parsed).toBe(0);
+  });
+
+  it('costs the same with fifty sites stored as with five — that is the whole issue', () => {
+    function costOfOneEdit(n: number) {
+      window.localStorage.clear();
+      clearSiteStore();
+      saveSites(manySites(n));
+      const loaded = loadSites();
+      const changed = [...loaded];
+      changed[1] = { ...loaded[1], title: 'edited' } as Site;
+      resetSiteStoreStats();
+      saveSites(changed);
+      return getSiteStoreStats();
+    }
+
+    expect(costOfOneEdit(50)).toEqual(costOfOneEdit(5));
+  });
+
+  it('does no work at all when nothing changed', () => {
+    saveSites(manySites(20));
+    const loaded = loadSites();
+
+    resetSiteStoreStats();
+    expect(saveSites(loaded)).toBe(true);
+
+    expect(getSiteStoreStats()).toMatchObject({
+      serialised: 0,
+      recordWrites: 0,
+      indexWrites: 0,
+      parsed: 0,
+    });
+  });
+
+  it('still recognises an equal site it has never seen the object of', () => {
+    // A caller that rebuilt the list from somewhere else gets no identity hit,
+    // so the record is serialised — but an identical string must not be written.
+    saveSites(manySites(3));
+    invalidateSiteCache();
+
+    resetSiteStoreStats();
+    saveSites(manySites(3));
+
+    expect(getSiteStoreStats().serialised).toBe(3);
+    expect(getSiteStoreStats().recordWrites).toBe(0);
+  });
+
+  it('parses each record once however often it is read', () => {
+    saveSites(manySites(10));
+    invalidateSiteCache();
+
+    resetSiteStoreStats();
+    loadSites();
+    const first = getSiteStoreStats().parsed;
+    loadSites();
+    loadSites();
+    const total = getSiteStoreStats().parsed;
+
+    expect(first).toBe(10);
+    expect(total).toBe(10);
+  });
+
+  it('hands out a stable reference, which is what makes the shortcut sound', () => {
+    saveSites(manySites(3));
+    invalidateSiteCache();
+
+    const a = loadSites();
+    const b = loadSites();
+
+    expect(a[0]).toBe(b[0]);
+    expect(a[2]).toBe(b[2]);
+  });
+
+  it('writes the index only when membership or order changed', () => {
+    saveSites(manySites(3));
+
+    resetSiteStoreStats();
+    saveSites([...loadSites()].reverse());
+    expect(getSiteStoreStats().indexWrites).toBe(1);
+
+    resetSiteStoreStats();
+    saveSites(loadSites());
+    expect(getSiteStoreStats().indexWrites).toBe(0);
+
+    expect(loadSites().map((s) => s.id)).toEqual(['s2', 's1', 's0']);
+  });
+
+  it('an explicit single-site save is never skipped, however unchanged it looks', () => {
+    // Durability beats cleverness: a caller reaching for saveSite is asserting
+    // the site changed, and a store that argued would lose someone's work.
+    const s = site('a');
+    saveSite(s);
+
+    resetSiteStoreStats();
+    expect(saveSite(s)).toBe(true);
+
+    expect(getSiteStoreStats().recordWrites).toBe(1);
+  });
+});
+
+// Deliberately spy-based rather than counter-based, so it says something about
+// the store's observable behaviour rather than about its own bookkeeping — and
+// so it can be pointed at any implementation. Against the version that compared
+// each site to storage, this read fifty records to save one.
+describe('what a save touches, observed from outside', () => {
+  it('reads no records to save one site out of fifty', () => {
+    saveSites(manySites(50));
+    const loaded = loadSites();
+    const changed = [...loaded];
+    changed[7] = { ...loaded[7], title: 'edited' } as Site;
+
+    const reads: string[] = [];
+    const writes: string[] = [];
+    const realGet = Storage.prototype.getItem;
+    const realSet = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function (this: Storage, k: string) {
+      reads.push(k);
+      return realGet.call(this, k);
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      k: string,
+      v: string,
+    ) {
+      writes.push(k);
+      realSet.call(this, k, v);
+    });
+
+    saveSites(changed);
+    vi.restoreAllMocks();
+
+    // The version that compared each site against storage read all fifty here.
+    expect(reads.filter((k) => k.startsWith('dt-site:'))).toEqual([]);
+    expect(writes).toEqual(['dt-site:s7']);
+  });
+});
+
+describe('the cache never outlives what it describes', () => {
+  it('does not believe a record is stored when the write failed', () => {
+    const s = site('a', { title: 'precious' });
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(saveSites([s])).toBe(false);
+    vi.restoreAllMocks();
+
+    // Same object, so the identity shortcut would skip it if the failed write
+    // had been cached. It must not have been.
+    expect(saveSites([s])).toBe(true);
+    expect(loadSite('a')?.title).toBe('precious');
+  });
+
+  it('surfaces a quota failure from the list path, not just the single path', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+    expect(saveSites([site('a')])).toBe(false);
+  });
+
+  it('surfaces a failure to write the index', () => {
+    saveSites([site('a')]);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      k: string,
+    ) {
+      if (k === 'dt-site-index') throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    // A new site changes membership, so the index must be rewritten.
+    expect(saveSite(site('b'))).toBe(false);
+  });
+
+  it('re-reads a record another tab replaced', () => {
+    saveSites([site('a', { title: 'ours' })]);
+    const ours = loadSites();
+
+    // What another tab writing dt-site:a looks like from in here.
+    window.localStorage.setItem('dt-site:a', JSON.stringify(site('a', { title: 'theirs' })));
+    window.dispatchEvent(new StorageEvent('storage', { key: 'dt-site:a' }));
+
+    expect(loadSite('a')?.title).toBe('theirs');
+
+    // And the stale object we still hold is written back rather than skipped.
+    resetSiteStoreStats();
+    saveSites(ours);
+    expect(getSiteStoreStats().recordWrites).toBe(1);
+    expect(loadSite('a')?.title).toBe('ours');
+  });
+
+  it('forgets everything when another tab clears storage', () => {
+    saveSites([site('a')]);
+    window.localStorage.clear();
+    window.dispatchEvent(new StorageEvent('storage', { key: null }));
+
+    expect(loadSites()).toEqual([]);
+  });
+
+  it('forgets a deleted site rather than serving it from cache', () => {
+    saveSites([site('a'), site('b')]);
+    loadSites();
+    deleteSite('a');
+
+    expect(loadSite('a')).toBeNull();
+    expect(loadSites().map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('migrates the legacy blob even with a warm cache, and indexes it', () => {
+    saveSites([site('kept')]);
+    loadSites();
+
+    window.localStorage.setItem(LEGACY_KEY, JSON.stringify([site('old-a'), site('old-b')]));
+
+    expect(loadSites().map((s) => s.id)).toEqual(['old-a', 'old-b']);
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem('dt-site-index') as string)).toEqual([
+      'old-a',
+      'old-b',
+    ]);
+    // The migrated records are readable through the cache that was already warm.
+    expect(loadSite('old-a')?.title).toBe('site old-a');
   });
 });

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,14 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/kartoza/decision-theatre/internal/fsutil"
 )
@@ -55,6 +58,21 @@ type Config struct {
 	// with the URL instead of being hardcoded in the client.
 	SatelliteAttribution string
 
+	// MapTilerKey authenticates the server's glyph fetches against
+	// api.maptiler.com. Fonts are the only thing it buys: the vector tiles are
+	// served from the local mbtiles file, so this is not what draws the map.
+	//
+	// It has no default and none is compiled in. The key that used to be written
+	// here in the source was published in the repository, in every release
+	// binary and in every data pack, which is why it now has to be supplied at
+	// run time — see issue #31. Empty is a supported state, not an error: the
+	// glyph proxy answers with no glyphs and the map renders without place
+	// labels, exactly as it already does on a machine with no internet.
+	//
+	// Never build a URL from this without going through MapTilerGlyphURL, which
+	// is what refuses to emit "key=" with nothing after it.
+	MapTilerKey string
+
 	// DesktopMode is true only when the process owns a desktop session and has
 	// opened the embedded WebView window.
 	//
@@ -95,6 +113,65 @@ func (c Config) Satellite() (tileURL, attribution string) {
 	return tileURL, attribution
 }
 
+// MapTilerKeyEnv names the environment variable the key can be supplied in.
+//
+// The environment rather than a flag is the intended route for a deployment: a
+// flag value is visible in `ps` to every user on the host and would have to be
+// written into deployments/docker-compose.yaml, which is tracked. The flag
+// exists as well because a developer running one command should not have to
+// export anything.
+const MapTilerKeyEnv = "DT_MAPTILER_API_KEY"
+
+// mapTilerGlyphEndpoint is the upstream glyph URL, without its key.
+const mapTilerGlyphEndpoint = "https://api.maptiler.com/fonts/%s/%s.pbf"
+
+// MapTilerGlyphURL builds the upstream URL for one font range, reporting false
+// when no key is configured.
+//
+// The boolean is the point of the signature. Returning a URL with an empty key
+// parameter would be answered by MapTiler with a 403, which reaches the user as
+// missing labels on the map with nothing in the interface to connect that to a
+// missing setting; the caller is made to notice the absence instead.
+//
+// fontstack and glyphRange arrive from the request path and are escaped, so a
+// crafted font name cannot append parameters of its own to the query string.
+func (c Config) MapTilerGlyphURL(fontstack, glyphRange string) (string, bool) {
+	key := strings.TrimSpace(c.MapTilerKey)
+	if key == "" {
+		return "", false
+	}
+	return fmt.Sprintf(mapTilerGlyphEndpoint,
+		url.PathEscape(fontstack), url.PathEscape(glyphRange),
+	) + "?key=" + url.QueryEscape(key), true
+}
+
+// ResolveMapTilerKey picks the key from the places it may be supplied, most
+// specific instruction first: the command line, then the environment, then the
+// saved settings.
+//
+// Three sources because there are three ways this application runs. A container
+// has an environment and no user; a desktop install that was double-clicked has
+// neither a command line nor an environment a person can reasonably set, so its
+// key lives in settings.json alongside the data pack path. settings may be nil.
+//
+// Surrounding whitespace is dropped. A key pasted into a file or a compose
+// environment block picks up a trailing newline easily, and MapTiler answers a
+// key with a newline in it the same way it answers a wrong one.
+func ResolveMapTilerKey(flagValue string, settings *Settings) string {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv(MapTilerKeyEnv)); v != "" {
+		return v
+	}
+	if settings != nil {
+		if v := strings.TrimSpace(settings.MapTilerKey); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // ListenAddress returns the host:port to bind, applying the safe default.
 func (c Config) ListenAddress() string {
 	return c.ListenAddressForPort(c.Port)
@@ -131,6 +208,12 @@ type Settings struct {
 	ExecutableWindows    string `json:"executable_windows,omitempty"`
 	ExecutableLinux      string `json:"executable_linux,omitempty"`
 	ExecutableMacOS      string `json:"executable_macos,omitempty"`
+
+	// MapTilerKey is how a desktop install supplies the glyph key. It is the
+	// only route available to a build that was downloaded and double-clicked,
+	// which has no command line and no environment of its own. See
+	// Config.MapTilerKey for what happens when it is absent.
+	MapTilerKey string `json:"maptiler_key,omitempty"`
 }
 
 // SettingsDir returns the platform-appropriate config directory.

--- a/internal/config/maptiler_test.go
+++ b/internal/config/maptiler_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The MapTiler key used to be a string literal in the source, so it was in the
+// repository, in every release binary and in every data pack — see issue #31.
+// It now comes from configuration, and the property that matters is not merely
+// that a configured key is used, but that an unconfigured one produces no
+// request at all rather than a request with nothing after "key=". MapTiler
+// answers that with 403, which surfaces to a user as a map with no labels and
+// nothing anywhere pointing at the setting that is missing.
+
+func TestMapTilerGlyphURLUsesConfiguredKey(t *testing.T) {
+	cfg := Config{MapTilerKey: "test-key-123"}
+
+	got, ok := cfg.MapTilerGlyphURL("Open Sans Regular", "0-255")
+	if !ok {
+		t.Fatal("MapTilerGlyphURL reported no key, but one is configured")
+	}
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("built an unparseable URL %q: %v", got, err)
+	}
+	if u.Host != "api.maptiler.com" {
+		t.Errorf("host = %q, want api.maptiler.com", u.Host)
+	}
+	if key := u.Query().Get("key"); key != "test-key-123" {
+		t.Errorf("key = %q, want the configured value", key)
+	}
+	if !strings.Contains(u.Path, "0-255") {
+		t.Errorf("path %q does not name the requested range", u.Path)
+	}
+}
+
+func TestMapTilerGlyphURLNoKeyProducesNoURL(t *testing.T) {
+	// Whitespace counts as absent: a key pasted into a compose file or a
+	// settings.json by hand collects a trailing newline easily, and " " must not
+	// be mistaken for a usable credential.
+	for name, key := range map[string]string{
+		"empty":       "",
+		"spaces":      "   ",
+		"newlineOnly": "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := Config{MapTilerKey: key}
+
+			got, ok := cfg.MapTilerGlyphURL("Open Sans Regular", "0-255")
+			if ok {
+				t.Fatalf("reported a usable key for %q", key)
+			}
+			if got != "" {
+				t.Fatalf("returned %q; an unconfigured key must yield no URL at all, "+
+					"least of all one ending in key=", got)
+			}
+		})
+	}
+}
+
+func TestMapTilerGlyphURLTrimsKey(t *testing.T) {
+	cfg := Config{MapTilerKey: "  test-key-123\n"}
+
+	got, ok := cfg.MapTilerGlyphURL("Open Sans Regular", "0-255")
+	if !ok {
+		t.Fatal("a key with surrounding whitespace was treated as absent")
+	}
+	u, _ := url.Parse(got)
+	if key := u.Query().Get("key"); key != "test-key-123" {
+		t.Errorf("key = %q, want it trimmed", key)
+	}
+}
+
+// fontstack and range come straight off the request path, so a crafted font name
+// must not be able to add parameters of its own to the upstream query string.
+func TestMapTilerGlyphURLEscapesPathSegments(t *testing.T) {
+	cfg := Config{MapTilerKey: "real-key"}
+
+	got, ok := cfg.MapTilerGlyphURL("Evil?key=stolen&x", "0-255#frag")
+	if !ok {
+		t.Fatal("MapTilerGlyphURL reported no key, but one is configured")
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("built an unparseable URL %q: %v", got, err)
+	}
+	if key := u.Query().Get("key"); key != "real-key" {
+		t.Errorf("key = %q; the font name overrode the configured key", key)
+	}
+	if u.Fragment != "" {
+		t.Errorf("fragment = %q; the range escaped its path segment", u.Fragment)
+	}
+	if len(u.Query()) != 1 {
+		t.Errorf("query = %v, want only the key parameter", u.Query())
+	}
+}
+
+func TestResolveMapTilerKeyPrecedence(t *testing.T) {
+	// Most specific instruction wins: what was typed on the command line, then
+	// what the environment supplies, then what was saved for this user.
+	tests := []struct {
+		name     string
+		flag     string
+		env      string
+		settings *Settings
+		want     string
+	}{
+		{"flag beats everything", "from-flag", "from-env",
+			&Settings{MapTilerKey: "from-settings"}, "from-flag"},
+		{"env beats settings", "", "from-env",
+			&Settings{MapTilerKey: "from-settings"}, "from-env"},
+		{"settings are the last resort", "", "",
+			&Settings{MapTilerKey: "from-settings"}, "from-settings"},
+		{"nothing configured", "", "", &Settings{}, ""},
+		{"nil settings", "", "", nil, ""},
+		{"whitespace is not a value", "  ", "\t",
+			&Settings{MapTilerKey: " from-settings "}, "from-settings"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(MapTilerKeyEnv, tc.env)
+
+			if got := ResolveMapTilerKey(tc.flag, tc.settings); got != tc.want {
+				t.Errorf("ResolveMapTilerKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A key saved by an earlier version, or written into the file by hand, has to
+// survive the JSON round trip or the desktop build loses it on the next launch.
+//
+// Marshalling directly rather than through SaveSettings: that writes to the real
+// per-user config directory on macOS and Windows, where there is no environment
+// variable to redirect it, and a test has no business overwriting a developer's
+// own settings.json.
+func TestSettingsCarryMapTilerKey(t *testing.T) {
+	data, err := json.Marshal(&Settings{MapTilerKey: "persisted-key"})
+	if err != nil {
+		t.Fatalf("marshalling settings: %v", err)
+	}
+	if !strings.Contains(string(data), `"maptiler_key"`) {
+		t.Errorf("settings JSON %s has no maptiler_key field", data)
+	}
+
+	var got Settings
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshalling settings: %v", err)
+	}
+	if got.MapTilerKey != "persisted-key" {
+		t.Errorf("MapTilerKey = %q after a round trip, want persisted-key", got.MapTilerKey)
+	}
+
+	// omitempty, so a settings file written before this field existed — and one
+	// written by a user who never set a key — stays as it was.
+	empty, err := json.Marshal(&Settings{})
+	if err != nil {
+		t.Fatalf("marshalling empty settings: %v", err)
+	}
+	if strings.Contains(string(empty), "maptiler_key") {
+		t.Errorf("empty settings serialised as %s, want the field omitted", empty)
+	}
+}

--- a/internal/server/glyph_test.go
+++ b/internal/server/glyph_test.go
@@ -1,0 +1,270 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kartoza/decision-theatre/internal/config"
+)
+
+// The glyph proxy is the one place in the process that talks to MapTiler, and
+// until issue #31 it did so with a key compiled into this file. These tests fix
+// the two properties that replaced it: the key comes from configuration, and its
+// absence stops the request instead of sending one that says "key=" and nothing
+// more.
+
+// recordingTransport answers every request from a canned response and remembers
+// what it was asked for, so a test can assert on the upstream URL without
+// reaching the network.
+type recordingTransport struct {
+	mu       sync.Mutex
+	requests []*url.URL
+
+	status int
+	body   []byte
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.requests = append(rt.requests, req.URL)
+	rt.mu.Unlock()
+
+	status := rt.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(rt.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func (rt *recordingTransport) seen() []*url.URL {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]*url.URL(nil), rt.requests...)
+}
+
+// installTransport points the package's glyph client at a stub for one test.
+// Not parallel-safe, deliberately: the client is a package variable, and sharing
+// it between concurrent tests would make the recorded requests meaningless.
+func installTransport(t *testing.T, rt *recordingTransport) {
+	t.Helper()
+
+	original := glyphHTTPClient
+	glyphHTTPClient = &http.Client{Transport: rt}
+	t.Cleanup(func() { glyphHTTPClient = original })
+}
+
+func newGlyphServer(t *testing.T, key string) *Server {
+	t.Helper()
+
+	srv, err := New(config.Config{
+		Port:        0,
+		DataDir:     t.TempDir(),
+		Version:     "test",
+		MapTilerKey: key,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv
+}
+
+// requestGlyphs issues one glyph request through the router, so the route
+// pattern and its {fontstack}/{range} variables are exercised too.
+func requestGlyphs(t *testing.T, srv *Server, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/fonts/{fontstack}/{range}.pbf", srv.handleGlyphProxy).Methods("GET")
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestGlyphProxyUsesConfiguredKey(t *testing.T) {
+	rt := &recordingTransport{body: []byte("glyph-bytes")}
+	installTransport(t, rt)
+
+	srv := newGlyphServer(t, "configured-key")
+
+	rec := requestGlyphs(t, srv, "/fonts/Open%20Sans%20Regular/0-255.pbf")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "glyph-bytes" {
+		t.Errorf("body = %q, want the upstream bytes", got)
+	}
+
+	seen := rt.seen()
+	if len(seen) != 1 {
+		t.Fatalf("made %d upstream requests, want 1", len(seen))
+	}
+	if key := seen[0].Query().Get("key"); key != "configured-key" {
+		t.Errorf("upstream key = %q, want the configured value", key)
+	}
+	if seen[0].Host != "api.maptiler.com" {
+		t.Errorf("upstream host = %q, want api.maptiler.com", seen[0].Host)
+	}
+}
+
+// The important half. Without a key the handler must not call MapTiler at all:
+// a request with an empty key parameter is refused with 403, the proxy would
+// swallow that into the same empty response, and the user would be left with an
+// unlabelled map and no indication that a setting is missing.
+func TestGlyphProxyWithoutKeyMakesNoRequest(t *testing.T) {
+	rt := &recordingTransport{body: []byte("must-not-be-fetched")}
+	installTransport(t, rt)
+
+	srv := newGlyphServer(t, "")
+
+	rec := requestGlyphs(t, srv, "/fonts/Open%20Sans%20Regular/0-255.pbf")
+
+	if n := len(rt.seen()); n != 0 {
+		t.Fatalf("made %d upstream requests with no key configured; the first was %s",
+			n, rt.seen()[0])
+	}
+
+	// Still a valid, empty answer rather than an error: MapLibre retries a 4xx or
+	// 5xx, and draws the map without those labels when handed an empty body.
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 so MapLibre stops asking", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/x-protobuf" {
+		t.Errorf("Content-Type = %q, want application/x-protobuf", ct)
+	}
+}
+
+// A key that is only whitespace is a mis-set variable, not a key.
+func TestGlyphProxyWhitespaceKeyMakesNoRequest(t *testing.T) {
+	rt := &recordingTransport{}
+	installTransport(t, rt)
+
+	srv := newGlyphServer(t, "   \n")
+
+	requestGlyphs(t, srv, "/fonts/Open%20Sans%20Regular/0-255.pbf")
+
+	if n := len(rt.seen()); n != 0 {
+		t.Fatalf("made %d upstream requests for a whitespace-only key", n)
+	}
+}
+
+// writeStyle puts a style.json where handleStyleJSON will find it, carrying the
+// kind of absolute MapTiler glyphs URL that used to be committed.
+func writeStyle(t *testing.T, dataDir, glyphs string) {
+	t.Helper()
+
+	dir := filepath.Join(dataDir, "mbtiles")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	style := map[string]any{
+		"version": 8,
+		"name":    "test",
+		"sources": map[string]any{"t": map[string]any{"type": "vector", "url": "http://elsewhere/tiles.json"}},
+		"glyphs":  glyphs,
+		"layers":  []any{},
+	}
+	data, err := json.Marshal(style)
+	if err != nil {
+		t.Fatalf("marshalling style: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "style.json"), data, 0o644); err != nil {
+		t.Fatalf("writing style.json: %v", err)
+	}
+}
+
+func servedStyle(t *testing.T, srv *Server) map[string]any {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/data/style.json", nil)
+	req.Host = "localhost:8080"
+	srv.handleStyleJSON(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("style status = %d, want 200", rec.Code)
+	}
+	var style map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &style); err != nil {
+		t.Fatalf("style is not JSON: %v", err)
+	}
+	return style
+}
+
+// There is exactly one place the key is injected, and the style is not it.
+//
+// The browser only ever reads the style through this handler, which rewrites
+// glyphs to the local proxy — so a key in the style file on disk was never used
+// for anything, and shipping the served style with a key in it would hand it to
+// every client for no benefit. The proxy holds the key; the style points at the
+// proxy.
+func TestServedStyleCarriesLocalProxyNotTheKey(t *testing.T) {
+	dataDir := t.TempDir()
+	writeStyle(t, dataDir, "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=leaked-key")
+
+	srv, err := New(config.Config{
+		Port:        0,
+		DataDir:     dataDir,
+		Version:     "test",
+		MapTilerKey: "configured-key",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	style := servedStyle(t, srv)
+
+	glyphs, _ := style["glyphs"].(string)
+	if glyphs != "http://localhost:8080/fonts/{fontstack}/{range}.pbf" {
+		t.Errorf("glyphs = %q, want the local proxy URL", glyphs)
+	}
+	if strings.Contains(glyphs, "key=") {
+		t.Errorf("glyphs = %q leaks a key parameter to the browser", glyphs)
+	}
+
+	// Belt and braces over the whole document: neither the key on disk nor the
+	// configured one may reach the client by any other field.
+	body, _ := json.Marshal(style)
+	for _, secret := range []string{"leaked-key", "configured-key", "api.maptiler.com"} {
+		if bytes.Contains(body, []byte(secret)) {
+			t.Errorf("served style contains %q:\n%s", secret, body)
+		}
+	}
+}
+
+// The proxy still has to be reachable from the style when no key is configured:
+// MapLibre needs a glyphs URL for its symbol layers, and the empty responses are
+// what let it render the map without labels rather than fail.
+func TestServedStyleStillPointsAtProxyWithoutKey(t *testing.T) {
+	dataDir := t.TempDir()
+	writeStyle(t, dataDir, "/fonts/{fontstack}/{range}.pbf")
+
+	srv, err := New(config.Config{Port: 0, DataDir: dataDir, Version: "test"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	style := servedStyle(t, srv)
+
+	if glyphs, _ := style["glyphs"].(string); glyphs != "http://localhost:8080/fonts/{fontstack}/{range}.pbf" {
+		t.Errorf("glyphs = %q, want the local proxy URL", glyphs)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,12 @@ type Server struct {
 	glyphCache      sync.Map
 	glyphCacheSizeB atomic.Int64
 
+	// Says once, on the first glyph request, that no MapTiler key is configured.
+	// Once rather than per request: a single map pane asks for a dozen ranges and
+	// grid view multiplies that by four, so logging each one would bury the
+	// message it is trying to deliver.
+	glyphKeyWarning sync.Once
+
 	// Auxiliary tile-only HTTP servers, one per extra localhost port.
 	// HTTP/1.1 caps connections at 6 per origin (host:port). Running N extra
 	// servers on sequential ports gives the browser N extra 6-connection pools
@@ -496,6 +502,18 @@ func (s *Server) handleTileJSON(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(tileJSON)
 }
 
+// writeEmptyGlyphs answers a glyph request with a valid, empty response.
+//
+// MapLibre treats this as "this font has no glyphs in this range" and carries on
+// drawing the map without those labels. It is deliberately not an error status:
+// a 4xx or 5xx makes MapLibre retry, and the whole reason this path exists is
+// that the upstream is not going to answer — no internet, no key, or a CDN that
+// is down. Not cached either, so the next request tries again.
+func writeEmptyGlyphs(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.WriteHeader(http.StatusOK)
+}
+
 // handleGlyphProxy serves MapLibre font glyph PBF files. The first request for
 // each {fontstack}/{range} pair is fetched from the upstream MapTiler CDN and
 // stored in an in-process cache; all subsequent requests (from other map
@@ -513,32 +531,42 @@ func (s *Server) handleGlyphProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upstreamURL := fmt.Sprintf(
-		"https://api.maptiler.com/fonts/%s/%s.pbf?key=cc4PpmmWZP73LjU1nsw3",
-		fontstack, glyphRange,
-	)
+	// No key, no request. The alternative — asking MapTiler for a glyph with an
+	// empty key parameter — is answered with 403, and a 403 here is invisible:
+	// the proxy would fall through to the same empty response below, so the only
+	// evidence of a missing setting would be a map with no labels on it. Refusing
+	// to build the URL at all is what makes the log line above possible.
+	upstreamURL, ok := s.cfg.MapTilerGlyphURL(fontstack, glyphRange)
+	if !ok {
+		s.glyphKeyWarning.Do(func() {
+			log.Printf("Glyph proxy: no MapTiler key configured, so map labels will "+
+				"not be drawn. Set %s, pass --maptiler-key, or add \"maptiler_key\" "+
+				"to settings.json. Everything else works without it.",
+				config.MapTilerKeyEnv)
+		})
+		writeEmptyGlyphs(w)
+		return
+	}
+
 	resp, err := glyphHTTPClient.Get(upstreamURL)
 	if err != nil {
 		// CDN unreachable (no internet, timeout, etc.) — return an empty 200 so
 		// MapLibre skips these glyphs and continues rendering instead of hanging.
 		log.Printf("Glyph proxy: upstream fetch failed for %s/%s: %v", fontstack, glyphRange, err)
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
+		writeEmptyGlyphs(w)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("Glyph proxy: upstream returned %d for %s/%s", resp.StatusCode, fontstack, glyphRange)
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
+		writeEmptyGlyphs(w)
 		return
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
+		writeEmptyGlyphs(w)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ func main() {
 			"application has always used; see issue #65.")
 	satelliteAttribution := flag.String("satellite-attribution", "",
 		"Attribution shown for --satellite-tile-url. Required by most providers' licences.")
+	maptilerKey := flag.String("maptiler-key", "",
+		"MapTiler API key used to fetch map font glyphs. Also read from "+
+			config.MapTilerKeyEnv+" and from maptiler_key in settings.json. "+
+			"Without it the map draws without place labels; nothing else changes.")
 	bindAddress := flag.String("bind", config.DefaultBindAddress,
 		"Interface to listen on. Loopback by default; the API is unauthenticated, "+
 			"so use 0.0.0.0 only where something in front of it controls access.")
@@ -53,11 +57,17 @@ func main() {
 	resolvedDataDir := *dataDir
 	resolvedResourcesDir := *resourcesDir
 
+	// Loaded unconditionally now: the data pack path is not the only thing kept
+	// here any more — a desktop install's MapTiler key is too, and that is needed
+	// whether or not the directories were given on the command line.
+	settings, err := config.LoadSettings()
+	if err != nil {
+		log.Printf("Warning: could not load settings: %v", err)
+		settings = &config.Settings{}
+	}
+
 	if resolvedDataDir == "" || resolvedResourcesDir == "" {
-		settings, err := config.LoadSettings()
-		if err != nil {
-			log.Printf("Warning: could not load settings: %v", err)
-		} else if settings.DataPackPath != "" {
+		if settings.DataPackPath != "" {
 			packData := filepath.Join(settings.DataPackPath, "data")
 			packResources := filepath.Join(settings.DataPackPath, "resources")
 			if _, err := os.Stat(packData); err == nil {
@@ -122,6 +132,7 @@ func main() {
 		BindAddress:          *bindAddress,
 		SatelliteTileURL:     *satelliteTileURL,
 		SatelliteAttribution: *satelliteAttribution,
+		MapTilerKey:          config.ResolveMapTilerKey(*maptilerKey, settings),
 		// --headless is the server build; anything else opens the window below.
 		DesktopMode: !*headless,
 	}

--- a/resources/mbtiles/style.json
+++ b/resources/mbtiles/style.json
@@ -1,7 +1,10 @@
 {
   "version": 8,
   "name": "UoW Tiles",
-  "metadata": {"maputnik:renderer": "mbgljs"},
+  "metadata": {
+    "maputnik:renderer": "mbgljs",
+    "kartoza:glyphs": "Relative on purpose, and rewritten to an absolute URL by the server before this style reaches a browser. It points at the application's own /fonts proxy, which fetches from MapTiler using the key supplied at run time (DT_MAPTILER_API_KEY, --maptiler-key, or maptiler_key in settings.json). Do not put a key in this file: it is tracked in git and copied into every data pack. See issue #31."
+  },
   "center": [32.7, 4.65],
   "zoom": 2.75,
   "sources": {
@@ -11,7 +14,7 @@
     }
   },
   "sprite": "",
-  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=cc4PpmmWZP73LjU1nsw3",
+  "glyphs": "/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "Country Boundaries",


### PR DESCRIPTION
Refs #31

> **Read this first.** `ticket_174` is doing overlapping work and was committed
> the same day. It **already removes the key literal from `server.go`** and reads
> `config.MapTilerAPIKey()`, with a comment covering both the satellite style and
> the glyph proxy. This branch was written without knowing that.
>
> The two do not conflict in intent, and this one covers ground `ticket_174` does
> not — but **`ticket_174` should land first** and this should then be reduced to
> what remains. The environment variable here was already renamed to
> `DT_MAPTILER_API_KEY` to match it.
>
> | | `ticket_174` | this branch |
> | --- | --- | --- |
> | key out of `server.go` | yes | yes |
> | key out of both `style.json` files | **no, still committed** | yes |
> | desktop configuration (`settings.json`) | environment only | yes |
> | escapes `{fontstack}`/`{range}` before interpolation | **no** | yes |

## Where the key was

`cc4PpmmWZP73LjU1nsw3`, in three tracked files:

- `internal/server/server.go:517` — the URL literal. **The only one ever used.**
- `resources/mbtiles/style.json:14` and `data/mbtiles/style.json:14` —
  byte-identical, both tracked (`.gitignore` carries an explicit
  `!data/mbtiles/style.json` exception). Both were **dead data**:
  `handleStyleJSON` overwrites `glyphs` unconditionally with the local proxy URL
  before a browser ever sees it, so the key in those files was never served — but
  it was still committed, and it still ships.

Also in **7 commits** of history (`cd698f3`, `aa38bd4`, `3ac8333`, `e5f0ac7`,
`062ff0a`, and `d7cd03d`/`ceee4ea` on `origin/ticket_174`), in every released
binary, and in **every data pack** — `pack-data` packs
`data/mbtiles/style.json` into each `decision-theatre-data-v*.zip`.

History was not rewritten.

## What changed

One injection point, in the glyph proxy. `Config.MapTilerKey` with no default
compiled in, `Config.MapTilerGlyphURL()` returning `(string, bool)`, and
`ResolveMapTilerKey` reading `--maptiler-key`, then `DT_MAPTILER_API_KEY`, then
`maptiler_key` in `settings.json`. The `settings.json` route exists because a
double-clicked desktop build has neither a command line nor an environment.

The `style.json` files now carry the relative proxy path they were being
rewritten to anyway.

**The fontstack and range path segments are now escaped.** They arrive from the
request and were interpolated straight into the upstream URL, so a crafted font
name could append query parameters to it. This is independent of where the key
comes from and applies to `ticket_174` as well.

**Absent key:** start normally, make no upstream request, answer 200-empty — what
the proxy already did offline, so MapLibre draws without those labels rather than
retrying — and log once naming all three settings. Refusing to start would break
an offline desktop tool over a font CDN; an empty `key=` earns a 403
indistinguishable from a font failure.

## Tests

`go build`, `go vet`, `go test ./...`, `-race`, `golangci-lint` (0 issues) and
`gofmt` all clean. New: `internal/config/maptiler_test.go` (URL built from
config, absent and whitespace-only keys yield no URL, escaping, precedence,
settings round-trip) and `internal/server/glyph_test.go`, where a stub transport
proves **zero** upstream requests are made without a key, and that the served
style carries the proxy URL and never the key — neither the configured one nor
one left on disk.

Documented in `server-deployment.md` (new variable, plus a "map has no labels"
troubleshooting entry), `install-the-application.md`, `api.md`,
`SPECIFICATION.md`, both `.env.example` files, and the compose `environment:`
block — not a `command:` flag, since that file is tracked and flags show in `ps`.

`.gitleaksignore`'s "public by design" rationale was wrong — the server proxies,
so the browser never saw the key — and is corrected.

## This does not close #31

Removing the key from the tree does not un-leak it. **It must still be revoked**,
and the replacement set in `deployments/.env` plus `--force-recreate app` for the
hosted deployment, and `settings.json` for desktop.

**The desktop regression is the part to weigh:** shipped builds have the key
compiled in, so upgrading users lose map labels with no interface to fix it —
hand-editing `settings.json` is the only path. `NOTES-maptiler.md` has the full
handover.

Unverified: whether the key has been abused, whether the claimed MapTiler domain
restriction exists, and whether the TLS key from `3ac8333` was actually rotated
as `.gitleaksignore` asserts.
