### PR TITLE
fix(server): exclude range requests from the static gzip cache to fix HTTP/2 walkthrough errors

### DIFF
--- a/internal/api/real_datapack_test.go
+++ b/internal/api/real_datapack_test.go
@@ -35,7 +35,7 @@ func realDatapackRouter(t *testing.T, dir string) *mux.Router {
 	}
 	t.Cleanup(store.Close)
 
-	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"}, nil)
 	r := mux.NewRouter()
 	handler.RegisterRoutes(r)
 	return r

--- a/internal/api/site_summary_test.go
+++ b/internal/api/site_summary_test.go
@@ -55,7 +55,7 @@ func newSiteTestHandler(t *testing.T, doctor ...string) *mux.Router {
 	}
 	t.Cleanup(store.Close)
 
-	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"})
+	handler := NewHandler(nil, store, nil, config.Config{DataDir: dir, Version: "test"}, nil)
 	r := mux.NewRouter()
 	handler.RegisterRoutes(r)
 	return r

--- a/internal/server/staticcache.go
+++ b/internal/server/staticcache.go
@@ -100,6 +100,19 @@ func (c *compressedStatic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A Range request must be answered against the real, uncompressed bytes.
+	// entry.body is already gzip-compressed, so slicing it here would hand
+	// http.ServeContent nothing to compute a meaningful Content-Range from: it
+	// would describe an offset into the compressed stream while Content-Encoding
+	// still claims gzip, a combination browsers reject under HTTP/2 with
+	// ERR_HTTP2_PROTOCOL_ERROR. This is the same framing bug isPartialContent
+	// (compress.go) fixes for the streaming compressor, reintroduced here because
+	// this cache pre-compresses before ServeContent ever sees the request.
+	if r.Header.Get("Range") != "" {
+		c.fallback.ServeHTTP(w, r)
+		return
+	}
+
 	name := path.Clean("/" + r.URL.Path)
 	f, err := c.fs.Open(name)
 	if err != nil {

--- a/internal/server/staticcache_test.go
+++ b/internal/server/staticcache_test.go
@@ -141,6 +141,41 @@ func TestCompressedStaticAnswers304(t *testing.T) {
 	}
 }
 
+// A Range request must fall back to the uncompressed file rather than slicing
+// the cached gzip body: ServeContent would describe the slice with a
+// Content-Range naming offsets into the compressed stream while
+// Content-Encoding still says gzip, a combination Chrome rejects under HTTP/2
+// with ERR_HTTP2_PROTOCOL_ERROR. This is what surfaced in production for large
+// walkthrough documents when the browser resumed an interrupted download with
+// a Range request.
+func TestCompressedStaticRangeRequestIsNotCompressed(t *testing.T) {
+	dir := writeStatic(t, "tour.json", 200_000)
+	want, err := os.ReadFile(filepath.Join(dir, "tour.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newCompressedStatic(http.Dir(dir))
+
+	// Prime the cache, so the compressed entry exists and could be sliced if the
+	// bug were still present.
+	getStatic(t, h, "/tour.json", map[string]string{"Accept-Encoding": "gzip"})
+
+	rec := getStatic(t, h, "/tour.json", map[string]string{
+		"Accept-Encoding": "gzip",
+		"Range":           "bytes=0-99",
+	})
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+	if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("Content-Encoding = %q on a 206, would corrupt the range framing", enc)
+	}
+	if got := rec.Body.Bytes(); !bytes.Equal(got, want[:100]) {
+		t.Errorf("range body = %d bytes, want the first 100 bytes of the uncompressed file", len(got))
+	}
+}
+
 // A client that did not offer gzip must not be handed a compressed body.
 func TestCompressedStaticHonoursAcceptEncoding(t *testing.T) {
 	dir := writeStatic(t, "tour.json", 200_000)


### PR DESCRIPTION
- compressedStatic (used for /data/walkthroughs/*) pre-compresses files and serves them via http.ServeContent, which doesn't know the cached body is already gzipped. A Range request — which Chrome sends automatically to resume an interrupted download — got sliced against the compressed bytes, producing a 206 with Content-Range offsets into the gzip stream while Content-Encoding: gzip was still set. Browsers reject that combination under HTTP/2 with ERR_HTTP2_PROTOCOL_ERROR, the same bug class an earlier fix addressed in the streaming compressor but not in this separate static-file cache. Range requests now fall back to the uncompressed file server, which handles them correctly. Includes a regression test verified to fail on the old code.