### PR TITLE
feat(ux): targets follow metadata order, charts inherit the picked factor's axis

### DIFF
--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -4,7 +4,7 @@ import { FiActivity, FiBarChart2, FiEdit2, FiGlobe, FiMap, FiPlus, FiSquare, FiT
 import ViewPane from './ViewPane';
 import { DEFAULT_PANE_STATES } from '../types';
 import type { LayoutMode, QuadColumns, PaneStates, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, SiteIndicators, RangeMode, ViewMode } from '../types';
-import { useAttributeDetails, useAttributeTargetInputs, useAttributeTargetRanges, useAttributeUnits, useAttributeVariableTypes } from '../hooks/useApi';
+import { useAttributeDetails, useAttributeOrder, useAttributeTargetInputs, useAttributeTargetRanges, useAttributeUnits, useAttributeVariableTypes } from '../hooks/useApi';
 import type { FullDomainData } from '../hooks/useApi';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -157,6 +157,7 @@ function ContentArea({
   const { units: attributeUnits } = useAttributeUnits();
   const { targetRanges } = useAttributeTargetRanges();
   const { variableTypes } = useAttributeVariableTypes();
+  const { order: attributeOrder } = useAttributeOrder();
   const [targetDraftValues, setTargetDraftValues] = useState<Record<string, string>>({});
   const [targetDefaultValues, setTargetDefaultValues] = useState<Record<string, number>>({});
   const [isSavingTargets, setIsSavingTargets] = useState(false);
@@ -191,11 +192,16 @@ function ContentArea({
     return keys
       .filter((key, idx, arr) => arr.indexOf(key) === idx)
       .sort((a, b) => {
+        const aOrder = attributeOrder[a];
+        const bOrder = attributeOrder[b];
+        if (aOrder != null && bOrder != null) return aOrder - bOrder;
+        if (aOrder != null) return -1;
+        if (bOrder != null) return 1;
         const aLabel = attributeDetails[a] ?? a;
         const bLabel = attributeDetails[b] ?? b;
         return aLabel.localeCompare(bLabel);
       });
-  }, [attributeDetails, siteIndicators, targetInputs, variableTypes]);
+  }, [attributeDetails, attributeOrder, siteIndicators, targetInputs, variableTypes]);
 
   const targetGroups = useMemo(() => {
     const groups = new Map<string, string[]>();
@@ -206,9 +212,16 @@ function ContentArea({
       groups.set(groupName, keysInGroup);
     });
     return Array.from(groups.entries())
-      .map(([groupName, keys]) => ({ groupName, keys }))
+      .map(([groupName, keys]) => ({
+        groupName,
+        // Herbivores lists alphabetically by label; every other group keeps
+        // the metadata.csv row order already applied in editableTargetKeys.
+        keys: groupName === 'Herbivores'
+          ? [...keys].sort((a, b) => (attributeDetails[a] ?? a).localeCompare(attributeDetails[b] ?? b))
+          : keys,
+      }))
       .sort((a, b) => a.groupName.localeCompare(b.groupName));
-  }, [editableTargetKeys, variableTypes]);
+  }, [attributeDetails, editableTargetKeys, variableTypes]);
 
   const targetHasBeenUpdated = useMemo(() => {
     if (!siteIndicators?.ideal || !siteIndicators?.current) return false;

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -23,7 +23,7 @@ import {
 import { FiChevronRight, FiInfo, FiMapPin, FiGlobe, FiSquare, FiTarget } from 'react-icons/fi';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { useAttributeCanMap, useAttributeCanGraph, useAttributeChartTypes, useAttributeColors, useColumns, useAttributeDetails, useAttributeGroupingVariables, useAttributeVariableTypes, useAttributeAxisLabels } from '../hooks/useApi';
+import { useAttributeCanMap, useAttributeCanGraph, useAttributeChartTypes, useAttributeColors, useColumns, useAttributeDetails, useAttributeGroupingVariables, useAttributeVariableTypes, useAttributeAxisLabels, useAttributeIgnoreXGrouping } from '../hooks/useApi';
 import { PRISM_CSS_GRADIENT, formatNumber } from './MapView';
 import type { Scenario, ComparisonState, MapStatistics, ColorScaleMode, ColorScaleType, ViewMode, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
@@ -477,6 +477,7 @@ function ControlPanel({
   const { groupingVariables } = useAttributeGroupingVariables();
   const { variableTypes } = useAttributeVariableTypes();
   const { axisLabels } = useAttributeAxisLabels();
+  const { ignoreXGrouping } = useAttributeIgnoreXGrouping();
   const bgColor = useColorModeValue('gray.50', 'gray.800');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const cardBg = useColorModeValue('white', 'gray.750');
@@ -496,6 +497,34 @@ function ControlPanel({
     window.addEventListener('dt:demo-chart-individual-factor', handler);
     return () => window.removeEventListener('dt:demo-chart-individual-factor', handler);
   }, []);
+
+  // Arriving at the chart view from map/dial with an attribute already
+  // selected should behave as if that attribute had just been picked from the
+  // INDIVIDUAL FACTOR select, so the GROUPING VARIABLE list is filtered by its
+  // axis label without requiring the user to re-pick the factor. This only
+  // fires on the actual map/dial -> chart transition (tracked via a ref), not
+  // on every re-render while already in chart view — otherwise clearing the
+  // INDIVIDUAL FACTOR select would immediately re-derive it from the
+  // still-set comparison.attribute and undo the clear.
+  const previousViewModeRef = useRef<ViewMode | undefined>(undefined);
+  useEffect(() => {
+    const previousViewMode = previousViewModeRef.current;
+    previousViewModeRef.current = viewMode;
+    if (viewMode !== 'chart' || previousViewMode === 'chart') return;
+
+    const attribute = comparison.attribute;
+    if (!attribute) return;
+
+    const vt = resolveVariableTypeForColumn(attribute, variableTypes);
+    if (!vt || vt === 'catchID') return;
+
+    setFactorDerivedMode(true);
+    setFactorDerivedValue(attribute);
+    if (chartGroup !== vt) {
+      onChartGroupChange?.(vt);
+      onChartAxisLabelFilterChange?.(null);
+    }
+  }, [viewMode, comparison.attribute, variableTypes, chartGroup, onChartGroupChange, onChartAxisLabelFilterChange]);
 
   const uniqueVariableTypes = useMemo(
     () => [...new Set(Object.values(variableTypes))].filter((t) => t && t !== 'catchID').sort(),
@@ -526,22 +555,44 @@ function ControlPanel({
       axisLabelsByGroup.get(group)!.add(axisLabel);
     }
 
-    const options: { value: string; label: string }[] = [];
+    const options: { value: string; label: string; axisLabel: string }[] = [];
     for (const [group, labelSet] of axisLabelsByGroup) {
       if (labelSet.size <= 1) {
-        options.push({ value: group, label: group.replace(/_/g, ' ') });
+        const [axisLabel] = labelSet;
+        options.push({ value: group, label: group.replace(/_/g, ' '), axisLabel });
         continue;
       }
       for (const axisLabel of labelSet) {
         options.push({
           value: encodeGroupingOption(group, axisLabel),
           label: `${group.replace(/_/g, ' ')} (${axisLabel})`,
+          axisLabel,
         });
       }
     }
 
-    return options.sort((a, b) => a.label.localeCompare(b.label));
-  }, [chartGroup, columns, canGraph, variableTypes, groupingVariables, axisLabels]);
+    const sortedOptions = options.sort((a, b) => a.label.localeCompare(b.label));
+
+    // Some variable types mix several unrelated axes by design (e.g. cover
+    // fraction alongside biomass), flagged in metadata.csv via
+    // ignore_x_grouping — those keep the plain alphabetical order instead of
+    // being narrowed down to the individual factor's axis label.
+    if (sourceColumns.some((col) => ignoreXGrouping[col])) return sortedOptions;
+
+    // Once an individual factor has been picked, only offer sibling grouping
+    // variables that share its axis label — combining different axes on one
+    // chart is meaningless (see the axisLabelsByGroup split above).
+    const selectedFactorColumn = factorDerivedMode && factorDerivedValue && !factorDerivedValue.startsWith('__group__|')
+      ? factorDerivedValue
+      : null;
+    const selectedFactorAxisLabel = selectedFactorColumn
+      ? resolveAxisLabelForColumn(selectedFactorColumn, axisLabels)
+      : '';
+    if (!selectedFactorAxisLabel) return sortedOptions;
+
+    const matchingOptions = sortedOptions.filter((option) => option.axisLabel === selectedFactorAxisLabel);
+    return matchingOptions.length > 0 ? matchingOptions : sortedOptions;
+  }, [chartGroup, columns, canGraph, variableTypes, groupingVariables, axisLabels, ignoreXGrouping, factorDerivedMode, factorDerivedValue]);
 
   const lineBoxplotToggleAvailable = useMemo(() => {
     if (viewMode !== 'chart' || !chartGroup || !chartAxisLabelFilter) return false;

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -221,6 +221,22 @@ export function useAttributeDetails() {
   return { details, loading };
 }
 
+export function useAttributeOrder() {
+  const [order, setOrder] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchJSON<Record<string, number>>(`${API_BASE}/metadata/order`)
+      .then((data) => {
+        setOrder(data || {});
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return { order, loading };
+}
+
 export function useAttributeVariableTypes() {
   const [variableTypes, setVariableTypes] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
@@ -384,6 +400,22 @@ export function useAttributeDial0Middle() {
   }, []);
 
   return { dial0Middle, loading };
+}
+
+export function useAttributeIgnoreXGrouping() {
+  const [ignoreXGrouping, setIgnoreXGrouping] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchJSON<Record<string, boolean>>(`${API_BASE}/metadata/ignorexgrouping`)
+      .then((data) => {
+        setIgnoreXGrouping(data || {});
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return { ignoreXGrouping, loading };
 }
 
 export function useAttributeChartTypes() {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -107,6 +107,7 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/columns", h.handleListColumns).Methods("GET")
 	r.HandleFunc("/metadata/colors", h.handleMetadataColors).Methods("GET")
 	r.HandleFunc("/metadata/details", h.handleMetadataDetails).Methods("GET")
+	r.HandleFunc("/metadata/order", h.handleMetadataOrder).Methods("GET")
 	r.HandleFunc("/metadata/variabletypes", h.handleMetadataVariableTypes).Methods("GET")
 	r.HandleFunc("/metadata/inputs", h.handleMetadataInputs).Methods("GET")
 	r.HandleFunc("/metadata/targetinputs", h.handleMetadataTargetInputs).Methods("GET")
@@ -120,6 +121,7 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/metadata/groupingvariables", h.handleMetadataGroupingVariables).Methods("GET")
 	r.HandleFunc("/metadata/groupingvalues", h.handleMetadataGroupingValues).Methods("GET")
 	r.HandleFunc("/metadata/dial0middle", h.handleMetadataDial0Middle).Methods("GET")
+	r.HandleFunc("/metadata/ignorexgrouping", h.handleMetadataIgnoreXGrouping).Methods("GET")
 	r.HandleFunc("/scenario/{scenario}/{attribute}", h.handleScenarioData).Methods("GET")
 	r.HandleFunc("/aggregate", h.handleAggregateData).Methods("GET")
 	r.HandleFunc("/precalculate/full", h.handlePrecalculateFull).Methods("GET")
@@ -219,6 +221,13 @@ func (h *Handler) handleMetadataDetails(w http.ResponseWriter, r *http.Request) 
 	respondJSON(w, http.StatusOK, h.metaCache.Details)
 }
 
+// handleMetadataOrder returns a map of attribute column names to their row
+// position in metadata.csv, so callers can sort attributes the way the
+// spreadsheet lists them instead of alphabetically.
+func (h *Handler) handleMetadataOrder(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, h.metaCache.Order)
+}
+
 // handleMetadataVariableTypes returns a map of attribute column names to variable types.
 func (h *Handler) handleMetadataVariableTypes(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, h.metaCache.VariableTypes)
@@ -261,6 +270,12 @@ func (h *Handler) handleMetadataCanGraph(w http.ResponseWriter, r *http.Request)
 // zero with positive values to the right and negative values to the left.
 func (h *Handler) handleMetadataDial0Middle(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, h.metaCache.Dial0Middle)
+}
+
+// handleMetadataIgnoreXGrouping returns a map of attribute column names to
+// ignore_x_grouping flags.
+func (h *Handler) handleMetadataIgnoreXGrouping(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, h.metaCache.IgnoreXGrouping)
 }
 
 // handleMetadataAxisLabels returns a map of attribute column names to axis labels.

--- a/internal/api/metadata_alias_test.go
+++ b/internal/api/metadata_alias_test.go
@@ -25,6 +25,7 @@ func fixtureCache() *MetadataCache {
 		GroupingVariables: map[string]string{},
 		GroupingValues:    map[string]string{},
 		Dial0Middle:       map[string]bool{},
+		IgnoreXGrouping:   map[string]bool{},
 		MaxValCurrent:     map[string]float64{},
 		MaxValReference:   map[string]float64{},
 	}

--- a/internal/api/metadata_cache.go
+++ b/internal/api/metadata_cache.go
@@ -28,8 +28,14 @@ type MetadataCache struct {
 	GroupingVariables map[string]string
 	GroupingValues    map[string]string
 	Dial0Middle       map[string]bool
+	IgnoreXGrouping   map[string]bool
 	MaxValCurrent     map[string]float64
 	MaxValReference   map[string]float64
+
+	// Order maps a column name to its row position in metadata.csv, so
+	// callers can sort attributes the way the spreadsheet lists them
+	// instead of alphabetically.
+	Order map[string]int
 }
 
 // loadMetadataCache opens metadata.csv once and builds all lookup maps.
@@ -51,8 +57,10 @@ func loadMetadataCache(dataDir string) *MetadataCache {
 		GroupingVariables: make(map[string]string),
 		GroupingValues:    make(map[string]string),
 		Dial0Middle:       make(map[string]bool),
+		IgnoreXGrouping:   make(map[string]bool),
 		MaxValCurrent:     make(map[string]float64),
 		MaxValReference:   make(map[string]float64),
+		Order:             make(map[string]int),
 	}
 
 	path := filepath.Join(dataDir, "metadata.csv")
@@ -155,6 +163,7 @@ func loadMetadataCache(dataDir string) *MetadataCache {
 	iGroupingValues := col("GroupingValues")
 
 	iDial0Middle := col("dial_0_middle")
+	iIgnoreXGrouping := col("ignore_x_grouping")
 
 	iMaxValCurrent := col("maxval_curr")
 	iMaxValReference := col("maxval_ref")
@@ -195,6 +204,12 @@ func loadMetadataCache(dataDir string) *MetadataCache {
 		rowCount++
 
 		norm := normalizeMetadataColumn(column)
+
+		// Order: row position in metadata.csv, zero-based.
+		mc.Order[column] = rowCount - 1
+		if norm != "" {
+			mc.Order[norm] = rowCount - 1
+		}
 
 		// Colors
 		if iColor >= 0 {
@@ -355,6 +370,19 @@ func loadMetadataCache(dataDir string) *MetadataCache {
 			}
 		}
 
+		// IgnoreXGrouping: whether the grouping-variable filter should skip
+		// narrowing options down to the selected factor's axis label for this
+		// column's variable type.
+		if iIgnoreXGrouping >= 0 {
+			if v := get(rec, iIgnoreXGrouping); v != "" {
+				b := parseBool(v)
+				mc.IgnoreXGrouping[column] = b
+				if norm != "" {
+					mc.IgnoreXGrouping[norm] = b
+				}
+			}
+		}
+
 		// MaxValCurrent / MaxValReference: curated per-scenario ceilings for
 		// choropleth color scaling, used instead of scanning every catchment.
 		if iMaxValCurrent >= 0 {
@@ -478,10 +506,16 @@ func (mc *MetadataCache) AddColumnAliases(columns []string) int {
 				added = true
 			}
 		}
+		if v, ok := mc.Order[metaName]; ok {
+			if _, exists := mc.Order[realName]; !exists {
+				mc.Order[realName] = v
+				added = true
+			}
+		}
 
 		// The boolean sets carry meaning by presence, so only a true entry is
 		// worth aliasing.
-		for _, set := range []map[string]bool{mc.Inputs, mc.TargetInputs, mc.CanMap, mc.CanGraph, mc.Dial0Middle} {
+		for _, set := range []map[string]bool{mc.Inputs, mc.TargetInputs, mc.CanMap, mc.CanGraph, mc.Dial0Middle, mc.IgnoreXGrouping} {
 			if v, ok := set[metaName]; ok && v {
 				if _, exists := set[realName]; !exists {
 					set[realName] = v

--- a/internal/bench/coverage.go
+++ b/internal/bench/coverage.go
@@ -187,6 +187,7 @@ var MetadataEndpoints = []string{
 	"colors", "details", "variabletypes", "inputs", "targetinputs",
 	"targetranges", "canmap", "cangraph", "axislabels", "xaxislabels",
 	"units", "charttypes", "groupingvariables", "groupingvalues", "dial0middle",
+	"ignorexgrouping",
 }
 
 // Coverage is what fraction of the server's routes this suite looked at.


### PR DESCRIPTION
Ticket #177 and #178
- Editable target/attribute lists now sort by their row position in metadata.csv (new Order field + /metadata/order endpoint) instead of pure alphabetical, so the UI matches the spreadsheet's intended ordering. The Herbivores group is the one exception and keeps alphabetical sorting.
- Arriving at the chart view from the map or dial with an attribute already selected now auto-fills the "individual factor" selector and narrows the "grouping variable" list to options that share that attribute's axis label, instead of showing every axis mixed together.
- New ignore_x_grouping metadata flag lets specific variable types opt out of that axis-label narrowing (e.g. cover fraction vs. biomass, which are intentionally mixed).
- Backend plumbing: MetadataCache.IgnoreXGrouping/Order maps, new /metadata/ignorexgrouping and /metadata/order routes, alias propagation for both, bench coverage entry, and test fixture updates.