### PR TITLE
feat(ux): one set of map controls, and the panes get their space back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One set of map controls, in the header, instead of thirty-six buttons.** Three
+  bands of controls competed for the most space-starved screen in the application.
+  A full-width bar above the panes held the view-mode, range-mode, add-pane and
+  target controls; each pane carried a vertical stack of six circular buttons — 3D,
+  choropleth, identify, satellite, swiper and zoom-to-site; and the header had a
+  `Spacer` between the site title and the navigation holding nothing at all.
+
+  Every one of those per-pane buttons already acted on *all* panes: they were one
+  setting drawn six times, and clicking any copy moved all six. A six-pane grid drew
+  36 buttons for 6 settings. They are drawn once now, in the space the header was
+  wasting, and the bar is deleted rather than hidden — returning a full horizontal
+  band of vertical space to the widgets.
+
+  The controls that genuinely belong to one pane — focus, configure factor, remove,
+  calculation details — stay in that pane. Six panes legitimately need six focus
+  buttons, and that is not duplication.
+
+  State moved to `App`, which is where it always belonged given what it did.
+  `MapView` now reads these as props and applies them through effects; only the
+  basemap still reports back, because the satellite-quota revert happens down
+  there. Zoom-to-site is a `dt:zoom-to-site` window event — the header cannot reach
+  a pane's MapLibre instance, and the guided tour's existing listener already
+  handled the readiness and deferral cases.
+
+  Accessibility along the way: the view and range switches are `radiogroup`s with
+  one tab stop, arrow-key traversal and `aria-checked`, where they had been
+  independent `IconButton`s conveying selection through background colour alone;
+  the toggles carry `aria-pressed` and an underline as well as a fill. Below `xl`
+  the full set collapses to the view switch plus the toggles, and below `md` into an
+  overflow menu that carries every control — not `display: none`.
+
 - **The sites list no longer downloads five megabytes of demo content to show a
   list of titles.** `listSites` fetched and parsed all four walkthrough documents —
   **5,025,346 bytes**, one of them 4 MB — on the path to first render, for demos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Blank map panes, and fifteen seconds of spinner, on a server with no imagery
+  provider.** Maps were constructed against `/api/satellite-style.json` whenever
+  the runtime was a browser, without waiting to learn whether satellite was
+  configured. On a deployment with no key that endpoint returns **404 text/plain**,
+  MapLibre cannot load the style, and a map whose style never loads **never fires
+  its `load` event** — so the pane sat behind its spinner until the 15-second
+  safety net gave up, six panes at a time, on every load.
+
+  `satelliteConfirmed()` now answers the question a style URL actually depends on:
+  has the server *said yes*, rather than *not yet said no*. The optimism that is
+  right for whether to enable the control is wrong for whether a URL is safe to
+  fetch, and the two differ for exactly the window in which a map is built.
+
+  The recovery is symmetric now, too. The listener only handled satellite
+  *becoming* unavailable, so a map built before `/api/info` resolved stayed on the
+  built-in style for the rest of the session even once a key was confirmed. It
+  re-applies what the user asked for against what is currently possible, which
+  covers both directions in one call. Intent is kept separate from what is on the
+  map, so "we do not know yet" can no longer be mistaken for a choice; only a real
+  loss switches the toggle off and says so.
+
+
 - **A walkthrough's charts, dials and aggregate table emptied thirty seconds after
   opening it.** The per-catchment breakdown ships embedded in the walkthrough
   document and is primed into an in-memory cache on load. That cache expires after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a pane's MapLibre instance, and the guided tour's existing listener already
   handled the readiness and deferral cases.
 
+  What is left on a pane — focus it, configure its factor, remove it, drag its
+  compare swiper — **appears on mouse over** rather than sitting on top of the data
+  all the time. Those controls could not move to the header the way the global
+  toggles did: they act on one pane, so six panes legitimately need six of them.
+  They get out of the way instead. One stylesheet covers both halves of that
+  chrome, the React toolbar and the imperatively-built swiper handle, so their
+  timing cannot drift apart. The swiper's divider line stays visible: it marks
+  which side of the comparison is which, and is information rather than a control.
+
+  The hiding is scoped to `@media (hover: hover) and (pointer: fine)`, because on a
+  touch screen there is no hover to bring a control back with; it lifts on
+  `:focus-within` as well as `:hover`, so a keyboard user can see where they are;
+  and it lifts entirely while a guided tour is running, since two of these
+  elements are tour spotlight targets and a ring drawn around something invisible
+  is worse than no ring.
+
   Accessibility along the way: the view and range switches are `radiogroup`s with
   one tab stop, arrow-key traversal and `aria-checked`, where they had been
   independent `IconButton`s conveying selection through background colour alone;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chrome, the React toolbar and the imperatively-built swiper handle, so their
   timing cannot drift apart. The swiper's divider line stays visible: it marks
   which side of the comparison is which, and is information rather than a control.
+  It does thin from 12px to 3px at rest, though, and widens with everything else
+  on hover — most of that width exists to be grabbed, which only matters once the
+  pointer is on the pane. Its width, fill and shadow used to be set inline from
+  JavaScript in six places across two duplicated blocks; they are one CSS rule
+  now, and `MapView` sets a `data-docked` attribute and nothing else.
 
   The hiding is scoped to `@media (hover: hover) and (pointer: fine)`, because on a
   touch screen there is no hover to bring a control back with; it lifts on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   half the size: 13–14px type at 6–8px padding becomes 10px at 2px, taking the
   scenario labels from roughly 28px tall to 16px and the factor label from 33px to
   16px. The three were three copies of the same twelve declarations and now share
-  one base, with each supplying only its position and its exposed corners.
+  one base, with each supplying only its position and its exposed corners. The
+  scenario colour accent on the left label moved to that label's right edge, so
+  both accents face the map between them: with the label flush in the corner, an
+  accent on its outer edge reads as part of the pane frame rather than as the
+  scenario's colour.
 
   Accessibility along the way: the view and range switches are `radiogroup`s with
   one tab stop, arrow-key traversal and `aria-checked`, where they had been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JavaScript in six places across two duplicated blocks; they are one CSS rule
   now, and `MapView` sets a `data-docked` attribute and nothing else.
 
+  **One zoom cluster for the grid, not six.** Every map drew its own zoom in /
+  zoom out / compass control at the bottom left. They were not six controls: every
+  map registers with `useMapSync`, and moving any one moves all the others, so all
+  six did the same thing to the same six maps. It now appears on the bottom-left
+  map only — resolved against what is actually showing a map, so a grid whose
+  bottom-left widget is a chart still has a zoom control, one row up or one column
+  across. The choice is recomputed rather than fixed, because panes are removable,
+  the columns toggle between two and three, and a pane can switch view at any time.
+
   The hiding is scoped to `@media (hover: hover) and (pointer: fine)`, because on a
   touch screen there is no hover to bring a control back with; it lifts on
   `:focus-within` as well as `:hover`, so a keyboard user can see where they are;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   labels are also about half the size — 13px type at 6px padding becomes 10px at
   2px, roughly 28px tall down to 16px. The factor label keeps its original type
   and padding: it names what the pane is showing, where the scenario names either
-  side are supporting text. The three were three copies of the same twelve declarations and now share
+  side are supporting text.
+
+  **And the scenario labels collapse to their colour accent at rest**, expanding
+  again on hover or focus. The question they answer — which side of the swiper is
+  which — only matters once someone is looking at that pane, and the answer
+  survives the collapse: each carries a 3px edge in its scenario's colour, and
+  that edge is what is left behind. A six-pane grid goes from eighteen pills to
+  six titles and twelve coloured ticks. The factor label is deliberately not in
+  the set: a grid of six unlabelled maps is the thing worth avoiding, and it has
+  no accent to be left with. The three were three copies of the same twelve declarations and now share
   one base, with each supplying only its position and its exposed corners. The
   scenario colour accent on the left label moved to that label's right edge, so
   both accents face the map between them: with the label flush in the corner, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,10 +201,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the top-left corner with only its bottom-right corner rounded, the factor
   centred under the top edge with both bottom corners rounded, the scenario on the
   right into the top-right corner with only its bottom-left — so they read as part
-  of the pane frame rather than as objects on top of the map. They are also about
-  half the size: 13–14px type at 6–8px padding becomes 10px at 2px, taking the
-  scenario labels from roughly 28px tall to 16px and the factor label from 33px to
-  16px. The three were three copies of the same twelve declarations and now share
+  of the pane frame rather than as objects on top of the map. The two scenario
+  labels are also about half the size — 13px type at 6px padding becomes 10px at
+  2px, roughly 28px tall down to 16px. The factor label keeps its original type
+  and padding: it names what the pane is showing, where the scenario names either
+  side are supporting text. The three were three copies of the same twelve declarations and now share
   one base, with each supplying only its position and its exposed corners. The
   scenario colour accent on the left label moved to that label's right edge, so
   both accents face the map between them: with the label flush in the corner, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,8 +210,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **And the scenario labels collapse to their colour accent at rest**, expanding
   again on hover or focus. The question they answer — which side of the swiper is
   which — only matters once someone is looking at that pane, and the answer
-  survives the collapse: each carries a 3px edge in its scenario's colour, and
-  that edge is what is left behind. A six-pane grid goes from eighteen pills to
+  survives the collapse: what is left is a 9px tick filled with that scenario's
+  own colour, text hidden, so the coding that made the label useful is the part
+  that stays. A six-pane grid goes from eighteen pills to
   six titles and twelve coloured ticks. The factor label is deliberately not in
   the set: a grid of six unlabelled maps is the thing worth avoiding, and it has
   no accent to be left with. The three were three copies of the same twelve declarations and now share

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   elements are tour spotlight targets and a ring drawn around something invisible
   is worse than no ring.
 
+  **The pane labels hang from the top edge instead of floating over the data.**
+  The two scenario names and the factor between them sat inset 12px from the top
+  corners as rounded pills, six panes' worth. They are pulled flush now — left into
+  the top-left corner with only its bottom-right corner rounded, the factor
+  centred under the top edge with both bottom corners rounded, the scenario on the
+  right into the top-right corner with only its bottom-left — so they read as part
+  of the pane frame rather than as objects on top of the map. They are also about
+  half the size: 13–14px type at 6–8px padding becomes 10px at 2px, taking the
+  scenario labels from roughly 28px tall to 16px and the factor label from 33px to
+  16px. The three were three copies of the same twelve declarations and now share
+  one base, with each supplying only its position and its exposed corners.
+
   Accessibility along the way: the view and range switches are `radiogroup`s with
   one tab stop, arrow-key traversal and `aria-checked`, where they had been
   independent `IconButton`s conveying selection through background colour alone;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,12 @@ function App() {
   const [isSwiperEnabled, setIsSwiperEnabled] = useState(true);
   const [mapRefreshSeq, setMapRefreshSeq] = useState(0);
   const [is3DMode, setIs3DMode] = useState(false);
+  // These three used to be state inside every MapView, toggled by a button
+  // stack repeated on each pane — six copies of one setting. They act on the
+  // whole grid, so they live here and the header owns the single control.
+  const [isIdentifyMode, setIsIdentifyMode] = useState(false);
+  const [isChoroplethEnabled, setIsChoroplethEnabled] = useState(true);
+  const [isGoogleBasemap, setIsGoogleBasemap] = useState(() => getAppRuntime() === 'browser');
   const colorScaleMode: ColorScaleMode = 'metadata';
   const [colorScaleType, setColorScaleType] = useState<ColorScaleType>('linear');
   const [rangeMode, setRangeMode] = useState<RangeMode>(loadRangeMode);
@@ -1167,6 +1173,16 @@ function App() {
           hasTargets: hasEditableTargets,
           siteId: currentSiteId,
           isExtracting: isExtractingIndicators,
+          is3DMode,
+          onIs3DModeChange: setIs3DMode,
+          isChoroplethEnabled,
+          onChoroplethEnabledChange: setIsChoroplethEnabled,
+          isIdentifyMode,
+          onIdentifyModeChange: setIsIdentifyMode,
+          isGoogleBasemap,
+          onGoogleBasemapChange: setIsGoogleBasemap,
+          isSwiperEnabled,
+          onSwiperEnabledChange: setIsSwiperEnabled,
         }}
       />
 
@@ -1199,11 +1215,13 @@ function App() {
             siteGeometry={currentSite?.geometry}
             onBoundaryUpdate={handleBoundaryUpdate}
             isSwiperEnabled={isSwiperEnabled}
-            onSwiperEnabledChange={setIsSwiperEnabled}
             colorScaleMode={colorScaleMode}
             colorScaleType={colorScaleType}
             is3DMode={is3DMode}
-            on3DModeChange={setIs3DMode}
+            isIdentifyMode={isIdentifyMode}
+            isChoroplethEnabled={isChoroplethEnabled}
+            isGoogleBasemap={isGoogleBasemap}
+            onGoogleBasemapChange={setIsGoogleBasemap}
             swiperPosition={swiperPosition}
             onSwiperPositionChange={setSwiperPosition}
             siteIndicators={currentSite?.indicators}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, Flex, useDisclosure, useToast } from '@chakra-ui/react';
 import ContentArea from './components/ContentArea';
 import ControlPanel from './components/ControlPanel';
@@ -15,7 +15,8 @@ import IndicatorEditorPage from './components/IndicatorEditorPage';
 import DownloadPage from './components/DownloadPage';
 import FeedbackLink from './components/FeedbackLink';
 import ResumeSessionModal from './components/ResumeSessionModal';
-import { patchSite, patchSiteIndicators, useServerInfo, getSite, useFullDomainPrecalculated, primeSiteCatchmentsFromEmbedded, saveLocalSite, useAttributeDetails, useAttributeVariableTypes, useAttributeUserInputs } from './hooks/useApi';
+import { editableTargetKeys } from './lib/editableTargets';
+import { patchSite, patchSiteIndicators, useServerInfo, getSite, useFullDomainPrecalculated, primeSiteCatchmentsFromEmbedded, saveLocalSite, useAttributeDetails, useAttributeVariableTypes, useAttributeUserInputs, useAttributeTargetInputs } from './hooks/useApi';
 import { getAppRuntime } from './types/runtime';
 import { showTargetWarningsPopup, showLowDataAvailabilityWarning, computeIndicatorAvailabilityFraction } from './utils/warnings';
 import type { Scenario, LayoutMode, QuadColumns, PaneStates, ComparisonState, AppPage, Site, IdentifyResult, MapExtent, MapStatistics, ColorScaleMode, ColorScaleType, RangeMode, ViewMode } from './types';
@@ -795,6 +796,19 @@ function App() {
     return () => window.removeEventListener('dt:demo-pane-state', handler);
   }, [handlePaneStateChange]);
 
+  const { targetInputs } = useAttributeTargetInputs();
+  const hasEditableTargets = useMemo(
+    () => editableTargetKeys(currentSite?.indicators, targetInputs, variableTypes, attributeDetails).length > 0,
+    [currentSite?.indicators, targetInputs, variableTypes, attributeDetails],
+  );
+
+  // The grid-wide controls act on every pane, so they take no pane index. The
+  // old signature took one and ignored it in quad layout, which read as a
+  // per-pane control and was not.
+  const handleGridViewModeChange = useCallback((mode: ViewMode) => {
+    setViewModes((prev) => prev.map(() => mode));
+  }, []);
+
   const handleViewModeChange = useCallback((paneIndex: number, mode: ViewMode) => {
     setViewModes((prev) => {
       if (layoutMode === 'quad') {
@@ -1143,6 +1157,17 @@ function App() {
         isBoundaryEditMode={isBoundaryEditMode}
         onToggleTargetModal={handleToggleTargetModal}
         isTargetModalOpen={isTargetModalOpen}
+        gridControls={{
+          viewMode: viewModes[focusedPane] ?? viewModes[0] ?? 'map',
+          onViewModeChange: handleGridViewModeChange,
+          rangeMode,
+          onRangeModeChange: setRangeMode,
+          onAddPane: handleAddPane,
+          onOpenTargets: handleToggleTargetModal,
+          hasTargets: hasEditableTargets,
+          siteId: currentSiteId,
+          isExtracting: isExtractingIndicators,
+        }}
       />
 
       <Flex flex={1} overflow="hidden" position="relative">
@@ -1162,7 +1187,6 @@ function App() {
             onFocusPane={handleFocusPane}
             onGoQuad={handleGoQuad}
             onOpenControlPanel={handleOpenGridControlPanel}
-            onAddPane={handleAddPane}
             onRemovePane={handleRemovePane}
             onIdentify={handleIdentify}
             identifyResult={identifyResult}
@@ -1191,9 +1215,7 @@ function App() {
             chartGraphModes={chartGraphModes}
             mapExtent={mapExtent}
             onSiteIndicatorsChange={handleSiteIndicatorsChange}
-            isExtractingIndicators={isExtractingIndicators}
             isTargetModalOpen={isTargetModalOpen}
-            onOpenTargetModal={onOpenTargetModal}
             onCloseTargetModal={onCloseTargetModal}
             refreshKey={mapRefreshSeq}
             quadColumns={quadColumns}

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -29,11 +29,14 @@ interface ContentAreaProps {
   siteGeometry?: GeoJSON.Geometry | null;
   onBoundaryUpdate?: (geometry: GeoJSON.Geometry) => void;
   isSwiperEnabled?: boolean;
-  onSwiperEnabledChange?: (enabled: boolean) => void;
   colorScaleMode: ColorScaleMode;
   colorScaleType: ColorScaleType;
   is3DMode?: boolean;
-  on3DModeChange?: (enabled: boolean) => void;
+  // Global map toggles: one control in the header, every pane reflects it.
+  isIdentifyMode?: boolean;
+  isChoroplethEnabled?: boolean;
+  isGoogleBasemap?: boolean;
+  onGoogleBasemapChange?: (enabled: boolean) => void;
   // Slider synchronization
   swiperPosition?: number;
   onSwiperPositionChange?: (position: number) => void;
@@ -107,11 +110,13 @@ function ContentArea({
   siteGeometry,
   onBoundaryUpdate,
   isSwiperEnabled,
-  onSwiperEnabledChange,
   colorScaleMode,
   colorScaleType,
   is3DMode,
-  on3DModeChange,
+  isIdentifyMode,
+  isChoroplethEnabled,
+  isGoogleBasemap,
+  onGoogleBasemapChange,
   swiperPosition,
   onSwiperPositionChange,
   siteIndicators,
@@ -340,11 +345,13 @@ function ContentArea({
                   siteGeometry={siteGeometry}
                   onBoundaryUpdate={onBoundaryUpdate}
                   isSwiperEnabled={isSwiperEnabled}
-                  onSwiperEnabledChange={onSwiperEnabledChange}
                   colorScaleMode={colorScaleMode}
                   colorScaleType={colorScaleType}
                   is3DMode={is3DMode}
-                  on3DModeChange={on3DModeChange}
+                  isIdentifyMode={isIdentifyMode}
+                  isChoroplethEnabled={isChoroplethEnabled}
+                  isGoogleBasemap={isGoogleBasemap}
+                  onGoogleBasemapChange={onGoogleBasemapChange}
                   swiperPosition={swiperPosition}
                   onSwiperPositionChange={onSwiperPositionChange}
                   siteIndicators={siteIndicators}
@@ -393,11 +400,13 @@ function ContentArea({
             siteGeometry={siteGeometry}
             onBoundaryUpdate={onBoundaryUpdate}
             isSwiperEnabled={isSwiperEnabled}
-            onSwiperEnabledChange={onSwiperEnabledChange}
             colorScaleMode={colorScaleMode}
             colorScaleType={colorScaleType}
             is3DMode={is3DMode}
-            on3DModeChange={on3DModeChange}
+            isIdentifyMode={isIdentifyMode}
+            isChoroplethEnabled={isChoroplethEnabled}
+            isGoogleBasemap={isGoogleBasemap}
+            onGoogleBasemapChange={onGoogleBasemapChange}
             swiperPosition={swiperPosition}
             onSwiperPositionChange={onSwiperPositionChange}
             siteIndicators={siteIndicators}

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -2,7 +2,6 @@ import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPane
 import { motion, AnimatePresence } from 'framer-motion';
 import ViewPane from './ViewPane';
 import { navigationPaneIndex } from '../lib/navigationPane';
-import { editableTargetKeys as editableTargetKeysFor } from '../lib/editableTargets';
 import { DEFAULT_PANE_STATES } from '../types';
 import type { LayoutMode, QuadColumns, PaneStates, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, SiteIndicators, RangeMode, ViewMode } from '../types';
 import { useAttributeDetails, useAttributeOrder, useAttributeTargetInputs, useAttributeTargetRanges, useAttributeUnits, useAttributeVariableTypes } from '../hooks/useApi';

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -1,7 +1,7 @@
-import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box, Button, FormControl, FormLabel, HStack, IconButton, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Slider, SliderFilledTrack, SliderThumb, SliderTrack, Spinner, Tooltip, VStack, useToast } from '@chakra-ui/react';
+import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box, Button, FormControl, FormLabel, HStack, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Slider, SliderFilledTrack, SliderThumb, SliderTrack, VStack, useToast } from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FiActivity, FiBarChart2, FiEdit2, FiGlobe, FiMap, FiPlus, FiSquare, FiTable, FiTarget } from 'react-icons/fi';
 import ViewPane from './ViewPane';
+import { editableTargetKeys as editableTargetKeysFor } from '../lib/editableTargets';
 import { DEFAULT_PANE_STATES } from '../types';
 import type { LayoutMode, QuadColumns, PaneStates, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, SiteIndicators, RangeMode, ViewMode } from '../types';
 import { useAttributeDetails, useAttributeTargetInputs, useAttributeTargetRanges, useAttributeUnits, useAttributeVariableTypes } from '../hooks/useApi';
@@ -17,7 +17,6 @@ interface ContentAreaProps {
   onFocusPane: (index: number) => void;
   onGoQuad: () => void;
   onOpenControlPanel?: (paneIndex: number) => void;
-  onAddPane: () => void;
   onRemovePane: (paneIndex: number) => void;
   onIdentify?: (result: IdentifyResult) => void;
   identifyResult?: IdentifyResult;
@@ -48,10 +47,8 @@ interface ContentAreaProps {
   chartGraphModes?: ('line' | 'boxplot' | null)[];
   mapExtent?: MapExtent | null;
   onSiteIndicatorsChange?: (indicators: SiteIndicators) => Promise<void> | void;
-  isExtractingIndicators?: boolean;
   // For target modal control from parent
   isTargetModalOpen?: boolean;
-  onOpenTargetModal?: () => void;
   onCloseTargetModal?: () => void;
   refreshKey?: number;
   quadColumns?: QuadColumns;
@@ -81,21 +78,6 @@ const paneVariants = {
   }),
 };
 
-const QUAD_VIEW_MODE_CONFIG: Record<ViewMode, { icon: React.ReactElement; label: string }> = {
-  map: { icon: <FiMap />, label: 'Map' },
-  chart: { icon: <FiBarChart2 />, label: 'Chart' },
-  dial: { icon: <FiActivity />, label: 'Dial' },
-  table: { icon: <FiTable />, label: 'Table' },
-};
-
-const QUAD_VIEW_MODES: ViewMode[] = ['map', 'chart', 'dial', 'table'];
-
-const RANGE_MODE_CONFIG: { id: RangeMode; label: string; icon: React.ReactElement }[] = [
-  { id: 'domain', label: 'Full', icon: <FiGlobe size={14} /> },
-  { id: 'extent', label: 'Extent', icon: <FiSquare size={14} /> },
-  { id: 'site', label: 'Site', icon: <FiTarget size={14} /> },
-];
-
 function formatVariableType(value: string): string {
   return value
     .replace(/_/g, ' ')
@@ -113,7 +95,6 @@ function ContentArea({
   onFocusPane,
   onGoQuad,
   onOpenControlPanel,
-  onAddPane,
   onRemovePane,
   onIdentify,
   identifyResult,
@@ -142,9 +123,7 @@ function ContentArea({
   chartGraphModes,
   mapExtent,
   onSiteIndicatorsChange,
-  isExtractingIndicators,
   isTargetModalOpen,
-  onOpenTargetModal,
   onCloseTargetModal,
   refreshKey,
   quadColumns = 2,
@@ -162,40 +141,11 @@ function ContentArea({
   const [isSavingTargets, setIsSavingTargets] = useState(false);
   const isQuad = mode === 'quad';
   const minimumQuadPaneCount = DEFAULT_PANE_STATES.length;
-  const quadActiveMode: ViewMode = viewModes[focusedPane] ?? viewModes[0] ?? 'map';
 
-  const editableTargetKeys = useMemo(() => {
-    const availableKeys = new Set<string>();
-    Object.keys(siteIndicators?.ideal ?? {}).forEach((k) => availableKeys.add(k));
-    Object.keys(siteIndicators?.reference ?? {}).forEach((k) => availableKeys.add(k));
-    Object.keys(siteIndicators?.current ?? {}).forEach((k) => availableKeys.add(k));
-
-    const keys = Object.entries(targetInputs)
-      .filter(([, allowed]) => allowed)
-      .map(([key]) => key)
-      .filter((key) => availableKeys.has(key))
-      .filter((key) => {
-        const refVal = siteIndicators?.reference?.[key];
-        const curVal = siteIndicators?.current?.[key];
-        return (typeof refVal === 'number' && Number.isFinite(refVal)) ||
-               (typeof curVal === 'number' && Number.isFinite(curVal));
-      })
-      .filter((key) => {
-        if (variableTypes[key] !== 'Herbivores') return true;
-        const refVal = siteIndicators?.reference?.[key];
-        const curVal = siteIndicators?.current?.[key];
-        const refNum = typeof refVal === 'number' && Number.isFinite(refVal) ? refVal : 0;
-        const curNum = typeof curVal === 'number' && Number.isFinite(curVal) ? curVal : 0;
-        return refNum > 0 || curNum > 0;
-      });
-    return keys
-      .filter((key, idx, arr) => arr.indexOf(key) === idx)
-      .sort((a, b) => {
-        const aLabel = attributeDetails[a] ?? a;
-        const bLabel = attributeDetails[b] ?? b;
-        return aLabel.localeCompare(bLabel);
-      });
-  }, [attributeDetails, siteIndicators, targetInputs, variableTypes]);
+  const editableTargetKeys = useMemo(
+    () => editableTargetKeysFor(siteIndicators, targetInputs, variableTypes, attributeDetails),
+    [attributeDetails, siteIndicators, targetInputs, variableTypes],
+  );
 
   const targetGroups = useMemo(() => {
     const groups = new Map<string, string[]>();
@@ -256,9 +206,6 @@ function ContentArea({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTargetModalOpen]);
 
-  const openTargetModal = () => {
-    if (typeof onOpenTargetModal === 'function') onOpenTargetModal();
-  };
 
   // Broadcast open/close so the guided tour can hide itself while the modal
   // is visible. Using a ref to skip the initial mount dispatch.
@@ -334,103 +281,13 @@ function ContentArea({
       display="flex"
       flexDirection="column"
     >
-      {isQuad && (
-        <HStack
-          spacing={1}
-          px={2}
-          py={2}
-          bg="gray.800"
-          borderBottom="1px"
-          borderColor="gray.700"
-          justify="center"
-        >
-          {QUAD_VIEW_MODES.map((viewMode) => {
-            const config = QUAD_VIEW_MODE_CONFIG[viewMode];
-            const isActive = quadActiveMode === viewMode;
-            return (
-              <Tooltip key={viewMode} label={`Show ${config.label} in all panes`} placement="bottom">
-                <IconButton
-                  aria-label={`Show ${config.label} in all panes`}
-                  icon={config.icon}
-                  onClick={() => onViewModeChange(focusedPane, viewMode)}
-                  variant="ghost"
-                  color={isActive ? 'white' : 'gray.300'}
-                  bg={isActive ? 'cyan.500' : 'transparent'}
-                  _hover={{ bg: isActive ? 'cyan.400' : 'whiteAlpha.200' }}
-                  size="sm"
-                  borderRadius="md"
-                />
-              </Tooltip>
-            );
-          })}
-
-          {onRangeModeChange && (
-            <HStack spacing={1} pl={2} ml={2} borderLeft="1px" borderColor="gray.600">
-              {RANGE_MODE_CONFIG.map((mode) => {
-                const isActive = rangeMode === mode.id;
-                const isDisabled = mode.id === 'site' && !siteId;
-                return (
-                  <Tooltip key={mode.id} label={isDisabled ? 'No site selected' : `${mode.label} range`} placement="bottom">
-                    <Button
-                      size="sm"
-                      leftIcon={mode.icon as React.ReactElement}
-                      onClick={() => !isDisabled && onRangeModeChange(mode.id)}
-                      variant="ghost"
-                      bg={isActive ? 'cyan.500' : 'transparent'}
-                      color={isActive ? 'white' : isDisabled ? 'gray.600' : 'gray.300'}
-                      _hover={{ bg: isDisabled ? 'transparent' : isActive ? 'cyan.400' : 'whiteAlpha.200' }}
-                      fontSize="xs"
-                      fontWeight={isActive ? '600' : '400'}
-                      px={3}
-                      cursor={isDisabled ? 'not-allowed' : 'pointer'}
-                    >
-                      {mode.label}
-                    </Button>
-                  </Tooltip>
-                );
-              })}
-            </HStack>
-          )}
-
-          <Tooltip label="Add pane" placement="bottom">
-            <IconButton
-              aria-label="Add pane"
-              icon={<FiPlus />}
-              onClick={onAddPane}
-              variant="ghost"
-              color="gray.200"
-              _hover={{ bg: 'whiteAlpha.200' }}
-              size="sm"
-              borderRadius="md"
-              ml={2}
-            />
-          </Tooltip>
-
-          {isExtractingIndicators && !siteIndicators && (
-            <HStack spacing={2} ml={2} color="gray.400">
-              <Spinner size="xs" color="cyan.400" />
-              <Box fontSize="sm">Extracting indicators…</Box>
-            </HStack>
-          )}
-
-          {siteIndicators && editableTargetKeys.length > 0 && (
-            <Tooltip label="Edit target values" placement="bottom">
-              <Button
-                id="demo-edit-targets-btn"
-                size="sm"
-                leftIcon={<FiEdit2 size={14} />}
-                onClick={openTargetModal}
-                variant="ghost"
-                color="gray.200"
-                _hover={{ bg: 'whiteAlpha.200' }}
-                ml={2}
-              >
-                Targets
-              </Button>
-            </Tooltip>
-          )}
-        </HStack>
-      )}
+      {/*
+        The grid-wide controls used to be a full-width bar here: four view-mode
+        icons, three range-mode buttons, add-pane and the target editor. They
+        cost a horizontal band of vertical space on the most space-starved
+        screen in the application, and they are now in the header, in a gap that
+        was empty. See GridControls.
+      */}
 
       <Box
         position="relative"

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -1,6 +1,7 @@
 import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box, Button, FormControl, FormLabel, HStack, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Slider, SliderFilledTrack, SliderThumb, SliderTrack, VStack, useToast } from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import ViewPane from './ViewPane';
+import { navigationPaneIndex } from '../lib/navigationPane';
 import { editableTargetKeys as editableTargetKeysFor } from '../lib/editableTargets';
 import { DEFAULT_PANE_STATES } from '../types';
 import type { LayoutMode, QuadColumns, PaneStates, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, SiteIndicators, RangeMode, ViewMode } from '../types';
@@ -278,6 +279,16 @@ function ContentArea({
     ? paneStates.map((_, index) => index)
     : [Math.min(focusedPane, Math.max(0, paneStates.length - 1))];
 
+  // One zoom cluster for the whole grid, on the bottom-left map. Recomputed
+  // rather than fixed, because which pane is bottom-left changes: panes are
+  // removable, the columns toggle between two and three, and a pane showing a
+  // chart cannot host a map control.
+  const navigationPane = navigationPaneIndex(
+    visibleIndices,
+    isQuad ? quadColumns : 1,
+    (paneIndex) => viewModes[paneIndex] === 'map',
+  );
+
   return (
     <Box
       position="relative"
@@ -352,6 +363,7 @@ function ContentArea({
                   isChoroplethEnabled={isChoroplethEnabled}
                   isGoogleBasemap={isGoogleBasemap}
                   onGoogleBasemapChange={onGoogleBasemapChange}
+                  showNavigation={i === navigationPane}
                   swiperPosition={swiperPosition}
                   onSwiperPositionChange={onSwiperPositionChange}
                   siteIndicators={siteIndicators}
@@ -407,6 +419,7 @@ function ContentArea({
             isChoroplethEnabled={isChoroplethEnabled}
             isGoogleBasemap={isGoogleBasemap}
             onGoogleBasemapChange={onGoogleBasemapChange}
+            showNavigation={visibleIndices[0] === navigationPane}
             swiperPosition={swiperPosition}
             onSwiperPositionChange={onSwiperPositionChange}
             siteIndicators={siteIndicators}

--- a/frontend/src/components/DemoTour.tsx
+++ b/frontend/src/components/DemoTour.tsx
@@ -14,6 +14,7 @@ import {
 import { AnimatePresence, motion, useDragControls } from 'framer-motion';
 import { FiX } from 'react-icons/fi';
 import { colors } from '../styles/colors';
+import { usePaneChromeForced } from '../hooks/usePaneChromeForced';
 import { loadDemoSiteForTour } from '../hooks/useApi';
 import type { Site } from '../types';
 
@@ -246,6 +247,8 @@ export default function DemoTour({
   const current = steps[step];
   const isLast = step === steps.length - 1;
   const spotlightRect = useSpotlightRect(visible ? current.targetId : undefined);
+
+  usePaneChromeForced(visible && !isBlockedByModal);
 
   if (!visible || isBlockedByModal) return null;
 

--- a/frontend/src/components/GridControls.tsx
+++ b/frontend/src/components/GridControls.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useRef } from 'react';
+import {
+  Box, Button, HStack, Icon, IconButton, Menu, MenuButton, MenuDivider,
+  MenuItem, MenuList, Spinner, Tooltip, useColorModeValue,
+} from '@chakra-ui/react';
+import {
+  FiActivity, FiBarChart2, FiEdit2, FiGlobe, FiMap, FiMoreHorizontal,
+  FiPlus, FiSquare, FiTable, FiTarget,
+} from 'react-icons/fi';
+import type { RangeMode, ViewMode } from '../types';
+
+/**
+ * The controls that act on the whole grid, in one place.
+ *
+ * These used to live in a full-width bar above the panes, which cost a
+ * horizontal band of vertical space on the most space-starved screen in the
+ * application, to hold four icons. They now sit in the header, in the gap that
+ * was previously empty between the site title and the navigation group.
+ *
+ * Everything here is global by definition. Anything that acts on one pane
+ * belongs in that pane's overlay and stays there — six panes legitimately need
+ * six focus buttons, and that is not duplication.
+ */
+
+/**
+ * Every user-visible string, in one object.
+ *
+ * There is no i18n layer in this application yet. Collecting the strings here
+ * does not create one, but it means the eventual extraction is mechanical
+ * rather than a hunt through JSX, and it stops new hardcoded English being
+ * scattered while that remains outstanding.
+ */
+const STRINGS = {
+  viewGroupLabel: 'View for all panes',
+  rangeGroupLabel: 'Colour range',
+  map: 'Map',
+  chart: 'Chart',
+  dial: 'Dial',
+  table: 'Table',
+  rangeFull: 'Full',
+  rangeExtent: 'Extent',
+  rangeSite: 'Site',
+  rangeSuffix: 'range',
+  noSite: 'No site selected',
+  addPane: 'Add pane',
+  targets: 'Targets',
+  editTargets: 'Edit target values',
+  extracting: 'Extracting indicators…',
+  more: 'More controls',
+} as const;
+
+const VIEW_MODES: { id: ViewMode; label: string; icon: React.ReactElement }[] = [
+  { id: 'map', label: STRINGS.map, icon: <FiMap /> },
+  { id: 'chart', label: STRINGS.chart, icon: <FiBarChart2 /> },
+  { id: 'dial', label: STRINGS.dial, icon: <FiActivity /> },
+  { id: 'table', label: STRINGS.table, icon: <FiTable /> },
+];
+
+const RANGE_MODES: { id: RangeMode; label: string; icon: React.ReactElement }[] = [
+  { id: 'domain', label: STRINGS.rangeFull, icon: <FiGlobe size={14} /> },
+  { id: 'extent', label: STRINGS.rangeExtent, icon: <FiSquare size={14} /> },
+  { id: 'site', label: STRINGS.rangeSite, icon: <FiTarget size={14} /> },
+];
+
+interface GridControlsProps {
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  rangeMode?: RangeMode;
+  onRangeModeChange?: (mode: RangeMode) => void;
+  onAddPane?: () => void;
+  onOpenTargets?: () => void;
+  hasTargets?: boolean;
+  siteId?: string | null;
+  isExtracting?: boolean;
+}
+
+/**
+ * A set of mutually exclusive choices, with the keyboard behaviour that implies.
+ *
+ * These were four independent IconButtons distinguished only by background
+ * colour: four tab stops for one decision, and a selection a screen reader could
+ * not report. A radiogroup is one tab stop with arrow keys between the options,
+ * and `aria-checked` says which is chosen. The selected option also carries an
+ * underline, because colour alone is not a distinction everyone can see.
+ */
+function SegmentedGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  isOptionDisabled,
+  renderLabel,
+}: {
+  label: string;
+  options: { id: T; label: string; icon: React.ReactElement }[];
+  value: T | undefined;
+  onChange: (id: T) => void;
+  isOptionDisabled?: (id: T) => boolean;
+  renderLabel?: boolean;
+}) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selectedBg = useColorModeValue('brand.500', 'brand.400');
+  const selectedFg = 'white';
+  const restFg = useColorModeValue('gray.600', 'gray.300');
+  const underline = useColorModeValue('brand.700', 'brand.200');
+
+  // Arrow keys move within the group and wrap, which is what a radiogroup is
+  // expected to do; Home and End jump to the ends.
+  const onKeyDown = useCallback((event: React.KeyboardEvent, index: number) => {
+    const usable = options.filter((o) => !isOptionDisabled?.(o.id));
+    if (usable.length === 0) return;
+
+    let next: number | null = null;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = (index + 1) % options.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = (index - 1 + options.length) % options.length;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = options.length - 1;
+        break;
+      default:
+        return;
+    }
+    // Step over anything disabled rather than landing on it.
+    let guard = 0;
+    while (next !== null && isOptionDisabled?.(options[next].id) && guard < options.length) {
+      next = (next + (event.key === 'ArrowLeft' || event.key === 'ArrowUp' ? -1 : 1) + options.length) % options.length;
+      guard += 1;
+    }
+    if (next === null) return;
+    event.preventDefault();
+    refs.current[next]?.focus();
+    onChange(options[next].id);
+  }, [options, isOptionDisabled, onChange]);
+
+  return (
+    <HStack role="radiogroup" aria-label={label} spacing={0.5}>
+      {options.map((option, index) => {
+        const isSelected = option.id === value;
+        const disabled = isOptionDisabled?.(option.id) ?? false;
+        const content = (
+          <Button
+            key={option.id}
+            ref={(el) => { refs.current[index] = el; }}
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={renderLabel ? undefined : option.label}
+            // One tab stop for the group: only the selected option is
+            // reachable by Tab, and the arrows move between them.
+            tabIndex={isSelected ? 0 : -1}
+            isDisabled={disabled}
+            onClick={() => !disabled && onChange(option.id)}
+            onKeyDown={(e) => onKeyDown(e, index)}
+            size="sm"
+            variant="ghost"
+            px={renderLabel ? 3 : 2}
+            minW={renderLabel ? undefined : 8}
+            fontSize="xs"
+            fontWeight={isSelected ? 600 : 400}
+            bg={isSelected ? selectedBg : 'transparent'}
+            color={isSelected ? selectedFg : restFg}
+            borderBottom="2px solid"
+            borderColor={isSelected ? underline : 'transparent'}
+            borderRadius="md"
+            _hover={{ bg: disabled ? 'transparent' : isSelected ? selectedBg : 'blackAlpha.100' }}
+          >
+            {renderLabel
+              ? <HStack spacing={1.5}><Icon as={() => option.icon} />{option.label}</HStack>
+              : option.icon}
+          </Button>
+        );
+        return (
+          <Tooltip
+            key={option.id}
+            label={disabled ? STRINGS.noSite : `${option.label}${renderLabel ? ` ${STRINGS.rangeSuffix}` : ''}`}
+            placement="bottom"
+          >
+            {content}
+          </Tooltip>
+        );
+      })}
+    </HStack>
+  );
+}
+
+function GridControls({
+  viewMode,
+  onViewModeChange,
+  rangeMode,
+  onRangeModeChange,
+  onAddPane,
+  onOpenTargets,
+  hasTargets,
+  siteId,
+  isExtracting,
+}: GridControlsProps) {
+  const dividerColor = useColorModeValue('gray.300', 'gray.600');
+  const noSite = useCallback((id: RangeMode) => id === 'site' && !siteId, [siteId]);
+
+  return (
+    <>
+      {/* Wide enough to lay the controls out: the full set, inline. */}
+      <HStack spacing={2} display={{ base: 'none', lg: 'flex' }}>
+        <SegmentedGroup
+          label={STRINGS.viewGroupLabel}
+          options={VIEW_MODES}
+          value={viewMode}
+          onChange={onViewModeChange}
+        />
+
+        {onRangeModeChange && (
+          <HStack spacing={2} pl={2} borderLeft="1px solid" borderColor={dividerColor}>
+            <SegmentedGroup
+              label={STRINGS.rangeGroupLabel}
+              options={RANGE_MODES}
+              value={rangeMode}
+              onChange={onRangeModeChange}
+              isOptionDisabled={noSite}
+              renderLabel
+            />
+          </HStack>
+        )}
+
+        {onAddPane && (
+          <Tooltip label={STRINGS.addPane} placement="bottom">
+            <IconButton
+              aria-label={STRINGS.addPane}
+              icon={<FiPlus />}
+              onClick={onAddPane}
+              size="sm"
+              variant="ghost"
+            />
+          </Tooltip>
+        )}
+
+        {hasTargets && onOpenTargets && (
+          <Tooltip label={STRINGS.editTargets} placement="bottom">
+            <Button
+              id="demo-edit-targets-btn"
+              size="sm"
+              variant="ghost"
+              leftIcon={<FiEdit2 size={14} />}
+              onClick={onOpenTargets}
+            >
+              {STRINGS.targets}
+            </Button>
+          </Tooltip>
+        )}
+
+        {isExtracting && (
+          <HStack spacing={2} color="gray.500">
+            <Spinner size="xs" />
+            <Box fontSize="sm">{STRINGS.extracting}</Box>
+          </HStack>
+        )}
+      </HStack>
+
+      {/*
+        Narrow: the view switch stays visible, because it is the primary control
+        on this screen and hiding it would make the interface unusable on a
+        phone. Everything else moves into a menu rather than disappearing — the
+        existing navigation group's display:none pattern is not acceptable here.
+      */}
+      <HStack spacing={1} display={{ base: 'flex', lg: 'none' }}>
+        <SegmentedGroup
+          label={STRINGS.viewGroupLabel}
+          options={VIEW_MODES}
+          value={viewMode}
+          onChange={onViewModeChange}
+        />
+        <Menu>
+          <MenuButton
+            as={IconButton}
+            aria-label={STRINGS.more}
+            icon={<FiMoreHorizontal />}
+            size="sm"
+            variant="ghost"
+          />
+          <MenuList>
+            {onRangeModeChange && RANGE_MODES.map((mode) => (
+              <MenuItem
+                key={mode.id}
+                icon={mode.icon}
+                isDisabled={noSite(mode.id)}
+                onClick={() => onRangeModeChange(mode.id)}
+                fontWeight={rangeMode === mode.id ? 600 : 400}
+              >
+                {`${mode.label} ${STRINGS.rangeSuffix}`}
+              </MenuItem>
+            ))}
+            {onAddPane && <MenuDivider />}
+            {onAddPane && (
+              <MenuItem icon={<FiPlus />} onClick={onAddPane}>{STRINGS.addPane}</MenuItem>
+            )}
+            {hasTargets && onOpenTargets && (
+              <MenuItem icon={<FiEdit2 />} onClick={onOpenTargets}>{STRINGS.targets}</MenuItem>
+            )}
+          </MenuList>
+        </Menu>
+      </HStack>
+    </>
+  );
+}
+
+export default GridControls;
+export { STRINGS as GRID_CONTROL_STRINGS };

--- a/frontend/src/components/GridControls.tsx
+++ b/frontend/src/components/GridControls.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Box, Button, HStack, Icon, IconButton, Menu, MenuButton, MenuDivider,
   MenuItem, MenuList, Spinner, Tooltip, useColorModeValue,
 } from '@chakra-ui/react';
 import {
-  FiActivity, FiBarChart2, FiEdit2, FiGlobe, FiMap, FiMoreHorizontal,
-  FiPlus, FiSquare, FiTable, FiTarget,
+  FiActivity, FiBarChart2, FiBox, FiColumns, FiEdit2, FiGlobe, FiInfo, FiMap,
+  FiMoreHorizontal, FiPlus, FiSquare, FiTable, FiTarget,
 } from 'react-icons/fi';
 import type { RangeMode, ViewMode } from '../types';
+import { satelliteUnavailable, subscribeSatelliteUnavailable } from '../lib/satelliteBasemap';
 
 /**
  * The controls that act on the whole grid, in one place.
@@ -47,7 +48,29 @@ const STRINGS = {
   editTargets: 'Edit target values',
   extracting: 'Extracting indicators…',
   more: 'More controls',
+  mapGroupLabel: 'Map display',
+  view3D: 'Show 3D extrusion',
+  view2D: 'Show flat map',
+  showChoropleth: 'Show choropleth',
+  hideChoropleth: 'Hide choropleth',
+  identifyOn: 'Identify catchment',
+  identifyOff: 'Stop identifying',
+  satelliteOn: 'Switch to satellite',
+  satelliteOff: 'Switch to default basemap',
+  satelliteUnavailable: 'Satellite imagery is unavailable',
+  swiperOn: 'Enable map swiper',
+  swiperOff: 'Disable map swiper',
+  zoomToSite: 'Zoom to site',
 } as const;
+
+/**
+ * Broadcast to every mounted map. The maps own their own MapLibre instance and
+ * cannot be reached from the header by prop, so the zoom is an event — the same
+ * one the guided tour already dispatches, handled by the same listener.
+ */
+function zoomToSite() {
+  window.dispatchEvent(new Event('dt:zoom-to-site'));
+}
 
 const VIEW_MODES: { id: ViewMode; label: string; icon: React.ReactElement }[] = [
   { id: 'map', label: STRINGS.map, icon: <FiMap /> },
@@ -62,6 +85,114 @@ const RANGE_MODES: { id: RangeMode; label: string; icon: React.ReactElement }[] 
   { id: 'site', label: STRINGS.rangeSite, icon: <FiTarget size={14} /> },
 ];
 
+/**
+ * An independent on/off control.
+ *
+ * Deliberately not a radio: these five are not a set of alternatives, they are
+ * five separate settings, so each is its own tab stop with `aria-pressed`. As
+ * with SegmentedGroup, the pressed state carries an underline as well as a
+ * background, because colour alone is not a distinction everyone can see.
+ */
+function ToggleButton({
+  label, icon, isOn, onToggle, isDisabled, disabledLabel,
+}: {
+  label: string;
+  icon: React.ReactElement;
+  isOn: boolean;
+  onToggle: () => void;
+  isDisabled?: boolean;
+  disabledLabel?: string;
+}) {
+  const onBg = useColorModeValue('brand.500', 'brand.400');
+  const offFg = useColorModeValue('gray.600', 'gray.300');
+  const underline = useColorModeValue('brand.700', 'brand.200');
+  return (
+    <Tooltip label={isDisabled ? disabledLabel ?? label : label} placement="bottom">
+      {/* Tooltip needs a focusable child, so the disabled case wraps in a Box. */}
+      <Box>
+        <IconButton
+          aria-label={label}
+          aria-pressed={isOn}
+          icon={icon}
+          isDisabled={isDisabled}
+          onClick={onToggle}
+          size="sm"
+          variant="ghost"
+          minW={8}
+          bg={isOn ? onBg : 'transparent'}
+          color={isOn ? 'white' : offFg}
+          borderBottom="2px solid"
+          borderColor={isOn ? underline : 'transparent'}
+          borderRadius="md"
+          _hover={{ bg: isDisabled ? 'transparent' : isOn ? onBg : 'blackAlpha.100' }}
+        />
+      </Box>
+    </Tooltip>
+  );
+}
+
+interface MapToggle {
+  key: string;
+  label: string;
+  icon: React.ReactElement;
+  isOn: boolean;
+  onToggle: () => void;
+  isDisabled?: boolean;
+  disabledLabel?: string;
+}
+
+/**
+ * The five toggles and zoom-to-site, as one unit.
+ *
+ * Shared by both layouts below rather than written twice: the whole point of
+ * this component is that a control exists once, and duplicating the markup to
+ * get two breakpoints would reintroduce the problem one level up.
+ */
+function MapToggleCluster({
+  toggles, siteId, dividerColor,
+}: {
+  toggles: MapToggle[];
+  siteId?: string | null;
+  dividerColor: string;
+}) {
+  if (toggles.length === 0) return null;
+  return (
+    <HStack
+      spacing={0.5}
+      pl={2}
+      borderLeft="1px solid"
+      borderColor={dividerColor}
+      aria-label={STRINGS.mapGroupLabel}
+      role="group"
+    >
+      {toggles.map((t) => (
+        <ToggleButton
+          key={t.key}
+          label={t.label}
+          icon={t.icon}
+          isOn={t.isOn}
+          onToggle={t.onToggle}
+          isDisabled={t.isDisabled}
+          disabledLabel={t.disabledLabel}
+        />
+      ))}
+      <Tooltip label={STRINGS.zoomToSite} placement="bottom">
+        <Box>
+          <IconButton
+            aria-label={STRINGS.zoomToSite}
+            icon={<FiTarget />}
+            onClick={zoomToSite}
+            isDisabled={!siteId}
+            size="sm"
+            variant="ghost"
+            minW={8}
+          />
+        </Box>
+      </Tooltip>
+    </HStack>
+  );
+}
+
 interface GridControlsProps {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
@@ -72,6 +203,18 @@ interface GridControlsProps {
   hasTargets?: boolean;
   siteId?: string | null;
   isExtracting?: boolean;
+  // The five map toggles. Each acted on every pane already, while being drawn
+  // once per pane; they are drawn once now.
+  is3DMode?: boolean;
+  onIs3DModeChange?: (enabled: boolean) => void;
+  isChoroplethEnabled?: boolean;
+  onChoroplethEnabledChange?: (enabled: boolean) => void;
+  isIdentifyMode?: boolean;
+  onIdentifyModeChange?: (enabled: boolean) => void;
+  isGoogleBasemap?: boolean;
+  onGoogleBasemapChange?: (enabled: boolean) => void;
+  isSwiperEnabled?: boolean;
+  onSwiperEnabledChange?: (enabled: boolean) => void;
 }
 
 /**
@@ -201,14 +344,41 @@ function GridControls({
   hasTargets,
   siteId,
   isExtracting,
+  is3DMode = false,
+  onIs3DModeChange,
+  isChoroplethEnabled = true,
+  onChoroplethEnabledChange,
+  isIdentifyMode = false,
+  onIdentifyModeChange,
+  isGoogleBasemap = false,
+  onGoogleBasemapChange,
+  isSwiperEnabled = true,
+  onSwiperEnabledChange,
 }: GridControlsProps) {
   const dividerColor = useColorModeValue('gray.300', 'gray.600');
   const noSite = useCallback((id: RangeMode) => id === 'site' && !siteId, [siteId]);
 
+  // Satellite can become unavailable at runtime — quota spent, or no provider
+  // configured once /api/info resolves. The button says so rather than offering
+  // a switch that silently fails.
+  const [noSatellite, setNoSatellite] = useState(satelliteUnavailable);
+  useEffect(() => subscribeSatelliteUnavailable(setNoSatellite), []);
+
+  // Only meaningful over a map. In chart, dial or table view they would be
+  // controls for something not on screen.
+  const showMapToggles = viewMode === 'map';
+  const mapToggles: (MapToggle & { on?: (enabled: boolean) => void })[] = ([
+    { key: '3d', label: is3DMode ? STRINGS.view2D : STRINGS.view3D, icon: <FiBox />, isOn: is3DMode, onToggle: () => onIs3DModeChange?.(!is3DMode), on: onIs3DModeChange },
+    { key: 'choropleth', label: isChoroplethEnabled ? STRINGS.hideChoropleth : STRINGS.showChoropleth, icon: <FiMap />, isOn: isChoroplethEnabled, onToggle: () => onChoroplethEnabledChange?.(!isChoroplethEnabled), on: onChoroplethEnabledChange },
+    { key: 'identify', label: isIdentifyMode ? STRINGS.identifyOff : STRINGS.identifyOn, icon: <FiInfo />, isOn: isIdentifyMode, onToggle: () => onIdentifyModeChange?.(!isIdentifyMode), on: onIdentifyModeChange },
+    { key: 'satellite', label: isGoogleBasemap ? STRINGS.satelliteOff : STRINGS.satelliteOn, icon: <FiGlobe />, isOn: isGoogleBasemap, onToggle: () => onGoogleBasemapChange?.(!isGoogleBasemap), on: onGoogleBasemapChange, isDisabled: noSatellite && !isGoogleBasemap, disabledLabel: STRINGS.satelliteUnavailable },
+    { key: 'swiper', label: isSwiperEnabled ? STRINGS.swiperOff : STRINGS.swiperOn, icon: <FiColumns />, isOn: isSwiperEnabled, onToggle: () => onSwiperEnabledChange?.(!isSwiperEnabled), on: onSwiperEnabledChange },
+  ] as const).filter((t) => t.on && showMapToggles);
+
   return (
     <>
       {/* Wide enough to lay the controls out: the full set, inline. */}
-      <HStack spacing={2} display={{ base: 'none', lg: 'flex' }}>
+      <HStack spacing={2} display={{ base: 'none', xl: 'flex' }} data-testid="grid-controls-wide">
         <SegmentedGroup
           label={STRINGS.viewGroupLabel}
           options={VIEW_MODES}
@@ -228,6 +398,8 @@ function GridControls({
             />
           </HStack>
         )}
+
+        <MapToggleCluster toggles={mapToggles} siteId={siteId} dividerColor={dividerColor} />
 
         {onAddPane && (
           <Tooltip label={STRINGS.addPane} placement="bottom">
@@ -269,13 +441,21 @@ function GridControls({
         phone. Everything else moves into a menu rather than disappearing — the
         existing navigation group's display:none pattern is not acceptable here.
       */}
-      <HStack spacing={1} display={{ base: 'flex', lg: 'none' }}>
+      <HStack spacing={1} display={{ base: 'flex', xl: 'none' }} data-testid="grid-controls-narrow">
         <SegmentedGroup
           label={STRINGS.viewGroupLabel}
           options={VIEW_MODES}
           value={viewMode}
           onChange={onViewModeChange}
         />
+        {/*
+          The toggles are icons already, so they still fit beside the view
+          switch on a laptop; below md they would push the title off the row,
+          and the menu carries them from there down.
+        */}
+        <Box display={{ base: 'none', md: 'flex' }}>
+          <MapToggleCluster toggles={mapToggles} siteId={siteId} dividerColor={dividerColor} />
+        </Box>
         <Menu>
           <MenuButton
             as={IconButton}
@@ -296,6 +476,23 @@ function GridControls({
                 {`${mode.label} ${STRINGS.rangeSuffix}`}
               </MenuItem>
             ))}
+            {showMapToggles && mapToggles.length > 0 && <MenuDivider />}
+            {showMapToggles && mapToggles.map((t) => (
+              <MenuItem
+                key={t.key}
+                icon={t.icon}
+                isDisabled={t.isDisabled}
+                onClick={t.onToggle}
+                fontWeight={t.isOn ? 600 : 400}
+              >
+                {t.isDisabled ? t.disabledLabel ?? t.label : t.label}
+              </MenuItem>
+            ))}
+            {showMapToggles && (
+              <MenuItem icon={<FiTarget />} isDisabled={!siteId} onClick={zoomToSite}>
+                {STRINGS.zoomToSite}
+              </MenuItem>
+            )}
             {onAddPane && <MenuDivider />}
             {onAddPane && (
               <MenuItem icon={<FiPlus />} onClick={onAddPane}>{STRINGS.addPane}</MenuItem>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -26,6 +26,8 @@ import { getAppRuntime } from '../types/runtime';
 import rewildLogo from '../assets/logo-vertical-white-3x 1.png';
 import fefaLogo from '../assets/JM_FEFA_Logo_Light_LightLightText_RGB_72dpi_aw.png';
 import { colors } from '../styles/colors';
+import GridControls from './GridControls';
+import type { RangeMode, ViewMode } from '../types';
 
 interface HeaderProps {
   onToggleDocs: () => void;
@@ -37,9 +39,24 @@ interface HeaderProps {
   isBoundaryEditMode?: boolean;
   onToggleTargetModal?: () => void;
   isTargetModalOpen?: boolean;
+
+  // The grid-wide controls, previously a full-width bar above the panes. They
+  // are passed rather than read from context because every piece of this state
+  // already lives in App, and threading it here keeps one owner.
+  gridControls?: {
+    viewMode: ViewMode;
+    onViewModeChange: (mode: ViewMode) => void;
+    rangeMode?: RangeMode;
+    onRangeModeChange?: (mode: RangeMode) => void;
+    onAddPane?: () => void;
+    onOpenTargets?: () => void;
+    hasTargets?: boolean;
+    siteId?: string | null;
+    isExtracting?: boolean;
+  };
 }
 
-function Header({ onToggleDocs, isDocsOpen, onNavigate, currentPage, siteTitle, onEditBoundary, isBoundaryEditMode }: HeaderProps) {
+function Header({ onToggleDocs, isDocsOpen, onNavigate, currentPage, siteTitle, onEditBoundary, isBoundaryEditMode, gridControls }: HeaderProps) {
   const { info } = useServerInfo();
   const isBrowser = getAppRuntime() === 'browser';
   const bgColor = useColorModeValue('white', colors.darkGray);
@@ -106,6 +123,12 @@ function Header({ onToggleDocs, isDocsOpen, onNavigate, currentPage, siteTitle, 
           </>
         )}
       </HStack>
+
+      <Spacer />
+
+      {gridControls && currentPage === 'map' && (
+        <GridControls {...gridControls} />
+      )}
 
       <Spacer />
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -53,6 +53,16 @@ interface HeaderProps {
     hasTargets?: boolean;
     siteId?: string | null;
     isExtracting?: boolean;
+    is3DMode?: boolean;
+    onIs3DModeChange?: (enabled: boolean) => void;
+    isChoroplethEnabled?: boolean;
+    onChoroplethEnabledChange?: (enabled: boolean) => void;
+    isIdentifyMode?: boolean;
+    onIdentifyModeChange?: (enabled: boolean) => void;
+    isGoogleBasemap?: boolean;
+    onGoogleBasemapChange?: (enabled: boolean) => void;
+    isSwiperEnabled?: boolean;
+    onSwiperEnabledChange?: (enabled: boolean) => void;
   };
 }
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -136,9 +136,14 @@ function Header({ onToggleDocs, isDocsOpen, onNavigate, currentPage, siteTitle, 
 
       <Spacer />
 
-      {gridControls && currentPage === 'map' && (
-        <GridControls {...gridControls} />
-      )}
+      {/*
+        Gated on the props being supplied, not on the page name. The pane grid
+        renders on 'map' and on 'explore' — exploring without a site selected is
+        the same screen — and only that render passes gridControls at all, so
+        the props are the signal. Naming a page here hid the whole cluster in
+        explore mode.
+      */}
+      {gridControls && <GridControls {...gridControls} />}
 
       <Spacer />
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text, useToast } from '@chakra-ui/react';
-import { FiSliders, FiMap, FiInfo, FiBox, FiTarget, FiPlus, FiMinus, FiColumns, FiTrash2, FiGlobe } from 'react-icons/fi';
+import { FiSliders, FiMap, FiPlus, FiMinus, FiTrash2 } from 'react-icons/fi';
 import maplibregl from 'maplibre-gl';
 import { bbox as turfBbox, featureCollection, union, difference, intersect, area as turfArea, simplify as turfSimplify } from '@turf/turf';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -14,7 +14,6 @@ import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from 
 import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
 import {
   satelliteStyleUrl,
-  satelliteUnavailable,
   subscribeSatelliteUnavailable,
 } from '../lib/satelliteBasemap';
 import {
@@ -51,7 +50,6 @@ interface MapViewProps {
   siteGeometry?: GeoJSON.Geometry | null;
   onBoundaryUpdate?: (geometry: GeoJSON.Geometry, thumbnail?: string | null) => void;
   isSwiperEnabled?: boolean;
-  onSwiperEnabledChange?: (enabled: boolean) => void;
   colorScaleMode: ColorScaleMode;
   colorScaleType: ColorScaleType;
   /** Which zone's min/max the color scale (and legend) is stretched to. Defaults to 'domain'. */
@@ -60,7 +58,14 @@ interface MapViewProps {
   swiperPosition?: number;
   onSwiperPositionChange?: (position: number) => void;
   is3DMode?: boolean;
-  on3DModeChange?: (enabled: boolean) => void;
+  // These five were pane-local state driven by a per-pane button stack. Every
+  // one of them acted on all panes, so App owns them now and each pane reflects
+  // the same value. Only the basemap reports back: the satellite-quota revert
+  // below is the one change that originates here.
+  isIdentifyMode?: boolean;
+  isChoroplethEnabled?: boolean;
+  isGoogleBasemap?: boolean;
+  onGoogleBasemapChange?: (enabled: boolean) => void;
   /** Increment to force a choropleth refresh (e.g. after indicator save). */
   refreshKey?: number;
   /** Called once when both map instances have finished loading. */
@@ -859,7 +864,7 @@ const EDIT_VERTICES_GLOW = 'edit-vertices-glow';
 const EDIT_VERTICES_OUTER = 'edit-vertices-outer';
 const EDIT_VERTICES_INNER = 'edit-vertices-inner';
 
-function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, onSwiperEnabledChange, colorScaleMode, colorScaleType, rangeMode = 'domain', swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, on3DModeChange, refreshKey, onReady, siteIndicators }: MapViewProps) {
+function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad: _isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, colorScaleMode, colorScaleType, rangeMode = 'domain', swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, isIdentifyMode: isIdentifyModeProp, isChoroplethEnabled: isChoroplethEnabledProp, isGoogleBasemap: isGoogleBasemapProp, onGoogleBasemapChange, refreshKey, onReady, siteIndicators }: MapViewProps) {
   const { colors: attributeColors, loading: attributeColorsLoading } = useAttributeColors();
   const { details: attributeDetails } = useAttributeDetails();
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -885,17 +890,16 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const mapsReady = useRef<{ left: boolean; right: boolean }>({ left: false, right: true });
   const resizeFrameRef = useRef<number | null>(null);
 
-  // Compare swiper state (split-screen on/off)
-  const [internalSwiperEnabled, setInternalSwiperEnabled] = useState(true);
-  const isSwiperEnabled = isSwiperEnabledProp ?? internalSwiperEnabled;
+  // Compare swiper state (split-screen on/off). Read-only here; the default
+  // covers the tests, which render MapView without the prop.
+  const isSwiperEnabled = isSwiperEnabledProp ?? true;
   const isSwiperEnabledRef = useRef(isSwiperEnabled);
   isSwiperEnabledRef.current = isSwiperEnabled;
 
-  // Identify mode state
-  const [isIdentifyMode, setIsIdentifyMode] = useState(false);
-
-  // Choropleth layer visibility state
-  const [isChoroplethEnabled, setIsChoroplethEnabled] = useState(true);
+  // Identify and choropleth visibility. Owned by App: they act on every pane,
+  // so they cannot be pane state.
+  const isIdentifyMode = isIdentifyModeProp ?? false;
+  const isChoroplethEnabled = isChoroplethEnabledProp ?? true;
   const isChoroplethEnabledRef = useRef(isChoroplethEnabled);
   isChoroplethEnabledRef.current = isChoroplethEnabled;
 
@@ -910,9 +914,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // for its existing choropleth/boundary guards; onReady only needs one.
   const onReadyFiredRef = useRef(false);
 
-  // 3D mode state
-  const [internal3DMode, setInternal3DMode] = useState(false);
-  const is3DMode = is3DModeProp ?? internal3DMode;
+  // 3D mode state. Read-only here, applied by the effect below.
+  const is3DMode = is3DModeProp ?? false;
   const is3DModeRef = useRef(is3DMode);
 
   // Store latest comparison in a ref so async callbacks see current values
@@ -2135,17 +2138,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     }, FETCH_DEBOUNCE_MS);
   }, []);
 
-  // Toggle identify mode
-  const toggleIdentifyMode = useCallback(() => {
-    setIsIdentifyMode(prev => !prev);
-  }, []);
-
-  const toggleChoropleth = useCallback(() => {
-    setIsChoroplethEnabled((prev) => !prev);
-  }, []);
-
   // Google basemap toggle state. Defaults on for the browser runtime.
-  const [isGoogleBasemap, setIsGoogleBasemap] = useState(() => getAppRuntime() === 'browser');
+  const isGoogleBasemap = isGoogleBasemapProp ?? (getAppRuntime() === 'browser');
+  // Held in a ref because applyBasemapStyle is memoised without it; closing
+  // over the prop directly would call a stale callback after a re-render.
+  const onGoogleBasemapChangeRef = useRef(onGoogleBasemapChange);
+  onGoogleBasemapChangeRef.current = onGoogleBasemapChange;
   const isGoogleBasemapRef = useRef(getAppRuntime() === 'browser');
   const toast = useToast();
 
@@ -2157,7 +2155,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (!leftMap) return;
 
     isGoogleBasemapRef.current = nextVal;
-    setIsGoogleBasemap(nextVal);
+    onGoogleBasemapChangeRef.current?.(nextVal);
 
     const newStyle: string = nextVal
       ? (window.location.origin + satelliteStyleUrl())
@@ -2188,24 +2186,6 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     }, 400);
   }, [reapplyBoundaryLayers]);
 
-  const toggleGoogleBasemap = useCallback(() => {
-    const nextVal = !isGoogleBasemapRef.current;
-
-    if (nextVal && satelliteUnavailable()) {
-      toast({
-        title: 'Satellite imagery unavailable',
-        description: "This month's quota has been used up, or no imagery "
-          + 'provider is configured. Showing the default map instead.',
-        status: 'warning',
-        duration: 8000,
-        isClosable: true,
-      });
-      return;
-    }
-
-    applyBasemapStyle(nextVal);
-  }, [applyBasemapStyle, toast]);
-
   // If satellite becomes unavailable (quota spent, or — at startup, before
   // /api/info has resolved — no provider turns out to be configured) while it
   // is actively showing, revert to the built-in basemap rather than leaving
@@ -2224,15 +2204,6 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       });
     });
   }, [applyBasemapStyle, toast]);
-
-  // Toggle split-screen swiper on/off
-  const toggleSwiper = useCallback(() => {
-    const next = !isSwiperEnabled;
-    if (isSwiperEnabledProp === undefined) {
-      setInternalSwiperEnabled(next);
-    }
-    onSwiperEnabledChange?.(next);
-  }, [isSwiperEnabled, isSwiperEnabledProp, onSwiperEnabledChange]);
 
   const deriveBoundsFromGeometry = useCallback((geometry: GeoJSON.Geometry | null): BoundingBox | null => {
     if (!geometry) return null;
@@ -2321,19 +2292,27 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     applyColors();
   }, [applyColors]);
 
-  const toggle3DMode = useCallback(() => {
-    const nextMode = !is3DModeRef.current;
-    if (is3DModeProp === undefined) {
-      setInternal3DMode(nextMode);
-    }
-    on3DModeChange?.(nextMode);
-    apply3DMode(nextMode);
-  }, [apply3DMode, is3DModeProp, on3DModeChange]);
-
   useEffect(() => {
     if (is3DModeRef.current === is3DMode) return;
     apply3DMode(is3DMode);
   }, [apply3DMode, is3DMode]);
+
+  // The same shape for the basemap. The control that used to call
+  // applyBasemapStyle directly is in the header now, so the style follows the
+  // prop rather than a click. The ref guard stops the quota-exceeded
+  // auto-revert below from being undone by its own state change.
+  useEffect(() => {
+    if (isGoogleBasemapRef.current === isGoogleBasemap) return;
+    applyBasemapStyle(isGoogleBasemap);
+  }, [applyBasemapStyle, isGoogleBasemap]);
+
+  // Choropleth visibility is read through a ref inside applyColors, so a change
+  // has to re-run it; nothing else would notice.
+  useEffect(() => {
+    // Through the ref, as elsewhere in this file: applyColors is rebuilt on
+    // every render, so depending on it directly would re-run this constantly.
+    applyColorsRef.current();
+  }, [isChoroplethEnabled]);
 
   // Update cursor when identify mode changes
   useEffect(() => {
@@ -4040,7 +4019,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       }
     };
     window.addEventListener('dt:tour-zoom-to-site', handler);
-    return () => window.removeEventListener('dt:tour-zoom-to-site', handler);
+    window.addEventListener('dt:zoom-to-site', handler);
+    return () => {
+      window.removeEventListener('dt:tour-zoom-to-site', handler);
+      window.removeEventListener('dt:zoom-to-site', handler);
+    };
   }, []);
 
   // Deferred tour zoom: executes once both maps are ready and siteBounds is
@@ -4758,7 +4741,6 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
   // Check if panel is unconfigured (no indicator selected)
   const isUnconfigured = !comparison.attribute;
-  const canZoomToSite = Boolean(siteBounds || siteGeometry || siteId);
 
   return (
     <Box
@@ -4881,128 +4863,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         </Flex>
       )}
 
-      {/* Tool buttons - only show when configured */}
-      {!isUnconfigured && (
-        <VStack
-          position="absolute"
-          bottom="120px"
-          left="10px"
-          zIndex={10}
-          spacing={1}
-        >
-          {/* 3D toggle button */}
-          <Tooltip label={is3DMode ? "Switch to 2D" : "Switch to 3D"} placement="right">
-            <IconButton
-              aria-label="Toggle 3D view"
-              icon={<FiBox />}
-              size="sm"
-              colorScheme={is3DMode ? "blue" : "gray"}
-              variant="solid"
-              bg={is3DMode ? colors.blue : "white"}
-              color={is3DMode ? "white" : "gray.700"}
-              onClick={toggle3DMode}
-              boxShadow="md"
-              _hover={{
-                bg: is3DMode ? "blue.600" : "gray.100"
-              }}
-            />
-          </Tooltip>
-
-          <Tooltip label={isChoroplethEnabled ? "Hide choropleth" : "Show choropleth"} placement="right">
-            <IconButton
-              aria-label="Toggle choropleth layer"
-              icon={<FiMap />}
-              size="sm"
-              colorScheme={isChoroplethEnabled ? "blue" : "gray"}
-              variant="solid"
-              bg={isChoroplethEnabled ? colors.blue : "white"}
-              color={isChoroplethEnabled ? "white" : "gray.700"}
-              onClick={toggleChoropleth}
-              boxShadow="md"
-              _hover={{
-                bg: isChoroplethEnabled ? "blue.600" : "gray.100"
-              }}
-            />
-          </Tooltip>
-
-          {/* Identify button */}
-          {!isQuad && (
-            <Tooltip label={isIdentifyMode ? "Disable Identify" : "Identify Catchment"} placement="right">
-              <IconButton
-                aria-label="Toggle identify mode"
-                icon={<FiInfo />}
-                size="sm"
-                colorScheme={isIdentifyMode ? "blue" : "gray"}
-                variant="solid"
-                bg={isIdentifyMode ? colors.blue: "white"}
-                color={isIdentifyMode ? "white" : "gray.700"}
-                onClick={toggleIdentifyMode}
-                boxShadow="md"
-                _hover={{
-                  bg: isIdentifyMode ? "blue.600" : "gray.100"
-                }}
-              />
-            </Tooltip>
-          )}
-
-          {/* Google basemap toggle */}
-          <Tooltip label={isGoogleBasemap ? "Switch to default basemap" : "Switch to satellite"} placement="right">
-            <IconButton
-              aria-label="Toggle satellite basemap"
-              icon={<FiGlobe />}
-              size="sm"
-              colorScheme={isGoogleBasemap ? "blue" : "gray"}
-              variant="solid"
-              bg={isGoogleBasemap ? colors.blue : "white"}
-              color={isGoogleBasemap ? "white" : "gray.700"}
-              onClick={toggleGoogleBasemap}
-              boxShadow="md"
-              _hover={{
-                bg: isGoogleBasemap ? "blue.600" : "gray.100"
-              }}
-            />
-          </Tooltip>
-
-          {/* Swiper toggle button */}
-          <Tooltip label={isSwiperEnabled ? "Disable map swiper" : "Enable map swiper"} placement="right">
-            <IconButton
-              aria-label="Toggle map swiper"
-              icon={<FiColumns />}
-              size="sm"
-              colorScheme={isSwiperEnabled ? "blue" : "gray"}
-              variant="solid"
-              bg={isSwiperEnabled ? colors.blue: "white"}
-              color={isSwiperEnabled ? "white" : "gray.700"}
-              onClick={toggleSwiper}
-              boxShadow="md"
-              _hover={{
-                bg: isSwiperEnabled ? "blue.600" : "gray.100"
-              }}
-            />
-          </Tooltip>
-
-          {/* Zoom to Site button - only show when site bounds are available */}
-          {canZoomToSite && (
-            <Tooltip label="Zoom to Site" placement="right">
-              <IconButton
-                aria-label="Zoom to site"
-                icon={<FiTarget />}
-                size="sm"
-                variant="solid"
-                bg="white"
-                color="gray.700"
-                onClick={() => {
-                  void zoomToSite();
-                }}
-                boxShadow="md"
-                _hover={{
-                  bg: "gray.100"
-                }}
-              />
-            </Tooltip>
-          )}
-        </VStack>
-      )}
+      {/*
+        The five map toggles — 3D, choropleth, identify, satellite, swiper — used
+        to be stacked down the left edge of every pane. They act on all panes, so
+        six panes drew thirty buttons for five decisions. They are in the header
+        now, once. See GridControls.
+      */}
 
       {/* Boundary Edit Mode Overlay */}
       {isBoundaryEditMode && siteGeometry && isPolygonalGeometry(siteGeometry) && (

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2308,7 +2308,14 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
   // Choropleth visibility is read through a ref inside applyColors, so a change
   // has to re-run it; nothing else would notice.
+  // Choropleth visibility is read through a ref inside applyColors, so a change
+  // has to re-run it; nothing else would notice. Only a *change*, though: the
+  // initial paint is already driven by the maps-ready effect, and a second run
+  // at mount would abort that one and start again.
+  const appliedChoroplethRef = useRef(isChoroplethEnabled);
   useEffect(() => {
+    if (appliedChoroplethRef.current === isChoroplethEnabled) return;
+    appliedChoroplethRef.current = isChoroplethEnabled;
     // Through the ref, as elsewhere in this file: applyColors is rebuilt on
     // every render, so depending on it directly would re-run this constantly.
     applyColorsRef.current();

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -3029,7 +3029,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       border-radius:0 0 10px 10px;
       z-index:15;
       background:rgba(0,0,0,0.85);
-      padding:2px 12px;
+      /* Keeps its original type and padding. The scenario labels either side
+         are supporting text and shrank; this one names what the pane is
+         showing, and is the only label worth reading from across a room. */
+      padding:8px 20px;
+      font-size:14px;
+      letter-spacing:0.5px;
       white-space:nowrap;
       max-width:60%;
       overflow:hidden;

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -66,6 +66,18 @@ interface MapViewProps {
   isChoroplethEnabled?: boolean;
   isGoogleBasemap?: boolean;
   onGoogleBasemapChange?: (enabled: boolean) => void;
+  /**
+   * Whether this map shows the zoom / compass cluster. Every map in a grid is
+   * synced through useMapSync, so one cluster drives all of them and the rest
+   * would be the same control drawn again — see lib/navigationPane.ts.
+   *
+   * Hidden with a class rather than by skipping addControl: which pane owns the
+   * cluster changes while the application runs — a pane is removed, the columns
+   * toggle between two and three, a pane switches to chart view — and the maps
+   * are built once. Adding and removing controls on each of those would be a
+   * lifecycle problem in exchange for nothing.
+   */
+  showNavigation?: boolean;
   /** Increment to force a choropleth refresh (e.g. after indicator save). */
   refreshKey?: number;
   /** Called once when both map instances have finished loading. */
@@ -864,7 +876,7 @@ const EDIT_VERTICES_GLOW = 'edit-vertices-glow';
 const EDIT_VERTICES_OUTER = 'edit-vertices-outer';
 const EDIT_VERTICES_INNER = 'edit-vertices-inner';
 
-function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad: _isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, colorScaleMode, colorScaleType, rangeMode = 'domain', swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, isIdentifyMode: isIdentifyModeProp, isChoroplethEnabled: isChoroplethEnabledProp, isGoogleBasemap: isGoogleBasemapProp, onGoogleBasemapChange, refreshKey, onReady, siteIndicators }: MapViewProps) {
+function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMapExtentChange, onStatisticsChange, isPanelOpen, isQuad: _isQuad, siteId, siteBounds, isBoundaryEditMode, siteGeometry, onBoundaryUpdate, isSwiperEnabled: isSwiperEnabledProp, colorScaleMode, colorScaleType, rangeMode = 'domain', swiperPosition, onSwiperPositionChange, is3DMode: is3DModeProp, isIdentifyMode: isIdentifyModeProp, isChoroplethEnabled: isChoroplethEnabledProp, isGoogleBasemap: isGoogleBasemapProp, onGoogleBasemapChange, showNavigation = true, refreshKey, onReady, siteIndicators }: MapViewProps) {
   const { colors: attributeColors, loading: attributeColorsLoading } = useAttributeColors();
   const { details: attributeDetails } = useAttributeDetails();
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -4744,6 +4756,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   return (
     <Box
       ref={mapContainerRef}
+      className={showNavigation ? undefined : 'dt-no-nav'}
       position="absolute"
       top={0}
       left={0}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2854,6 +2854,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // Slider handle
     const handle = document.createElement('div');
     handle.id = 'tour-map-swiper';
+    // Revealed on hover with the rest of the pane's controls — see
+    // styles/paneChrome.css. The divider line it sits on stays visible: that
+    // marks which side of the comparison is which, and is information rather
+    // than a control.
+    handle.className = 'dt-pane-chrome';
     handle.style.cssText = `
       position:absolute;
       top:50%;

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -13,6 +13,7 @@ import { colors } from '../styles/colors';
 import { applyZoomOutClipToBounds, fetchCatchmentBounds, fetchTileBounds } from '../lib/mapBounds';
 import { sharedRequest, isAbortError, type SharedCache } from '../lib/sharedRequest';
 import {
+  satelliteConfirmed,
   satelliteStyleUrl,
   subscribeSatelliteUnavailable,
 } from '../lib/satelliteBasemap';
@@ -2152,6 +2153,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
   // Google basemap toggle state. Defaults on for the browser runtime.
   const isGoogleBasemap = isGoogleBasemapProp ?? (getAppRuntime() === 'browser');
+  // What the user asked for, as against what is on the map. The two differ for
+  // the whole window between a map being built and /api/info resolving, and
+  // conflating them was how a startup guess became a permanent answer.
+  const wantsSatelliteRef = useRef(isGoogleBasemap);
+  wantsSatelliteRef.current = isGoogleBasemap;
   // Held in a ref because applyBasemapStyle is memoised without it; closing
   // over the prop directly would call a stale callback after a re-render.
   const onGoogleBasemapChangeRef = useRef(onGoogleBasemapChange);
@@ -2166,10 +2172,15 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     const rightMap = rightMapRef.current;
     if (!leftMap) return;
 
-    isGoogleBasemapRef.current = nextVal;
-    onGoogleBasemapChangeRef.current?.(nextVal);
+    // Wanting satellite and being able to show it are different questions. If
+    // the server has not confirmed it, show the built-in style rather than hand
+    // MapLibre a URL that 404s — but say nothing upward: this is not the user
+    // changing their mind, and reporting it as one would turn "we do not know
+    // yet" into a decision that survives the answer arriving.
+    const showSatellite = nextVal && satelliteConfirmed();
+    isGoogleBasemapRef.current = showSatellite;
 
-    const newStyle: string = nextVal
+    const newStyle: string = showSatellite
       ? (window.location.origin + satelliteStyleUrl())
       : (window.location.origin + '/data/style.json');
 
@@ -2204,16 +2215,33 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   // the map to fail tile-by-tile.
   useEffect(() => {
     return subscribeSatelliteUnavailable((unavailable) => {
-      if (!unavailable || !isGoogleBasemapRef.current) return;
-      applyBasemapStyle(false);
-      toast({
-        title: 'Satellite imagery unavailable',
-        description: "This month's quota has been used up, or no imagery "
-          + 'provider is configured. Switched to the default map.',
-        status: 'warning',
-        duration: 8000,
-        isClosable: true,
-      });
+      // Symmetric: re-apply what the user asked for against what is now
+      // possible. applyBasemapStyle refuses satellite it cannot show, so this
+      // one call both falls back when the quota runs out and switches over
+      // when a key finally arrives. The previous version handled only the
+      // first, which left a map built before /api/info stuck on the built-in
+      // style for the rest of the session.
+      const wanted = wantsSatelliteRef.current;
+      if (!wanted && !isGoogleBasemapRef.current) return;
+      applyBasemapStyle(wanted);
+
+      // Only a real loss is reported upward, and it is reported as a change of
+      // state the toggle should show — which is the "switch back to the default
+      // map" the user sees. Failing to *gain* satellite is not a decision.
+      if (unavailable && wanted) {
+        onGoogleBasemapChangeRef.current?.(false);
+      }
+
+      if (unavailable && wanted) {
+        toast({
+          title: 'Satellite imagery unavailable',
+          description: "This month's quota has been used up, or no imagery "
+            + 'provider is configured. Switched to the default map.',
+          status: 'warning',
+          duration: 8000,
+          isClosable: true,
+        });
+      }
     });
   }, [applyBasemapStyle, toast]);
 
@@ -3021,7 +3049,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // pane's fetch already hits this server's own in-memory cache (see
     // internal/server/satellite.go's styleCache) rather than the upstream
     // provider, so there is no repeated external request to save here.
-    const mapStyle = isGoogleBasemapRef.current
+    // Only if the server has confirmed satellite. A map built against a style
+    // that 404s never fires 'load', so its pane sits behind a spinner until the
+    // 15-second safety net below — and /api/info, which would have said so,
+    // usually resolves a moment later. The listener further up switches to
+    // satellite the moment confirmation arrives.
+    const mapStyle = isGoogleBasemapRef.current && satelliteConfirmed()
       ? window.location.origin + satelliteStyleUrl()
       : getStyleForMap(styleUrl);
 
@@ -3200,7 +3233,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         container: rightContainer,
         // Re-read the basemap choice rather than reusing the style captured at
         // init: the user may have toggled the satellite basemap since.
-        style: isGoogleBasemapRef.current
+        style: isGoogleBasemapRef.current && satelliteConfirmed()
           ? window.location.origin + satelliteStyleUrl()
           : getStyleForMap(styleUrl),
         center: [leftCenter.lng, leftCenter.lat],

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2976,65 +2976,65 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     leftClipContainerRef.current = leftClipContainer;
     compareContainerRef.current = rightClipContainer;
 
-    // Scenario labels on each side
-    const leftLabel = document.createElement('div');
-    leftLabel.id = 'left-label';
-    leftLabel.style.cssText = `
+    /**
+     * The three pane labels — the two scenario names and the factor between
+     * them — differ only in where they sit and which corners that leaves
+     * exposed. They were three copies of the same twelve declarations.
+     *
+     * All three hang from the top edge rather than floating inset from it: at
+     * six panes the inset pills read as clutter over the data, and pulling them
+     * flush turns them into part of the pane frame. Anything after the base
+     * wins, so a caller can override padding or background.
+     */
+    const labelStyle = (extra: string) => `
       position:absolute;
-      top:12px;
-      left:12px;
+      top:0;
       z-index:5;
       background:rgba(0,0,0,0.7);
       color:white;
-      padding:6px 14px;
-      border-radius:20px;
-      font-size:13px;
+      padding:2px 8px;
+      font-size:10px;
       font-weight:600;
-      letter-spacing:0.5px;
+      letter-spacing:0.3px;
       backdrop-filter:blur(8px);
-    `;
+    ` + extra;
+
+    // Scenario labels on each side
+    const leftLabel = document.createElement('div');
+    leftLabel.id = 'left-label';
+    leftLabel.style.cssText = labelStyle(`
+      left:0;
+      /* Only the corner facing the map is rounded: the other three are against
+         the pane's own edges, and rounding those left a floating pill with a
+         sliver of map showing through behind it. */
+      border-radius:0 0 10px 0;
+    `);
     container.appendChild(leftLabel);
 
     const rightLabel = document.createElement('div');
     rightLabel.id = 'right-label';
-    rightLabel.style.cssText = `
-      position:absolute;
-      top:12px;
-      right:12px;
-      z-index:5;
-      background:rgba(0,0,0,0.7);
-      color:white;
-      padding:6px 14px;
-      border-radius:20px;
-      font-size:13px;
-      font-weight:600;
-      letter-spacing:0.5px;
-      backdrop-filter:blur(8px);
-    `;
+    rightLabel.style.cssText = labelStyle(`
+      right:0;
+      border-radius:0 0 0 10px;
+    `);
     container.appendChild(rightLabel);
 
     // Indicator label (centered over split line)
     const indicatorLabel = document.createElement('div');
     indicatorLabel.id = 'indicator-label';
-    indicatorLabel.style.cssText = `
-      position:absolute;
-      top:12px;
+    indicatorLabel.style.cssText = labelStyle(`
       left:50%;
       transform:translateX(-50%);
+      /* Hangs off the top edge, so both bottom corners are the ones exposed. */
+      border-radius:0 0 10px 10px;
       z-index:15;
       background:rgba(0,0,0,0.85);
-      color:white;
-      padding:8px 20px;
-      border-radius:20px;
-      font-size:14px;
-      font-weight:600;
-      letter-spacing:0.5px;
-      backdrop-filter:blur(8px);
+      padding:2px 12px;
       white-space:nowrap;
       max-width:60%;
       overflow:hidden;
       text-overflow:ellipsis;
-    `;
+    `);
     container.appendChild(indicatorLabel);
 
     // Load style from server (mbtiles base layers)

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2836,19 +2836,20 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     // Create the slider with touch-action to prevent browser gestures
     const slider = document.createElement('div');
+    // Width, fill, shadow and their transition come from the .dt-swiper-line
+    // rule: inline styles would out-specify it, and the resting width depends on
+    // whether the pane is hovered, which JS here has no business knowing.
+    slider.className = 'dt-swiper-line';
+    slider.dataset.docked = '';
     slider.style.cssText = `
       position:absolute;
       top:0;
       left:0%;
-      width:12px;
       height:100%;
-      background:white;
       z-index:10;
       cursor:ew-resize;
-      box-shadow:0 0 8px rgba(0,0,0,0.4);
       transform:translateX(-50%);
       touch-action:none;
-      transition:background 0.2s ease, box-shadow 0.2s ease, width 0.2s ease;
     `;
 
     // Slider handle
@@ -2890,6 +2891,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     function updateSliderVisuals(docked: 'left' | 'right' | null) {
       if (docked === sliderDockedRef.current) return;
       sliderDockedRef.current = docked;
+      // Width, fill and shadow are the stylesheet's — see styles/paneChrome.css,
+      // which also thins the line while the pane is not hovered.
+      slider.dataset.docked = docked ?? '';
 
       // When docked to an edge, the map on that side is clipped to zero
       // width, so its scenario label would sit over the other side's map
@@ -2899,27 +2903,18 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
       if (docked === 'left') {
         // Docked left - half circle on right side
-        slider.style.background = 'transparent';
-        slider.style.boxShadow = 'none';
-        slider.style.width = '6px';
         handle.style.borderRadius = '0 50% 50% 0';
         handle.style.left = '100%';
         handle.style.transform = 'translate(0, -50%)';
         handle.innerHTML = ARROW_RIGHT;
       } else if (docked === 'right') {
         // Docked right - half circle on left side
-        slider.style.background = 'transparent';
-        slider.style.boxShadow = 'none';
-        slider.style.width = '6px';
         handle.style.borderRadius = '50% 0 0 50%';
         handle.style.left = '0';
         handle.style.transform = 'translate(-100%, -50%)';
         handle.innerHTML = ARROW_LEFT;
       } else {
         // Undocked - normal state
-        slider.style.background = 'white';
-        slider.style.boxShadow = '0 0 8px rgba(0,0,0,0.4)';
-        slider.style.width = '12px';
         handle.style.borderRadius = '50%';
         handle.style.left = '50%';
         handle.style.transform = 'translate(-50%, -50%)';
@@ -3566,6 +3561,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     if (newDockedState !== sliderDockedRef.current) {
       sliderDockedRef.current = newDockedState;
+      slider.dataset.docked = newDockedState ?? '';
 
       // Same rationale as updateSliderVisuals: the docked-away side's map
       // is clipped to zero width, so its scenario label would otherwise
@@ -3574,25 +3570,16 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       if (rightLabelEl) rightLabelEl.style.display = newDockedState === 'right' ? 'none' : 'block';
 
       if (newDockedState === 'left') {
-        slider.style.background = 'transparent';
-        slider.style.boxShadow = 'none';
-        slider.style.width = '6px';
         handle.style.borderRadius = '0 50% 50% 0';
         handle.style.left = '100%';
         handle.style.transform = 'translate(0, -50%)';
         handle.innerHTML = ARROW_RIGHT;
       } else if (newDockedState === 'right') {
-        slider.style.background = 'transparent';
-        slider.style.boxShadow = 'none';
-        slider.style.width = '6px';
         handle.style.borderRadius = '50% 0 0 50%';
         handle.style.left = '0';
         handle.style.transform = 'translate(-100%, -50%)';
         handle.innerHTML = ARROW_LEFT;
       } else {
-        slider.style.background = 'white';
-        slider.style.boxShadow = '0 0 8px rgba(0,0,0,0.4)';
-        slider.style.width = '12px';
         handle.style.borderRadius = '50%';
         handle.style.left = '50%';
         handle.style.transform = 'translate(-50%, -50%)';

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2994,6 +2994,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       color:white;
       padding:2px 8px;
       font-size:10px;
+      white-space:nowrap;
+      overflow:hidden;
       font-weight:600;
       letter-spacing:0.3px;
       backdrop-filter:blur(8px);
@@ -3002,6 +3004,11 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     // Scenario labels on each side
     const leftLabel = document.createElement('div');
     leftLabel.id = 'left-label';
+    // Collapses to its colour accent while the pane is at rest — see
+    // styles/paneChrome.css. The factor label deliberately does not: it names
+    // what the pane is showing, and a grid of six unlabelled maps is the thing
+    // worth avoiding.
+    leftLabel.className = 'dt-pane-label';
     leftLabel.style.cssText = labelStyle(`
       left:0;
       /* Only the corner facing the map is rounded: the other three are against
@@ -3013,6 +3020,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
     const rightLabel = document.createElement('div');
     rightLabel.id = 'right-label';
+    rightLabel.className = 'dt-pane-label';
     rightLabel.style.cssText = labelStyle(`
       right:0;
       border-radius:0 0 0 10px;

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -3686,7 +3686,12 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (leftLabel) {
       const leftInfo = SCENARIOS.find((s) => s.id === comparison.leftScenario);
       leftLabel.textContent = leftInfo?.label || comparison.leftScenario;
-      leftLabel.style.borderLeft = `3px solid ${leftInfo?.color || '#fff'}`;
+      // On the inward edge, the same as the right label's. Now that the label
+      // is flush in the top-left corner, its left edge is against the pane
+      // frame — an accent there reads as part of the frame rather than as the
+      // scenario's colour. Both labels point their accent at the map between
+      // them, which is what the colour identifies.
+      leftLabel.style.borderRight = `3px solid ${leftInfo?.color || '#fff'}`;
       // Keep it hidden if the swiper is docked left (left map clipped to
       // zero width), unless the swiper is off, in which case dock state is
       // irrelevant and the left map fills the view.
@@ -3696,6 +3701,8 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
     if (rightLabel) {
       const rightInfo = SCENARIOS.find((s) => s.id === comparison.rightScenario);
       rightLabel.textContent = rightInfo?.label || comparison.rightScenario;
+      // Already inward-facing: this one sits in the top-right corner, so its
+      // left edge is the one over the map.
       rightLabel.style.borderLeft = `3px solid ${rightInfo?.color || '#fff'}`;
       rightLabel.style.display = isSwiperEnabled && sliderDockedRef.current !== 'right' ? 'block' : 'none';
     }

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2990,8 +2990,6 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       position:absolute;
       top:0;
       z-index:5;
-      background:rgba(0,0,0,0.7);
-      color:white;
       padding:2px 8px;
       font-size:10px;
       white-space:nowrap;
@@ -3037,6 +3035,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       border-radius:0 0 10px 10px;
       z-index:15;
       background:rgba(0,0,0,0.85);
+      color:white;
       /* Keeps its original type and padding. The scenario labels either side
          are supporting text and shrank; this one names what the pane is
          showing, and is the only label worth reading from across a room. */
@@ -3704,7 +3703,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       // frame — an accent there reads as part of the frame rather than as the
       // scenario's colour. Both labels point their accent at the map between
       // them, which is what the colour identifies.
-      leftLabel.style.borderRight = `3px solid ${leftInfo?.color || '#fff'}`;
+      const leftAccent = leftInfo?.color || '#fff';
+      // The custom property is what the collapsed state fills with — see
+      // styles/paneChrome.css. Set here because only this side knows the
+      // scenario's colour, and read there so the border and the fill cannot
+      // disagree.
+      leftLabel.style.setProperty('--dt-accent', leftAccent);
+      leftLabel.style.borderRight = `3px solid ${leftAccent}`;
       // Keep it hidden if the swiper is docked left (left map clipped to
       // zero width), unless the swiper is off, in which case dock state is
       // irrelevant and the left map fills the view.
@@ -3716,7 +3721,9 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       rightLabel.textContent = rightInfo?.label || comparison.rightScenario;
       // Already inward-facing: this one sits in the top-right corner, so its
       // left edge is the one over the map.
-      rightLabel.style.borderLeft = `3px solid ${rightInfo?.color || '#fff'}`;
+      const rightAccent = rightInfo?.color || '#fff';
+      rightLabel.style.setProperty('--dt-accent', rightAccent);
+      rightLabel.style.borderLeft = `3px solid ${rightAccent}`;
       rightLabel.style.display = isSwiperEnabled && sliderDockedRef.current !== 'right' ? 'block' : 'none';
     }
 

--- a/frontend/src/components/TourGuide.tsx
+++ b/frontend/src/components/TourGuide.tsx
@@ -13,6 +13,7 @@ import {
 import { AnimatePresence, motion, useDragControls } from 'framer-motion';
 import { FiActivity, FiBarChart2, FiHelpCircle, FiMap, FiMapPin, FiX } from 'react-icons/fi';
 import { colors } from '../styles/colors';
+import { usePaneChromeForced } from '../hooks/usePaneChromeForced';
 import { createSite, listSites } from '../hooks/useApi';
 import { getAppRuntime } from '../types/runtime';
 import type { Site } from '../types';
@@ -301,6 +302,7 @@ export default function TourGuide() {
   const current = STEPS[step];
   const isLast = step === STEPS.length - 1;
   const rect = useSpotlightRect(visible ? current.targetId : undefined);
+  usePaneChromeForced(visible);
 
   if (!visible) return null;
 

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -569,6 +569,7 @@ function ViewPane({
 
   return (
     <Box
+      className="dt-pane"
       position="relative"
       w="100%"
       h="100%"
@@ -733,6 +734,7 @@ function ViewPane({
       {/* Per-pane toolbar */}
       <HStack
         id="tour-view-modes"
+        className="dt-pane-chrome"
         position="absolute"
         bottom={compact ? 2 : 3}
         right={compact ? 2 : 3}

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -42,11 +42,14 @@ interface ViewPaneProps {
   siteGeometry?: GeoJSON.Geometry | null;
   onBoundaryUpdate?: (geometry: GeoJSON.Geometry) => void;
   isSwiperEnabled?: boolean;
-  onSwiperEnabledChange?: (enabled: boolean) => void;
   colorScaleMode: ColorScaleMode;
   colorScaleType: ColorScaleType;
   is3DMode?: boolean;
-  on3DModeChange?: (enabled: boolean) => void;
+  // Global map toggles: one control in the header, every pane reflects it.
+  isIdentifyMode?: boolean;
+  isChoroplethEnabled?: boolean;
+  isGoogleBasemap?: boolean;
+  onGoogleBasemapChange?: (enabled: boolean) => void;
   // Slider synchronization
   swiperPosition?: number;
   onSwiperPositionChange?: (position: number) => void;
@@ -113,11 +116,13 @@ function ViewPane({
   siteGeometry,
   onBoundaryUpdate,
   isSwiperEnabled,
-  onSwiperEnabledChange,
   colorScaleMode,
   colorScaleType,
   is3DMode,
-  on3DModeChange,
+  isIdentifyMode,
+  isChoroplethEnabled,
+  isGoogleBasemap,
+  onGoogleBasemapChange,
   swiperPosition,
   onSwiperPositionChange,
   siteIndicators,
@@ -597,12 +602,14 @@ function ViewPane({
           siteGeometry={siteGeometry}
           onBoundaryUpdate={onBoundaryUpdate}
           isSwiperEnabled={isSwiperEnabled}
-          onSwiperEnabledChange={onSwiperEnabledChange}
           colorScaleMode={colorScaleMode}
           colorScaleType={colorScaleType}
           rangeMode={rangeMode}
           is3DMode={is3DMode}
-          on3DModeChange={on3DModeChange}
+          isIdentifyMode={isIdentifyMode}
+          isChoroplethEnabled={isChoroplethEnabled}
+          isGoogleBasemap={isGoogleBasemap}
+          onGoogleBasemapChange={onGoogleBasemapChange}
           swiperPosition={swiperPosition}
           onSwiperPositionChange={onSwiperPositionChange}
           refreshKey={refreshKey}

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -50,6 +50,7 @@ interface ViewPaneProps {
   isChoroplethEnabled?: boolean;
   isGoogleBasemap?: boolean;
   onGoogleBasemapChange?: (enabled: boolean) => void;
+  showNavigation?: boolean;
   // Slider synchronization
   swiperPosition?: number;
   onSwiperPositionChange?: (position: number) => void;
@@ -123,6 +124,7 @@ function ViewPane({
   isChoroplethEnabled,
   isGoogleBasemap,
   onGoogleBasemapChange,
+  showNavigation,
   swiperPosition,
   onSwiperPositionChange,
   siteIndicators,
@@ -611,6 +613,7 @@ function ViewPane({
           isChoroplethEnabled={isChoroplethEnabled}
           isGoogleBasemap={isGoogleBasemap}
           onGoogleBasemapChange={onGoogleBasemapChange}
+          showNavigation={showNavigation}
           swiperPosition={swiperPosition}
           onSwiperPositionChange={onSwiperPositionChange}
           refreshKey={refreshKey}

--- a/frontend/src/hooks/usePaneChromeForced.ts
+++ b/frontend/src/hooks/usePaneChromeForced.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * Keep the pane chrome visible while a guided tour is on screen.
+ *
+ * Pane controls hide themselves until the pointer is over the pane they act on
+ * (see styles/paneChrome.css). Two of them — the compare swiper handle and the
+ * pane toolbar — are tour targets, and a spotlight ring drawn around something
+ * invisible is worse than no ring at all.
+ *
+ * Shared by both tour components rather than written twice: they already carry
+ * duplicate spotlight implementations, and the override has to agree with the
+ * stylesheet's class name in one place, not two.
+ */
+export function usePaneChromeForced(active: boolean): void {
+  useEffect(() => {
+    document.body.classList.toggle('dt-tour-active', active);
+    return () => document.body.classList.remove('dt-tour-active');
+  }, [active]);
+}

--- a/frontend/src/lib/editableTargets.ts
+++ b/frontend/src/lib/editableTargets.ts
@@ -1,0 +1,60 @@
+import type { SiteIndicators } from '../types';
+
+/**
+ * Which attributes a user may set a target value for, for a given site.
+ *
+ * Extracted from ContentArea when the grid-wide controls moved into the header:
+ * the Targets button now lives in one place and the modal it opens in another,
+ * and both have to agree about whether there is anything to edit. Two copies of
+ * this filter chain would disagree the moment either was touched, and the
+ * disagreement would present as a button that opens an empty dialog.
+ *
+ * The rules, in order:
+ *
+ *   - the attribute must be one the catalogue permits a target on
+ *   - the site must have a value for it under ideal, reference or current
+ *   - it must have a finite reference or current reading, since a target is
+ *     meaningless without something to compare against
+ *   - herbivore attributes additionally need a non-zero reading: zero there
+ *     means the species is absent, not that it is at zero density
+ *
+ * Returned sorted by display label, deduplicated.
+ */
+export function editableTargetKeys(
+  siteIndicators: SiteIndicators | null | undefined,
+  targetInputs: Record<string, boolean>,
+  variableTypes: Record<string, string>,
+  attributeDetails: Record<string, string>,
+): string[] {
+  const availableKeys = new Set<string>();
+  Object.keys(siteIndicators?.ideal ?? {}).forEach((k) => availableKeys.add(k));
+  Object.keys(siteIndicators?.reference ?? {}).forEach((k) => availableKeys.add(k));
+  Object.keys(siteIndicators?.current ?? {}).forEach((k) => availableKeys.add(k));
+
+  const keys = Object.entries(targetInputs)
+    .filter(([, allowed]) => allowed)
+    .map(([key]) => key)
+    .filter((key) => availableKeys.has(key))
+    .filter((key) => {
+      const refVal = siteIndicators?.reference?.[key];
+      const curVal = siteIndicators?.current?.[key];
+      return (typeof refVal === 'number' && Number.isFinite(refVal)) ||
+        (typeof curVal === 'number' && Number.isFinite(curVal));
+    })
+    .filter((key) => {
+      if (variableTypes[key] !== 'Herbivores') return true;
+      const refVal = siteIndicators?.reference?.[key];
+      const curVal = siteIndicators?.current?.[key];
+      const refNum = typeof refVal === 'number' && Number.isFinite(refVal) ? refVal : 0;
+      const curNum = typeof curVal === 'number' && Number.isFinite(curVal) ? curVal : 0;
+      return refNum > 0 || curNum > 0;
+    });
+
+  return keys
+    .filter((key, idx, arr) => arr.indexOf(key) === idx)
+    .sort((a, b) => {
+      const aLabel = attributeDetails[a] ?? a;
+      const bLabel = attributeDetails[b] ?? b;
+      return aLabel.localeCompare(bLabel);
+    });
+}

--- a/frontend/src/lib/navigationPane.ts
+++ b/frontend/src/lib/navigationPane.ts
@@ -1,0 +1,32 @@
+/**
+ * Which pane carries the zoom cluster.
+ *
+ * Every map drew its own zoom in / zoom out / compass control at the bottom
+ * left, so a six-pane grid drew six of them. They are not six controls: every
+ * map in the grid is registered with useMapSync, and moving any one moves all
+ * the others, so all six did the same thing to all six maps. One is enough.
+ *
+ * It goes to the bottom-left map — furthest from the panes' own controls at the
+ * top and bottom right, and the corner a hand reaches for on a scrolled grid.
+ * "Bottom-left" is resolved against what is actually showing a map: a grid
+ * whose bottom-left widget is a chart still needs a zoom control somewhere, so
+ * the search walks up and to the right until it finds one.
+ */
+export function navigationPaneIndex(
+  visibleIndices: number[],
+  columns: number,
+  isMapPane: (paneIndex: number) => boolean,
+): number | null {
+  if (columns < 1) return null;
+
+  const rows = Math.ceil(visibleIndices.length / columns);
+  for (let row = rows - 1; row >= 0; row -= 1) {
+    for (let column = 0; column < columns; column += 1) {
+      const position = row * columns + column;
+      if (position >= visibleIndices.length) continue;
+      const paneIndex = visibleIndices[position];
+      if (isMapPane(paneIndex)) return paneIndex;
+    }
+  }
+  return null;
+}

--- a/frontend/src/lib/satelliteBasemap.ts
+++ b/frontend/src/lib/satelliteBasemap.ts
@@ -40,6 +40,14 @@ let quotaExceeded = false;
 // the first response keeps trying, rather than never offering satellite at
 // all while a perfectly good key is loading.
 let available = true;
+// Distinct from `available`: has the server actually said yes, rather than not
+// yet having said no. Optimism is right for whether to offer the control — a
+// key that is still loading should not disable it — and wrong for whether to
+// hand MapLibre a style URL. A map constructed against a style that 404s never
+// fires its 'load' event, and a pane whose map never loads sits behind a
+// spinner until the 15-second safety net gives up. The built-in style is local
+// and always there, so starting on it costs a style swap and nothing else.
+let confirmed = false;
 
 type UnavailableListener = (unavailable: boolean) => void;
 const unavailableListeners = new Set<UnavailableListener>();
@@ -71,6 +79,9 @@ export function applyServerSatelliteConfig(info: ServerInfo | null | undefined):
   const wasUnavailable = unavailable();
 
   quotaExceeded = info?.satellite_quota_exceeded ?? false;
+  // Only an explicit true. A missing field means an older server that cannot
+  // tell us, which is exactly the case not to gamble on.
+  confirmed = info?.satellite_available === true;
   // Missing field (an older server, or a response that raced applyServer-
   // SatelliteConfig before /api/info finished) defaults to available: the
   // same "assume it works" the module-level default above already commits to.
@@ -79,6 +90,18 @@ export function applyServerSatelliteConfig(info: ServerInfo | null | undefined):
   if (unavailable() !== wasUnavailable) {
     for (const listener of unavailableListeners) listener(unavailable());
   }
+}
+
+/**
+ * Whether satellite imagery is safe to hand to MapLibre right now.
+ *
+ * Use this to choose a style URL. Use satelliteUnavailable() to decide whether
+ * to offer the control: the two differ for the whole window between the map
+ * being constructed and /api/info resolving, and that window is precisely when
+ * a wrong guess strands a pane behind a spinner.
+ */
+export function satelliteConfirmed(): boolean {
+  return confirmed && !quotaExceeded;
 }
 
 /** The (local, proxied) style URL to pass to maplibre. */
@@ -127,6 +150,7 @@ export function subscribeSatelliteUnavailable(listener: UnavailableListener): ()
 /** Exported for tests. */
 export function resetSatelliteConfig(): void {
   styleUrl = DEFAULT_SATELLITE_STYLE_URL;
+  confirmed = false;
   attribution = DEFAULT_SATELLITE_ATTRIBUTION;
   quotaExceeded = false;
   available = true;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import { theme } from './styles/theme';
 // Vite fingerprints and bundles them, and so no build or launch reaches out to
 // a font CDN — the desktop application is offline by design.
 import './assets/fonts/fonts.css';
+import './styles/paneChrome.css';
 
 // Global error reporting, development only.
 //

--- a/frontend/src/styles/paneChrome.css
+++ b/frontend/src/styles/paneChrome.css
@@ -123,3 +123,19 @@
     transition: none;
   }
 }
+
+/*
+ * One zoom cluster for a grid of maps.
+ *
+ * Every map registers with useMapSync and moving any one moves all the others,
+ * so six zoom clusters were six ways to do the same thing to the same six maps.
+ * lib/navigationPane.ts picks which pane keeps its own; the rest carry this
+ * class. The control stays in the DOM because which pane owns it changes while
+ * the application runs, and hiding is reactive where addControl is not.
+ *
+ * .maplibregl-ctrl-bottom-left is MapLibre's own positioning class, part of the
+ * stylesheet the library ships for placing controls in a corner.
+ */
+.dt-no-nav .maplibregl-ctrl-bottom-left {
+  display: none;
+}

--- a/frontend/src/styles/paneChrome.css
+++ b/frontend/src/styles/paneChrome.css
@@ -139,3 +139,45 @@
 .dt-no-nav .maplibregl-ctrl-bottom-left {
   display: none;
 }
+
+/*
+ * The scenario labels collapse to their colour accent.
+ *
+ * At rest a pane should be its map. "Ecological Reference" and "Current State"
+ * answer a question — which side of the swiper is which — that only matters once
+ * someone is looking at that pane, and the answer survives the collapse anyway:
+ * each label carries a 3px edge in its scenario's colour, and that edge is what
+ * is left behind. Six panes go from eighteen pills to six titles and twelve
+ * coloured ticks.
+ *
+ * The factor label is deliberately not in this set. It names what the pane is
+ * showing, and a grid of six unlabelled maps is exactly the thing worth
+ * avoiding. It also has no accent, so there would be nothing left of it.
+ *
+ * max-width is the animatable property here, because the labels have no fixed
+ * width to travel between. The cost is that the reveal finishes slightly before
+ * the transition does, on a label whose text is shorter than the bound.
+ */
+@media (hover: hover) and (pointer: fine) {
+  .dt-pane-label {
+    max-width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    transition: max-width 220ms ease, padding 220ms ease;
+  }
+
+  .dt-pane:hover .dt-pane-label,
+  .dt-pane:focus-within .dt-pane-label,
+  body.dt-tour-active .dt-pane-label {
+    /* Wide enough for the longest scenario name at this size, and no wider. */
+    max-width: 14em;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dt-pane-label {
+    transition: none;
+  }
+}

--- a/frontend/src/styles/paneChrome.css
+++ b/frontend/src/styles/paneChrome.css
@@ -1,0 +1,62 @@
+/*
+ * Pane chrome that appears on mouse over.
+ *
+ * A six-pane grid drew its controls six times over. The toggles that acted on
+ * every pane have moved to one cluster in the header; what is left here are the
+ * controls that genuinely belong to a single pane — focus it, configure its
+ * factor, remove it, drag its compare swiper. Those cannot move anywhere, so
+ * they get out of the way instead, and come back when the pointer is over the
+ * pane they act on.
+ *
+ * Written as CSS rather than Chakra props because it has to cover both: the
+ * pane toolbar is a React component and the swiper handle is a DOM node built
+ * imperatively inside MapView. One rule covers both, so the timing cannot
+ * drift between them.
+ */
+
+/*
+ * Only where hovering exists. On a touch screen there is no hover to reveal
+ * with, so a control hidden this way would be a control that is simply gone —
+ * everything stays visible there.
+ */
+@media (hover: hover) and (pointer: fine) {
+  .dt-pane-chrome {
+    opacity: 0;
+    /* Not clickable while invisible: an invisible hit target that swallows a
+       map click is worse than a visible button. */
+    pointer-events: none;
+    transition: opacity 160ms ease;
+  }
+
+  /*
+   * focus-within matters as much as hover: these are real controls, and a
+   * keyboard user tabbing into one must be able to see where they are. Focus
+   * still reaches them while pointer-events is none — that property only
+   * affects the pointer.
+   */
+  .dt-pane:hover .dt-pane-chrome,
+  .dt-pane:focus-within .dt-pane-chrome {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /*
+   * The guided tour spotlights some of this chrome by id. A ring drawn around
+   * something invisible is worse than no ring, so a running tour overrides the
+   * hiding for as long as it is on screen.
+   */
+  body.dt-tour-active .dt-pane-chrome {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+/*
+ * Someone who has asked for less motion still gets the reveal — it is the
+ * animation that is unwelcome, not the control appearing.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .dt-pane-chrome {
+    transition: none;
+  }
+}

--- a/frontend/src/styles/paneChrome.css
+++ b/frontend/src/styles/paneChrome.css
@@ -60,3 +60,66 @@
     transition: none;
   }
 }
+
+/*
+ * The compare swiper's divider line.
+ *
+ * The line is information, not a control: it says which side of the map belongs
+ * to which scenario, so unlike the handle it stays visible. But at 12px across
+ * six panes it was one of the loudest things on the screen, and most of that
+ * width exists to be grabbed — which only matters once the pointer is on the
+ * pane. So it rests thin and thickens with the rest of the chrome.
+ *
+ * These four properties used to be set inline from JavaScript, in six places
+ * across two duplicated blocks. They are one rule now; MapView sets
+ * data-docked and nothing else.
+ */
+.dt-swiper-line {
+  width: 12px;
+  background: white;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+  transition: width 200ms ease, background 200ms ease, box-shadow 200ms ease;
+}
+
+/*
+ * Docked to an edge: the line itself disappears and the handle becomes a
+ * half-circle tab against the frame, which is the only way back.
+ */
+.dt-swiper-line[data-docked='left'],
+.dt-swiper-line[data-docked='right'] {
+  width: 6px;
+  background: transparent;
+  box-shadow: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .dt-swiper-line {
+    width: 3px;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+  }
+
+  .dt-pane:hover .dt-swiper-line,
+  .dt-pane:focus-within .dt-swiper-line,
+  body.dt-tour-active .dt-swiper-line {
+    width: 12px;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Docked stays docked, hovered or not: there is no line to widen. */
+  .dt-pane:hover .dt-swiper-line[data-docked='left'],
+  .dt-pane:hover .dt-swiper-line[data-docked='right'],
+  .dt-pane:focus-within .dt-swiper-line[data-docked='left'],
+  .dt-pane:focus-within .dt-swiper-line[data-docked='right'],
+  body.dt-tour-active .dt-swiper-line[data-docked='left'],
+  body.dt-tour-active .dt-swiper-line[data-docked='right'] {
+    width: 6px;
+    background: transparent;
+    box-shadow: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dt-swiper-line {
+    transition: none;
+  }
+}

--- a/frontend/src/styles/paneChrome.css
+++ b/frontend/src/styles/paneChrome.css
@@ -145,15 +145,24 @@
  *
  * At rest a pane should be its map. "Ecological Reference" and "Current State"
  * answer a question — which side of the swiper is which — that only matters once
- * someone is looking at that pane, and the answer survives the collapse anyway:
- * each label carries a 3px edge in its scenario's colour, and that edge is what
- * is left behind. Six panes go from eighteen pills to six titles and twelve
- * coloured ticks.
+ * someone is looking at that pane, and the answer survives the collapse: what is
+ * left is a small tick in the scenario's own colour, so the coding that made the
+ * label useful is the part that stays.
  *
  * The factor label is deliberately not in this set. It names what the pane is
  * showing, and a grid of six unlabelled maps is exactly the thing worth
  * avoiding. It also has no accent, so there would be nothing left of it.
  *
+ * Fill and text colour live here rather than inline on the element, because an
+ * inline background would out-specify the collapsed state and the tick would
+ * stay black.
+ */
+.dt-pane-label {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+}
+
+/*
  * max-width is the animatable property here, because the labels have no fixed
  * width to travel between. The cost is that the reveal finishes slightly before
  * the transition does, on a label whose text is shorter than the bound.
@@ -161,9 +170,24 @@
 @media (hover: hover) and (pointer: fine) {
   .dt-pane-label {
     max-width: 0;
-    padding-left: 0;
-    padding-right: 0;
-    transition: max-width 220ms ease, padding 220ms ease;
+    /* Not zero: the padding is what gives the collapsed tick a body to fill.
+       With the border alone it would be a 3px hairline, too thin to read as a
+       colour at all. Three each side plus the border makes a 9px tab. */
+    padding-left: 3px;
+    padding-right: 3px;
+    /* The whole tick is the accent, so the border stops being a separate mark
+       and the label reads as one small block of the scenario's colour. The
+       fallback matters: --dt-accent is set by MapView once the scenario is
+       known, and the label exists before that. */
+    background-color: var(--dt-accent, rgba(0, 0, 0, 0.7));
+    /* Clipped by overflow already; transparent text also fades it out on the
+       way, rather than having it appear the instant there is room. */
+    color: transparent;
+    transition:
+      max-width 220ms ease,
+      padding 220ms ease,
+      background-color 220ms ease,
+      color 220ms ease;
   }
 
   .dt-pane:hover .dt-pane-label,
@@ -173,6 +197,8 @@
     max-width: 14em;
     padding-left: 8px;
     padding-right: 8px;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
   }
 }
 

--- a/frontend/src/test/gridControls.test.tsx
+++ b/frontend/src/test/gridControls.test.tsx
@@ -17,6 +17,7 @@ import { render, screen, within, cleanup, fireEvent } from '@testing-library/rea
 import { ChakraProvider } from '@chakra-ui/react';
 import { theme } from '../styles/theme';
 import GridControls from '../components/GridControls';
+import Header from '../components/Header';
 import { resetSatelliteConfig, applyServerSatelliteConfig } from '../lib/satelliteBasemap';
 
 type Props = ComponentProps<typeof GridControls>;
@@ -126,5 +127,41 @@ describe('GridControls map toggles', () => {
     ]) {
       expect(within(menu).getByText(label)).toBeInTheDocument();
     }
+  });
+});
+
+describe('Header placement', () => {
+  /**
+   * The cluster was gated on `currentPage === 'map'` and vanished in explore
+   * mode — which renders the same six-pane grid, just without a site selected.
+   * The pane grid is the thing these controls act on, and only that render
+   * passes gridControls, so the props are the gate.
+   */
+  const gridControls = {
+    viewMode: 'map' as const,
+    onViewModeChange: () => {},
+    siteId: null,
+    is3DMode: false,
+    onIs3DModeChange: () => {},
+  };
+
+  it.each(['map', 'explore'] as const)('shows the controls on the %s page', (page) => {
+    render(
+      <ChakraProvider theme={theme}>
+        <Header onToggleDocs={() => {}} isDocsOpen={false} currentPage={page} gridControls={gridControls} />
+      </ChakraProvider>,
+    );
+    expect(screen.getAllByRole('radiogroup', { name: 'View for all panes' }).length)
+      .toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('Show 3D extrusion').length).toBeGreaterThan(0);
+  });
+
+  it('shows nothing when no grid is on screen to control', () => {
+    render(
+      <ChakraProvider theme={theme}>
+        <Header onToggleDocs={() => {}} isDocsOpen={false} currentPage="landing" />
+      </ChakraProvider>,
+    );
+    expect(screen.queryByRole('radiogroup', { name: 'View for all panes' })).toBeNull();
   });
 });

--- a/frontend/src/test/gridControls.test.tsx
+++ b/frontend/src/test/gridControls.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The consolidated grid controls.
+ *
+ * Five map toggles — 3D, choropleth, identify, satellite, swiper — used to be a
+ * vertical stack of circular IconButtons drawn inside every MapView. Every one
+ * of them acted on all panes, so a six-pane grid drew thirty buttons for five
+ * settings, and clicking any copy moved all of them. They are drawn once now,
+ * in the header.
+ *
+ * These tests pin the properties that made the old arrangement wrong: one
+ * control per setting, a state a screen reader can report, and — for the
+ * narrow layout — a route to every control rather than `display: none`.
+ */
+import type { ComponentProps } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, within, cleanup, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import GridControls from '../components/GridControls';
+import { resetSatelliteConfig, applyServerSatelliteConfig } from '../lib/satelliteBasemap';
+
+type Props = ComponentProps<typeof GridControls>;
+
+function renderControls(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onViewModeChange: vi.fn(),
+    onIs3DModeChange: vi.fn(),
+    onChoroplethEnabledChange: vi.fn(),
+    onIdentifyModeChange: vi.fn(),
+    onGoogleBasemapChange: vi.fn(),
+    onSwiperEnabledChange: vi.fn(),
+  };
+  const props: Props = {
+    viewMode: 'map',
+    siteId: 'site-1',
+    is3DMode: false,
+    isChoroplethEnabled: true,
+    isIdentifyMode: false,
+    isGoogleBasemap: false,
+    isSwiperEnabled: true,
+    ...handlers,
+    ...overrides,
+  };
+  render(
+    <ChakraProvider theme={theme}>
+      <GridControls {...props} />
+    </ChakraProvider>,
+  );
+  // Both responsive layouts are in the DOM: jsdom applies no media queries, so
+  // Chakra's display:{base,xl} cannot hide either one. Queries are scoped to a
+  // layout so a duplicate within one is still a failure.
+  return {
+    ...handlers,
+    wide: within(screen.getByTestId('grid-controls-wide')),
+    narrow: within(screen.getByTestId('grid-controls-narrow')),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  resetSatelliteConfig();
+});
+
+describe('GridControls map toggles', () => {
+  it('draws one control per setting, not one per pane', () => {
+    const { wide } = renderControls();
+    for (const label of [
+      'Show 3D extrusion', 'Hide choropleth', 'Identify catchment',
+      'Switch to satellite', 'Disable map swiper', 'Zoom to site',
+    ]) {
+      expect(wide.getAllByLabelText(label)).toHaveLength(1);
+    }
+  });
+
+  it('reports its state through aria-pressed rather than colour alone', () => {
+    const { wide } = renderControls({ is3DMode: true, isIdentifyMode: false });
+    expect(wide.getByLabelText('Show flat map')).toHaveAttribute('aria-pressed', 'true');
+    expect(wide.getByLabelText('Identify catchment')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('asks for the opposite of the current value', () => {
+    const handlers = renderControls({ isChoroplethEnabled: true });
+    fireEvent.click(handlers.wide.getByLabelText('Hide choropleth'));
+    expect(handlers.onChoroplethEnabledChange).toHaveBeenCalledWith(false);
+  });
+
+  it('hides the map toggles when the panes are not showing maps', () => {
+    renderControls({ viewMode: 'table' });
+    expect(screen.queryByLabelText('Identify catchment')).toBeNull();
+    expect(screen.queryByLabelText('Zoom to site')).toBeNull();
+  });
+
+  it('broadcasts zoom-to-site, because the header cannot reach a pane map', () => {
+    const heard = vi.fn();
+    window.addEventListener('dt:zoom-to-site', heard);
+    const { wide } = renderControls();
+    fireEvent.click(wide.getByLabelText('Zoom to site'));
+    window.removeEventListener('dt:zoom-to-site', heard);
+    expect(heard).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables zoom-to-site with no site to zoom to', () => {
+    const { wide } = renderControls({ siteId: null });
+    expect(wide.getByLabelText('Zoom to site')).toBeDisabled();
+  });
+
+  it('disables satellite when the server reports no provider', () => {
+    applyServerSatelliteConfig({ satellite_available: false } as never);
+    const { wide } = renderControls({ isGoogleBasemap: false });
+    expect(wide.getByLabelText('Switch to satellite')).toBeDisabled();
+  });
+
+  it('omits a toggle whose handler was not supplied', () => {
+    const { wide } = renderControls({ onIdentifyModeChange: undefined });
+    expect(screen.queryByLabelText('Identify catchment')).toBeNull();
+    expect(wide.getByLabelText('Show 3D extrusion')).toBeInTheDocument();
+  });
+
+  it('routes every control into the overflow menu on a narrow screen', async () => {
+    const { narrow } = renderControls();
+    fireEvent.click(narrow.getByLabelText('More controls'));
+    const menu = await screen.findByRole('menu');
+    for (const label of [
+      'Show 3D extrusion', 'Hide choropleth', 'Identify catchment',
+      'Switch to satellite', 'Disable map swiper', 'Zoom to site',
+    ]) {
+      expect(within(menu).getByText(label)).toBeInTheDocument();
+    }
+  });
+});

--- a/frontend/src/test/navigationPane.test.ts
+++ b/frontend/src/test/navigationPane.test.ts
@@ -1,0 +1,49 @@
+/**
+ * One zoom cluster for a grid of maps, not one per pane.
+ *
+ * Every map in the grid is registered with useMapSync, so moving any one moves
+ * all the others: six zoom clusters were six ways to do the same thing.
+ */
+import { describe, it, expect } from 'vitest';
+import { navigationPaneIndex } from '../lib/navigationPane';
+
+const allMaps = () => true;
+
+describe('navigationPaneIndex', () => {
+  it('picks the bottom-left pane of a full grid', () => {
+    // 6 panes, 3 across: bottom row is 3,4,5 — bottom-left is 3.
+    expect(navigationPaneIndex([0, 1, 2, 3, 4, 5], 3, allMaps)).toBe(3);
+    // 6 panes, 2 across: bottom row is 4,5 — bottom-left is 4.
+    expect(navigationPaneIndex([0, 1, 2, 3, 4, 5], 2, allMaps)).toBe(4);
+  });
+
+  it('picks the bottom-left of a part-filled last row', () => {
+    // 5 panes, 3 across: last row holds 3 and 4 only.
+    expect(navigationPaneIndex([0, 1, 2, 3, 4], 3, allMaps)).toBe(3);
+  });
+
+  it('is the only pane, when there is only one', () => {
+    expect(navigationPaneIndex([2], 1, allMaps)).toBe(2);
+    expect(navigationPaneIndex([2], 3, allMaps)).toBe(2);
+  });
+
+  it('walks up and right when the bottom-left pane is not a map', () => {
+    // 3,4 are charts; 5 is a map, same row, to the right.
+    expect(navigationPaneIndex([0, 1, 2, 3, 4, 5], 3, (i) => i === 5)).toBe(5);
+    // The whole bottom row is charts: the control moves up a row.
+    expect(navigationPaneIndex([0, 1, 2, 3, 4, 5], 3, (i) => i < 3)).toBe(0);
+  });
+
+  it('gives no pane the control when no pane shows a map', () => {
+    expect(navigationPaneIndex([0, 1, 2], 2, () => false)).toBeNull();
+  });
+
+  it('follows the visible panes, not their indices', () => {
+    // Panes are removable, so the visible set is not always 0..n.
+    expect(navigationPaneIndex([1, 4, 7, 9], 2, allMaps)).toBe(7);
+  });
+
+  it('refuses a nonsense column count rather than looping', () => {
+    expect(navigationPaneIndex([0, 1], 0, allMaps)).toBeNull();
+  });
+});

--- a/frontend/src/test/paneChrome.test.tsx
+++ b/frontend/src/test/paneChrome.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
 vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
 
 const CSS = readFileSync('src/styles/paneChrome.css', 'utf8');
+const MAPVIEW = readFileSync('src/components/MapView.tsx', 'utf8');
 
 const comparison: ComparisonState = {
   leftScenario: 'current',
@@ -115,6 +116,41 @@ describe('pane chrome stylesheet', () => {
 
   it('selects the class the tour override sets', () => {
     expect(CSS).toContain('body.dt-tour-active .dt-pane-chrome');
+  });
+});
+
+describe('the compare swiper divider', () => {
+  it('rests thin and thickens with the rest of the chrome', () => {
+    const hover = CSS.indexOf('@media (hover: hover) and (pointer: fine)');
+    const thin = CSS.indexOf('width: 3px');
+    expect(thin).toBeGreaterThan(hover);
+    expect(CSS).toContain('.dt-pane:hover .dt-swiper-line');
+    expect(CSS).toContain('.dt-pane:focus-within .dt-swiper-line');
+  });
+
+  it('stays visible rather than hiding like the handle', () => {
+    // The line says which side of the map is which scenario. Losing it is
+    // losing information, not losing a control.
+    expect(CSS).not.toContain('.dt-swiper-line {\n  opacity: 0');
+    const base = CSS.slice(CSS.indexOf('.dt-swiper-line {'));
+    expect(base.slice(0, base.indexOf('}'))).toContain('background: white');
+  });
+
+  it('is driven by an attribute MapView sets, not by inline styles', () => {
+    // Six sets of inline width/background/box-shadow across two duplicated
+    // blocks used to do this. Inline styles would out-specify the rule above,
+    // so a stray one silently disables the whole behaviour.
+    expect(MAPVIEW).not.toMatch(/slider\.style\.(width|background|boxShadow)/);
+    // Both docking paths — the drag handler and the synced-position effect.
+    expect(MAPVIEW.match(/slider\.dataset\.docked/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('keeps a docked divider docked whether hovered or not', () => {
+    // Docked, the line is gone and the handle is a half-circle tab against the
+    // frame — the only way back. Widening it on hover would draw a white bar
+    // over a map that is clipped to zero width on that side.
+    expect(CSS).toContain("body.dt-tour-active .dt-swiper-line[data-docked='right']");
+    expect(CSS).toContain(".dt-pane:hover .dt-swiper-line[data-docked='left']");
   });
 });
 

--- a/frontend/src/test/paneChrome.test.tsx
+++ b/frontend/src/test/paneChrome.test.tsx
@@ -171,6 +171,41 @@ describe('the zoom cluster', () => {
   });
 });
 
+describe('the scenario labels', () => {
+  it('collapses to the accent, and only where there is a pointer to hover', () => {
+    const guard = CSS.indexOf('@media (hover: hover) and (pointer: fine)');
+    const collapse = CSS.indexOf('.dt-pane-label {');
+    expect(collapse).toBeGreaterThan(guard);
+    // The accent is a border, so zeroing width and padding leaves it standing.
+    // Zeroing the border instead would leave nothing at all.
+    const rule = CSS.slice(collapse, CSS.indexOf('}', collapse));
+    expect(rule).toContain('max-width: 0');
+    expect(rule).toContain('padding-left: 0');
+    expect(rule).not.toContain('border');
+  });
+
+  it('clips rather than wraps on the way down', () => {
+    // Without nowrap the text reflows to one word per line as the box narrows,
+    // and the label grows tall while it is meant to be disappearing.
+    const style = MAPVIEW.slice(MAPVIEW.indexOf('const labelStyle'));
+    const base = style.slice(0, style.indexOf('` + extra'));
+    expect(base).toContain('white-space:nowrap');
+    expect(base).toContain('overflow:hidden');
+  });
+
+  it('leaves the factor label alone', () => {
+    // It names what the pane is showing, and has no accent to be left with.
+    const indicator = MAPVIEW.slice(MAPVIEW.indexOf("indicatorLabel.id = 'indicator-label'"));
+    expect(indicator.slice(0, indicator.indexOf('container.appendChild')))
+      .not.toContain('dt-pane-label');
+  });
+
+  it('is applied to both scenario labels', () => {
+    expect(MAPVIEW).toContain("leftLabel.className = 'dt-pane-label'");
+    expect(MAPVIEW).toContain("rightLabel.className = 'dt-pane-label'");
+  });
+});
+
 describe('usePaneChromeForced', () => {
   it('lifts the hiding while a tour is on screen, and puts it back after', () => {
     const { rerender, unmount } = renderHook(

--- a/frontend/src/test/paneChrome.test.tsx
+++ b/frontend/src/test/paneChrome.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Pane chrome that appears on mouse over.
+ *
+ * The controls that act on the whole grid have moved to the header. What is
+ * left on a pane is what genuinely belongs to that pane — focus it, configure
+ * its factor, remove it, drag its compare swiper — and those get out of the way
+ * until the pointer is over the pane they act on.
+ *
+ * jsdom applies no stylesheets, so opacity cannot be asserted here. What these
+ * tests pin is the contract the one stylesheet is written against: the hover
+ * scope and the hidden elements carry the classes it selects on, and a running
+ * tour lifts the hiding. Those are the parts that break silently when someone
+ * edits the markup.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, renderHook, cleanup } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import { usePaneChromeForced } from '../hooks/usePaneChromeForced';
+import type { ComparisonState } from '../types';
+
+vi.mock('../components/MapView', () => ({ default: () => <div data-testid="map-view" /> }));
+vi.mock('../components/ChartView', () => ({ default: () => <div /> }));
+vi.mock('../components/DialChart', () => ({ default: () => <div /> }));
+vi.mock('../components/AggregateTable', () => ({ default: () => <div /> }));
+
+const CSS = readFileSync('src/styles/paneChrome.css', 'utf8');
+
+const comparison: ComparisonState = {
+  leftScenario: 'current',
+  rightScenario: 'future',
+  attribute: '',
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { headers: { 'content-type': 'application/json' } })),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.classList.remove('dt-tour-active');
+});
+
+async function renderPane() {
+  const ViewPane = (await import('../components/ViewPane')).default;
+  return render(
+    <ChakraProvider theme={theme}>
+      <ViewPane
+        comparison={comparison}
+        paneIndex={0}
+        layoutMode="quad"
+        viewMode="map"
+        onViewModeChange={() => {}}
+        onFocusPane={() => {}}
+        onGoQuad={() => {}}
+        onOpenControlPanel={() => {}}
+        colorScaleMode="rainbow"
+        colorScaleType="linear"
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe('ViewPane chrome', () => {
+  it('makes the pane the hover scope', async () => {
+    const { container } = await renderPane();
+    expect(container.querySelectorAll('.dt-pane')).toHaveLength(1);
+  });
+
+  it('puts the per-pane toolbar inside that scope, marked to hide', async () => {
+    const { container } = await renderPane();
+    const pane = container.querySelector('.dt-pane');
+    const toolbar = container.querySelector('.dt-pane-chrome');
+    expect(toolbar).not.toBeNull();
+    // The selector is `.dt-pane:hover .dt-pane-chrome` — a descendant
+    // combinator, so a toolbar outside the pane would never be revealed.
+    expect(pane?.contains(toolbar!)).toBe(true);
+  });
+
+  it('keeps the pane\'s own controls in the pane', async () => {
+    // The point of the hover reveal is that these could not move to the header
+    // the way the global toggles did: they act on one pane, so six panes
+    // legitimately need six of them.
+    const { getByLabelText } = await renderPane();
+    expect(getByLabelText('Focus pane')).toBeInTheDocument();
+    expect(getByLabelText('Configure factor')).toBeInTheDocument();
+  });
+});
+
+describe('pane chrome stylesheet', () => {
+  it('hides the chrome only where a pointer can hover', () => {
+    // Without this guard a touch user loses the controls outright: there is no
+    // hover to bring them back with.
+    const guard = CSS.indexOf('@media (hover: hover) and (pointer: fine)');
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(CSS.indexOf('opacity: 0')).toBeGreaterThan(guard);
+  });
+
+  it('reveals on focus as well as hover', () => {
+    // A keyboard user tabbing into a control must be able to see where they are.
+    expect(CSS).toContain('.dt-pane:hover .dt-pane-chrome');
+    expect(CSS).toContain('.dt-pane:focus-within .dt-pane-chrome');
+  });
+
+  it('does not leave an invisible element swallowing map clicks', () => {
+    expect(CSS).toContain('pointer-events: none');
+    expect(CSS).toContain('pointer-events: auto');
+  });
+
+  it('selects the class the tour override sets', () => {
+    expect(CSS).toContain('body.dt-tour-active .dt-pane-chrome');
+  });
+});
+
+describe('usePaneChromeForced', () => {
+  it('lifts the hiding while a tour is on screen, and puts it back after', () => {
+    const { rerender, unmount } = renderHook(
+      ({ active }) => usePaneChromeForced(active),
+      { initialProps: { active: true } },
+    );
+    expect(document.body.classList.contains('dt-tour-active')).toBe(true);
+
+    rerender({ active: false });
+    expect(document.body.classList.contains('dt-tour-active')).toBe(false);
+
+    rerender({ active: true });
+    unmount();
+    expect(document.body.classList.contains('dt-tour-active')).toBe(false);
+  });
+});

--- a/frontend/src/test/paneChrome.test.tsx
+++ b/frontend/src/test/paneChrome.test.tsx
@@ -171,17 +171,42 @@ describe('the zoom cluster', () => {
   });
 });
 
+/**
+ * The stylesheet carries three `.dt-pane-label` rules, in this order: the
+ * unconditional appearance, the collapsed state inside the hover guard, and the
+ * reduced-motion override. Addressing them by position beats matching the first
+ * one and hoping — which is what these tests did until the collapsed rule
+ * stopped being the only one.
+ */
+const labelRules = [...CSS.matchAll(/\.dt-pane-label \{([^}]*)\}/g)].map((m) => m[1]);
+const [labelBase, labelCollapsed] = labelRules;
+
 describe('the scenario labels', () => {
-  it('collapses to the accent, and only where there is a pointer to hover', () => {
-    const guard = CSS.indexOf('@media (hover: hover) and (pointer: fine)');
-    const collapse = CSS.indexOf('.dt-pane-label {');
-    expect(collapse).toBeGreaterThan(guard);
-    // The accent is a border, so zeroing width and padding leaves it standing.
-    // Zeroing the border instead would leave nothing at all.
-    const rule = CSS.slice(collapse, CSS.indexOf('}', collapse));
-    expect(rule).toContain('max-width: 0');
-    expect(rule).toContain('padding-left: 0');
-    expect(rule).not.toContain('border');
+  it('gives the expanded appearance unconditionally', () => {
+    // The touch case: nothing ever hovers, so whatever is outside the guard is
+    // what a touch user gets, permanently.
+    expect(labelBase).toContain('background-color: rgba(0, 0, 0, 0.7)');
+    expect(labelBase).toContain('color: white');
+    expect(labelBase).not.toContain('max-width: 0');
+  });
+
+  it('collapses only where there is a pointer to hover', () => {
+    const guard = CSS.lastIndexOf('@media (hover: hover) and (pointer: fine)');
+    expect(CSS.indexOf(labelCollapsed)).toBeGreaterThan(guard);
+    expect(labelCollapsed).toContain('max-width: 0');
+  });
+
+  it('fills the collapsed tick with the accent, and gives it a body to fill', () => {
+    expect(labelCollapsed).toContain('background-color: var(--dt-accent');
+    // Zero padding would leave the 3px border alone — a hairline, too thin to
+    // read as a colour. The padding is what there is to fill.
+    expect(labelCollapsed).not.toContain('padding-left: 0');
+    // A fallback matters: the label exists before the scenario is known.
+    expect(labelCollapsed).toContain('var(--dt-accent, ');
+  });
+
+  it('hides the text rather than relying on the clip alone', () => {
+    expect(labelCollapsed).toContain('color: transparent');
   });
 
   it('clips rather than wraps on the way down', () => {
@@ -191,6 +216,22 @@ describe('the scenario labels', () => {
     const base = style.slice(0, style.indexOf('` + extra'));
     expect(base).toContain('white-space:nowrap');
     expect(base).toContain('overflow:hidden');
+  });
+
+  it('keeps fill and text colour out of the inline style', () => {
+    // An inline background would out-specify the collapsed rule and the tick
+    // would stay black.
+    const style = MAPVIEW.slice(MAPVIEW.indexOf('const labelStyle'));
+    const base = style.slice(0, style.indexOf('` + extra'));
+    expect(base).not.toContain('background');
+    expect(base).not.toContain('color:');
+  });
+
+  it('sets the accent in one place, so border and fill cannot disagree', () => {
+    expect(MAPVIEW).toContain("leftLabel.style.setProperty('--dt-accent', leftAccent)");
+    expect(MAPVIEW).toContain('borderRight = `3px solid ${leftAccent}`');
+    expect(MAPVIEW).toContain("rightLabel.style.setProperty('--dt-accent', rightAccent)");
+    expect(MAPVIEW).toContain('borderLeft = `3px solid ${rightAccent}`');
   });
 
   it('leaves the factor label alone', () => {

--- a/frontend/src/test/paneChrome.test.tsx
+++ b/frontend/src/test/paneChrome.test.tsx
@@ -154,6 +154,23 @@ describe('the compare swiper divider', () => {
   });
 });
 
+describe('the zoom cluster', () => {
+  it('hides MapLibre\'s own control on every pane but one', () => {
+    // MapLibre's positioning class, part of the stylesheet the library ships.
+    expect(CSS).toContain('.dt-no-nav .maplibregl-ctrl-bottom-left');
+    expect(CSS).toContain('display: none');
+  });
+
+  it('is not skipped at construction, so it can follow the layout', () => {
+    // Which pane is bottom-left changes while the application runs — a pane is
+    // removed, the columns toggle, a pane switches to chart view — and the maps
+    // are built once. Gating addControl would freeze the cluster on whichever
+    // pane happened to be bottom-left when its map was created.
+    expect(MAPVIEW).toContain("addControl(new maplibregl.NavigationControl(), 'bottom-left')");
+    expect(MAPVIEW).not.toMatch(/if \(showNavigation[^)]*\)\s*\w*[Mm]ap\.addControl/);
+  });
+});
+
 describe('usePaneChromeForced', () => {
   it('lifts the hiding while a tour is on screen, and puts it back after', () => {
     const { rerender, unmount } = renderHook(

--- a/frontend/src/test/satelliteBasemap.test.ts
+++ b/frontend/src/test/satelliteBasemap.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import {
   DEFAULT_SATELLITE_STYLE_URL,
   DEFAULT_SATELLITE_ATTRIBUTION,
   applyServerSatelliteConfig,
   resetSatelliteConfig,
   satelliteAttribution,
+  satelliteConfirmed,
   satelliteStyleUrl,
   satelliteUnavailable,
   subscribeSatelliteUnavailable,
@@ -164,5 +165,58 @@ describe('satellite availability and quota tracking', () => {
     unsubscribe();
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
     expect(listener).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Choosing a style URL is a different question from offering the control.
+ *
+ * A map constructed against a style that 404s never fires MapLibre's 'load'
+ * event, so its pane sits behind a spinner until the 15-second safety net gives
+ * up. That is what a deployment with no imagery provider looked like: six blank
+ * panes, then fifteen seconds, on every load. The optimism that is right for
+ * "should the button be enabled" is wrong for "is this URL safe to fetch".
+ */
+describe('satelliteConfirmed', () => {
+  beforeEach(() => resetSatelliteConfig());
+  afterEach(() => resetSatelliteConfig());
+
+  it('is false before the server has said anything', () => {
+    // satelliteUnavailable() is optimistically false at the same moment: the
+    // control stays enabled while a perfectly good key is still loading.
+    expect(satelliteConfirmed()).toBe(false);
+    expect(satelliteUnavailable()).toBe(false);
+  });
+
+  it('is true only once the server says available', () => {
+    applyServerSatelliteConfig({ satellite_available: true } as never);
+    expect(satelliteConfirmed()).toBe(true);
+  });
+
+  it('is false for a server too old to have the field', () => {
+    // The same response that leaves satelliteUnavailable() optimistic: an
+    // unanswered question is exactly the one not to gamble a style URL on.
+    applyServerSatelliteConfig({} as never);
+    expect(satelliteUnavailable()).toBe(false);
+    expect(satelliteConfirmed()).toBe(false);
+  });
+
+  it('goes false again when the quota is spent', () => {
+    applyServerSatelliteConfig({ satellite_available: true } as never);
+    applyServerSatelliteConfig({
+      satellite_available: true,
+      satellite_quota_exceeded: true,
+    } as never);
+    expect(satelliteConfirmed()).toBe(false);
+    expect(satelliteUnavailable()).toBe(true);
+  });
+
+  it('and true again when a new month resets it', () => {
+    applyServerSatelliteConfig({
+      satellite_available: true,
+      satellite_quota_exceeded: true,
+    } as never);
+    applyServerSatelliteConfig({ satellite_available: true } as never);
+    expect(satelliteConfirmed()).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #161.

> **Not for merging yet — held for client approval.** Opened as a draft so the
> state says so rather than a comment saying so. It is not in `MERGE_NOW`.

Before:

<img width="2549" height="981" alt="image" src="https://github.com/user-attachments/assets/51d24312-97d1-41ca-8a47-8b43d467307e" />

After my improvements:

<img width="2560" height="987" alt="image" src="https://github.com/user-attachments/assets/1cdf2bb9-2da5-41dc-b9e8-fb2023fe7740" />

Not shown in the screenshot is that when you move over a map panel, the coloured labels in the corners expand to show the full text and the resize bar and handle appear again.

My intent here is to reduce visual clutter and redundant widgets and have a simpler, cleaner interface.

## The count

A six-pane grid, before and after:

| | before | after |
|---|---|---:|
| map toggles (3D, choropleth, identify, satellite, swiper) | 5 × 6 = 30 | 5 |
| zoom-to-site | 6 | 1 |
| zoom / compass clusters | 6 | 1 |
| scenario + factor labels | 18 pills, always up | 6 titles, 12 ticks at rest |
| full-width bar above the panes | 49px | deleted |


Every one of those thirty toggles already acted on **all** panes: they were one
setting drawn six times, and clicking any copy moved all six. The zoom clusters
were the same — every map registers with `useMapSync`, so moving any one moves
the others.

