### PR TITLE
fix(ci): build the docs from the flake so releases ship their artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,10 +431,21 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "image=$name:$tag" >> "$GITHUB_OUTPUT"
+          # The flake tags every build with the version in flake.nix, so each
+          # one is `decision-theatre:4.0.0` no matter which commit it came from.
+          # Two pull requests then produce images a reviewer cannot tell apart,
+          # and loading one silently replaces the other. Stamp the commit into a
+          # second tag so each build is its own identifiable thing. The
+          # version-tagged name is kept for the --version check below, which is
+          # about the version and nothing else.
+          echo "sha_image=$name:$tag-${SHA:0:12}" >> "$GITHUB_OUTPUT"
+        env:
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Load it into docker
         run: |
           docker load < result
+          docker tag ${{ steps.build.outputs.image }} ${{ steps.build.outputs.sha_image }}
           docker image ls ${{ steps.build.outputs.name }}
 
       - name: It reports the flake's version
@@ -495,7 +506,10 @@ jobs:
 
       - name: Export the image
         run: |
-          docker save ${{ steps.build.outputs.image }} \
+          # Saved under the commit-stamped tag: that is the name it will carry
+          # once a reviewer loads it, and it is the one that identifies which
+          # build they are looking at.
+          docker save ${{ steps.build.outputs.sha_image }} \
             | gzip > decision-theatre-image.tar.gz
           ls -lh decision-theatre-image.tar.gz
 
@@ -527,7 +541,7 @@ jobs:
         run: |
           {
             printf '## Container image\n\n'
-            printf '`%s` — %s\n\n' "${{ steps.build.outputs.image }}" \
+            printf '`%s` — %s\n\n' "${{ steps.build.outputs.sha_image }}" \
               "$(du -h decision-theatre-image.tar.gz | cut -f1) compressed"
             printf 'Built from the flake: its contents are the runtime closure of the binary, so nothing states a dependency version twice.\n\n'
             printf '### Software bill of materials\n\n'
@@ -563,18 +577,22 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.event.pull_request.head.sha }}
+          IMAGE: ${{ steps.build.outputs.sha_image }}
         run: |
           {
             cat build-report.md
             printf '\n---\n\n### Try this build\n\n'
-            printf 'Download the `container-image` artefact from [this run](https://github.com/%s/actions/runs/%s), then:\n\n' \
-              "$REPO" "$RUN_ID"
+            printf 'This image lives in the run artefacts, not in a registry — there is nothing to `docker pull` — because pull requests do not publish to GHCR; only tagged releases do. Fetch it with the `gh` CLI:\n\n'
             printf '```bash\n'
-            printf 'unzip container-image.zip\n'
+            printf 'gh run download %s --repo %s --name container-image\n' "$RUN_ID" "$REPO"
             printf 'docker load < decision-theatre-image.tar.gz\n'
-            printf 'docker run --rm -p 8080:8080 %s\n' "${{ steps.build.outputs.image }}"
+            printf 'docker run --rm -p 8080:8080 %s\n' "$IMAGE"
             printf '```\n\n'
-            printf 'Kept for 7 days. Commit `%s`.\n' "$SHA"
+            printf 'Or download `container-image` from [this run](https://github.com/%s/actions/runs/%s) in the browser and unzip it first.\n\n' \
+              "$REPO" "$RUN_ID"
+            printf 'It loads as `%s` — the flake version stamped with the commit, so builds from different pull requests do not overwrite each other on your machine. Kept for 7 days; commit `%s`.\n\n' \
+              "$IMAGE" "$SHA"
+            printf 'Released images *are* in the registry: `ghcr.io/kartoza/decisiontheatre:<version>` for every release, plus `:latest` following the newest stable one.\n'
           } > pr-comment.md
 
       - name: Post or update the comment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,61 @@ permissions:
 
 jobs:
   # ==========================================
+  # Documentation — built once, from the flake
+  #
+  # Every platform build embeds this site, and each of them used to build it
+  # itself with `pip install mkdocs …` off a hand-written package list. That
+  # list omitted mkdocs-macros-plugin, which mkdocs.yml requires, so `mkdocs
+  # build` aborted with "The macros plugin is not installed" on the first runner
+  # to reach it — and fail-fast cancelled the other four. No release since has
+  # carried a single platform artefact.
+  #
+  # flake.nix already declares the correct set in mkdocsEnv, and docs.yml
+  # already builds the site this way. The release workflow was the only place
+  # restating the dependencies by hand, which is the same failure the hand-
+  # maintained Dockerfile had before it was replaced by the flake.
+  # ==========================================
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build documentation
+        run: nix build .#docs --print-build-logs
+
+      - name: Collect the site
+        run: |
+          # `result` is a symlink into the read-only nix store; upload-artifact
+          # needs a real, writable directory.
+          mkdir -p docs_site
+          cp -rL result/. docs_site/
+          chmod -R u+w docs_site
+          if [ ! -f docs_site/index.html ]; then
+            echo "::error::the docs derivation produced no index.html"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: docs_site/
+
+  # ==========================================
   # Build platform-specific binaries
   # ==========================================
   build:
+    needs: docs
     strategy:
+      # Every platform is required for the release, so cancelling the other four
+      # the moment one fails only hides how much is broken — it took a run per
+      # platform to learn that. Let them all report.
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -63,14 +114,13 @@ jobs:
           npm ci
           npm run build
 
-      - uses: actions/setup-python@v5
+      # Built once by the `docs` job, from the flake, and embedded here. Not
+      # rebuilt per platform: it is the same site five times over, and Python
+      # is no longer needed on any of these runners.
+      - uses: actions/download-artifact@v4
         with:
-          python-version: '3.12'
-
-      - name: Build documentation
-        run: |
-          pip install mkdocs mkdocs-material mkdocs-minify-plugin pygments pymdown-extensions
-          mkdocs build -d internal/server/docs_site
+          name: docs-site
+          path: internal/server/docs_site
 
       - name: Copy frontend to embed dir (unix)
         if: runner.os != 'Windows'
@@ -215,9 +265,15 @@ jobs:
         include:
           - suffix: linux-amd64
             arch: x86_64
+            os: ubuntu-latest
           - suffix: linux-arm64
             arch: aarch64
-    runs-on: ubuntu-latest
+            # Built on an arm64 runner with the arm64 appimagetool. It used to
+            # run the x86_64 tool here and pass ARCH=aarch64, which does not
+            # give you a working aarch64 AppImage — the runtime it embeds is the
+            # tool's own architecture.
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -230,9 +286,16 @@ jobs:
         run: chmod +x dist/decision-theatre
 
       - name: Build AppImage
+        env:
+          # appimagetool is itself an AppImage, and a type-2 AppImage mounts
+          # itself with libfuse2 — which the ubuntu-24.04 runner images no
+          # longer carry. Without this it dies on `dlopen(): libfuse.so.2`, the
+          # job fails, and the release ships with no AppImage at all. Asking it
+          # to unpack itself instead needs no root and no extra package.
+          APPIMAGE_EXTRACT_AND_RUN: 1
         run: |
-          # Download appimagetool
-          wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool
+          # Download appimagetool for the architecture we are building for
+          wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${{ matrix.arch }}.AppImage" -O appimagetool
           chmod +x appimagetool
 
           # Create AppDir
@@ -240,9 +303,12 @@ jobs:
           cp dist/decision-theatre AppDir/usr/bin/
           cp packaging/appimage/AppRun AppDir/
           cp packaging/appimage/decision-theatre.desktop AppDir/
-          # Placeholder icon (1x1 PNG)
-          echo -n "" > AppDir/decision-theatre.png
-          touch AppDir/decision-theatre.png
+          # A real icon, rather than the zero-byte file that used to stand in
+          # for one. Icon= in the .desktop entry points at this, so an empty
+          # file means every desktop environment shows the AppImage with no
+          # icon — and appimagetool is entitled to reject it outright. Reuses
+          # the brand favicon rather than committing a second copy of it.
+          cp docs/assets/brand/favicon.png AppDir/decision-theatre.png
 
           # Build
           ARCH=${{ matrix.arch }} ./appimagetool --no-appstream AppDir/ \
@@ -306,6 +372,18 @@ jobs:
 
       - name: Make binary executable
         run: chmod +x packaging/snap/decision-theatre
+
+      # `version: git` is a core20-era keyword. Under core24 it is not
+      # interpreted — it is taken literally, and the release shipped a snap
+      # whose version was the three characters "git". Substituted here because
+      # the tag is only known at release time; the checked-in value stays as the
+      # placeholder it has always been.
+      - name: Stamp the release version into the snap
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          sed -i "s/^version: .*/version: '${VERSION#v}'/" packaging/snap/snapcraft.yaml
+          grep '^version:' packaging/snap/snapcraft.yaml
 
       - uses: snapcore/action-build@v1
         id: snapcraft
@@ -423,17 +501,72 @@ jobs:
           merge-multiple: true
           path: release
 
+      # Every artefact docs/developer-guide/releasing.md says a release carries.
+      # A packaging job that produced nothing used to surface only as a release
+      # quietly missing a platform — the checksum step swallowed the absence
+      # with `2>/dev/null ... || true`, and nothing else looked. Now it stops
+      # the release, and names what is missing.
+      - name: Verify every documented artefact is present
+        working-directory: release
+        run: |
+          # nullglob so `*.deb` with nothing to match expands to nothing rather
+          # than to the literal string. It does not cover the exact filenames
+          # below — a word with no wildcard in it is not a pattern at all, and
+          # bash passes it through whether or not the file exists — so each
+          # candidate is existence-tested rather than merely counted.
+          shopt -s nullglob
+          expected=(
+            "1|decision-theatre-linux-amd64.tar.gz|Linux amd64 archive"
+            "1|decision-theatre-linux-arm64.tar.gz|Linux arm64 archive"
+            "1|decision-theatre-darwin-amd64.tar.gz|macOS amd64 archive"
+            "1|decision-theatre-darwin-arm64.tar.gz|macOS arm64 archive"
+            "1|decision-theatre-windows-amd64.zip|Windows amd64 archive"
+            "2|*.deb|Debian packages (amd64 and arm64)"
+            "2|*.rpm|RPM packages (amd64 and arm64)"
+            "1|Decision_Theatre-x86_64.AppImage|AppImage, amd64"
+            "1|Decision_Theatre-aarch64.AppImage|AppImage, arm64"
+            "1|*.flatpak|Flatpak bundle"
+            "1|*.snap|Snap package"
+            "1|decision-theatre-darwin-amd64.dmg|macOS amd64 disk image"
+            "1|decision-theatre-darwin-arm64.dmg|macOS arm64 disk image"
+            "1|*.msi|Windows installer"
+          )
+          incomplete=0
+          for row in "${expected[@]}"; do
+            IFS='|' read -r want glob what <<< "$row"
+            got=0
+            for f in $glob; do
+              [ -e "$f" ] && got=$((got + 1))
+            done
+            if [ "$got" -lt "$want" ]; then
+              echo "::error::missing $what — expected $want file(s) matching '$glob', found $got"
+              incomplete=1
+            else
+              printf '  ok   %s (%s)\n' "$what" "$got"
+            fi
+          done
+          echo
+          ls -lh
+          if [ "$incomplete" != "0" ]; then
+            echo "::error::the release is incomplete — not publishing a partial set"
+            exit 1
+          fi
+
       - name: Merge checksums
         run: |
           cat checksums/checksums-*.txt | sort > release/checksums.txt
-          # Add checksums for installers
+          # No `|| true` here: the step above has already established that every
+          # one of these exists, so a failure now is a real failure.
           cd release
-          sha256sum *.deb *.rpm *.AppImage *.flatpak *.snap *.dmg *.msi 2>/dev/null >> checksums.txt || true
+          sha256sum *.deb *.rpm *.AppImage *.flatpak *.snap *.dmg *.msi >> checksums.txt
 
       - uses: softprops/action-gh-release@v2
         with:
           files: release/*
           generate_release_notes: true
+          # v2.4.0-rc1 and friends are marked as pre-releases, so the release
+          # page agrees with what the container job did with :latest.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           body: |
             ## Installation
 
@@ -449,6 +582,7 @@ jobs:
             | **NixOS** | Flake | `nix profile install github:kartoza/DecisionTheatre` |
             | **macOS** | `.dmg` | Open and drag to Applications |
             | **Windows** | `.msi` | Run the installer |
+            | **Server (Docker)** | GHCR image | `ghcr.io/kartoza/decisiontheatre` — see **Container image** below |
 
             ### Portable binaries (no installer)
 
@@ -490,6 +624,11 @@ jobs:
   # so the name is lowercased rather than interpolated directly.
   # ==========================================
   container:
+    # Sequenced after `release` rather than run alongside it. This job appends
+    # its section to the release body; the release job sets that body outright.
+    # Run concurrently, whichever finishes last wins, and roughly half the time
+    # the container notes are silently overwritten.
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -512,6 +651,14 @@ jobs:
           name="$(nix eval --raw .#container.imageName)"
           echo "image=$name:$tag" >> "$GITHUB_OUTPUT"
           echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          # Semver's own rule: anything after a hyphen is a pre-release
+          # identifier — v2.4.0-rc1, v2.4.0-beta.2. Decided once here so the
+          # push and the release notes cannot disagree about what this tag is.
+          if [ "${GITHUB_REF_NAME}" != "${GITHUB_REF_NAME%%-*}" ]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: It runs
         run: |
@@ -533,14 +680,27 @@ jobs:
           '
           {
             printf '## Container image\n\n'
-            printf '```bash\ndocker pull %s\n```\n\n' "$GHCR_TAG"
+            printf '```bash\n'
+            printf 'docker pull %s:%s   # this release, an immovable pin\n' \
+              "$GHCR_REPO" "$GHCR_VERSION"
+            if [ "$PRERELEASE" = "false" ]; then
+              printf 'docker pull %s:latest  # the newest stable release\n' "$GHCR_REPO"
+            fi
+            printf '```\n\n'
+            if [ "$PRERELEASE" = "false" ]; then
+              printf 'Both tags are published: `:%s` never moves, and `:latest` now points here. Pin the version for anything you want to stay put.\n\n' "$GHCR_VERSION"
+            else
+              printf 'This is a **pre-release**, so only `:%s` was published. `:latest` is unchanged and still points at the most recent stable release, so an unpinned `docker pull` will not pick this up.\n\n' "$GHCR_VERSION"
+            fi
             printf '### Software bill of materials\n\n'
             nix develop .#supplychain --command python3 scripts/sbom_table.py sbom-syft.json
             printf '\n### Vulnerability scan\n\n'
             nix develop .#supplychain --command python3 scripts/cve_table.py cve-scan.json
           } > build-report.md
         env:
-          GHCR_TAG: ghcr.io/kartoza/decisiontheatre:${{ steps.build.outputs.version }}
+          GHCR_REPO: ghcr.io/kartoza/decisiontheatre
+          GHCR_VERSION: ${{ steps.build.outputs.version }}
+          PRERELEASE: ${{ steps.build.outputs.prerelease }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -555,8 +715,17 @@ jobs:
           # carries capitals.
           ghcr="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
           version="${{ steps.build.outputs.version }}"
-          # :<version> is the immovable pin; :latest follows the newest release.
-          for t in "$version" latest; do
+          # :<version> is the immovable pin and is published for every tag.
+          # :latest follows the newest *stable* release only — whatever it
+          # points at is what an unpinned `docker pull` deploys, so a release
+          # candidate must never land there.
+          tags=("$version")
+          if [ "${{ steps.build.outputs.prerelease }}" = "true" ]; then
+            echo "::notice::${GITHUB_REF_NAME} is a pre-release — :latest left where it is"
+          else
+            tags+=("latest")
+          fi
+          for t in "${tags[@]}"; do
             docker tag ${{ steps.build.outputs.image }} "$ghcr:$t"
             docker push "$ghcr:$t"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is a `container-image` artefact kept for 7 days, so a change can be run before it
   merges without building anything locally.
 
+  It is tagged `decision-theatre:<flake version>-<commit>` rather than with the
+  flake version alone. Every build previously came out as `decision-theatre:4.0.0`
+  regardless of which commit produced it, so images from two pull requests were
+  indistinguishable and loading one replaced the other. The pull request comment
+  now carries the `gh run download` command that fetches it, says plainly that
+  pull request builds are not pushed to a registry, and points at GHCR for the
+  released images.
+
 - **Every release publishes the image to GHCR** as
-  `ghcr.io/kartoza/decisiontheatre:<version>` and `:latest`, with the image
-  tarball, SPDX SBOM and Grype scan attached as release assets and the same tables
-  appended to the release notes.
+  `ghcr.io/kartoza/decisiontheatre:<version>`, and stable releases additionally
+  move `:latest` to it, with the image tarball, SPDX SBOM and Grype scan attached
+  as release assets and the same tables appended to the release notes. A
+  pre-release tag — anything with a hyphen after the version, `v2.4.0-rc1` —
+  publishes only its version tag and leaves `:latest` where it is, so an unpinned
+  `docker pull` never lands on a release candidate. The release itself is marked as
+  a pre-release on GitHub to match.
 
   The scan does not fail the build. A CVE in a system library is a fact to weigh,
   not automatically a defect here, and a gate that trips on every Negligible
@@ -230,6 +242,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both families are OFL-1.1.
 
 ### Fixed
+
+- **No release since v0.2.0 has carried a single platform artefact, and the cause
+  was a hand-written `pip install` list.** Each of the five platform builds built
+  the documentation itself from `pip install mkdocs mkdocs-material
+  mkdocs-minify-plugin pygments pymdown-extensions`, which omits
+  mkdocs-macros-plugin — and `mkdocs.yml` declares the `macros` plugin. So
+  `mkdocs build` aborted with `Config value 'plugins': The "macros" plugin is not
+  installed` on the first runner to reach it, `fail-fast` cancelled the other
+  four, and the `release` job — which needs all five — never ran. v2.3.0 carries
+  three assets: the container image, its SBOM and its scan, published by the one
+  job that did not depend on any of this.
+
+  The documentation is now built once by a `docs` job running `nix build .#docs`,
+  the derivation `docs.yml` and the container image already used, and each
+  platform build downloads and embeds it. `flake.nix` had the correct set in
+  `mkdocsEnv` all along. This is the same failure the hand-maintained Dockerfile
+  had — a second dependency list drifting from the first — in the last place
+  still keeping one. No runner in the release workflow installs Python now.
+
+  The build matrix also no longer fails fast, so a broken platform no longer
+  hides the state of the other four.
+
+- **The release workflow now refuses to publish an incomplete release.** It checks
+  that every artefact `docs/developer-guide/releasing.md` promises is present —
+  five archives, two `.deb`, two `.rpm`, two `.AppImage`, one `.flatpak`, one
+  `.snap`, two `.dmg`, one `.msi` — and fails with the name of whatever is missing.
+  The checksum step previously ended in `2>/dev/null ... || true`, so a packaging
+  job that produced nothing surfaced only as a release quietly short a platform,
+  and nothing else looked.
+
+- **The AppImages were not being built.** `appimagetool` is itself a type-2
+  AppImage and mounts itself with libfuse2, which the `ubuntu-24.04` runner images
+  no longer carry, so it died on `dlopen(): libfuse.so.2` before doing any work.
+  It now runs with `APPIMAGE_EXTRACT_AND_RUN=1`, which needs neither root nor an
+  extra package.
+
+- **The arm64 AppImage was built with the x86_64 `appimagetool`**, passing
+  `ARCH=aarch64` to a tool that embeds a runtime of its own architecture. It is now
+  built on an `ubuntu-24.04-arm` runner with the aarch64 tool.
+
+- **The AppImage icon was a zero-byte file.** `Icon=decision-theatre` in the
+  desktop entry pointed at an empty placeholder, so the AppImage carried no icon at
+  all. It now uses the brand favicon already in the repository.
+
+- **The snap was versioned `git`.** `version: git` is a core20-era keyword that
+  `core24` does not interpret, so the literal three characters were taken as the
+  version. The release tag is now substituted in at build time.
+
+- **The container job could silently erase its own section from the release
+  notes.** It appends to a release body that the `release` job sets outright, and
+  the two ran concurrently — whichever finished last won. It now runs after it.
+
 
 - **A walkthrough's charts, dials and aggregate table emptied thirty seconds after
   opening it.** The per-catchment breakdown ships embedded in the walkthrough

--- a/docs/developer-guide/releasing.md
+++ b/docs/developer-guide/releasing.md
@@ -11,13 +11,23 @@ git push origin v0.2.0
 
 This triggers the GitHub Actions release workflow.
 
+A tag carrying a **pre-release identifier** — anything with a hyphen after the
+version, such as `v2.4.0-rc1` or `v2.4.0-beta.2` — is treated differently in two
+places: the GitHub release is marked as a pre-release, and the container image
+does not take the `:latest` tag. See [Phase 4](#phase-4-publish-the-container-image).
+
 ## What the Release Workflow Does
 
-The `.github/workflows/release.yml` workflow has two phases:
+The `.github/workflows/release.yml` workflow has four phases:
 
 ### Phase 1: Build Binaries
 
-Builds platform-specific binaries using a matrix strategy:
+The documentation is built first, once, by the `docs` job: `nix build .#docs` —
+the same derivation `docs.yml` and the container image use. Every platform build
+downloads that site and embeds it rather than building its own, so the plugin
+list lives in `flake.nix` and nowhere else.
+
+Then platform-specific binaries, using a matrix strategy:
 
 | Runner | Target | Archive |
 |--------|--------|---------|
@@ -29,14 +39,17 @@ Builds platform-specific binaries using a matrix strategy:
 
 For each platform:
 
-1. Sets up Go 1.24, Node.js 22, and Python 3.12
+1. Sets up Go 1.24 and Node.js 22
 2. Builds the frontend (`npm ci && npm run build`)
-3. Builds documentation (`mkdocs build`)
+3. Downloads the documentation the `docs` job built
 4. Copies built assets into `internal/server/static/` and `internal/server/docs_site/`
 5. Installs platform-specific CGO dependencies
 6. Builds the Go binary with `-ldflags "-s -w -X main.version=<tag>"`
 7. Packages into `.tar.gz` (Unix) or `.zip` (Windows)
 8. Generates SHA256 checksums
+
+The matrix does not fail fast. Every platform is required for the release, so
+cancelling the other four the moment one fails only hides how much is broken.
 
 ### Phase 2: Package Installers
 
@@ -59,6 +72,49 @@ All artifacts are collected and published as a GitHub Release with:
 - Installer packages (`.deb`, `.rpm`, `.AppImage`, `.flatpak`, `.snap`, `.dmg`, `.msi`)
 - Merged SHA256 checksums file
 - Auto-generated release notes with installation instructions
+
+Before it publishes anything, the job checks that **every artefact listed above is
+actually present** and fails the release if one is missing, naming it. A packaging
+job that produced nothing used to surface only as a release quietly missing a
+platform. The expected set is the list in Phase 1 and Phase 2 — five archives, two
+`.deb`, two `.rpm`, two `.AppImage`, one `.flatpak`, one `.snap`, two `.dmg` and
+one `.msi` — so adding a packaging job means adding it to that check too.
+
+### Phase 4: Publish the Container Image
+
+The `container` job builds the deployment image from the flake, verifies that it
+runs and serves, and pushes it to GHCR:
+
+| Tag | Published for | Moves? |
+|-----|---------------|--------|
+| `ghcr.io/kartoza/decisiontheatre:<version>` | every `v*` tag | Never — an immovable pin |
+| `ghcr.io/kartoza/decisiontheatre:latest` | stable releases only | Repointed at each new stable release |
+
+```bash
+docker pull ghcr.io/kartoza/decisiontheatre:2.4.0   # this exact release
+docker pull ghcr.io/kartoza/decisiontheatre:latest  # the newest stable release
+```
+
+Pre-release tags publish their version tag and stop there. Whatever `:latest`
+points at is what an unpinned `docker pull` deploys, so a release candidate must
+never land there.
+
+The job also attaches the image tarball, its SBOM (`sbom.spdx.json`) and its
+vulnerability scan (`cve-scan.json`) to the release, and appends a section to the
+release notes naming both tags. It runs *after* Phase 3 rather than alongside it,
+because it appends to the release body that Phase 3 sets outright — run
+concurrently, whichever finishes last wins, and roughly half the time the
+container section is the one that gets overwritten.
+
+See [Server Deployment](server-deployment.md) for running the image.
+
+!!! note "Pull request builds are not published to the registry"
+    CI builds the same image on every pull request, but keeps it as a run artefact
+    for 7 days rather than pushing it — there is nothing to `docker pull`. It is
+    tagged `decision-theatre:<flake version>-<commit>`, so builds from different
+    pull requests are distinguishable and do not overwrite each other when loaded.
+    The CI comment on the pull request carries the `gh run download` command that
+    fetches it.
 
 ## Building Packages Locally
 

--- a/docs/developer-guide/server-deployment.md
+++ b/docs/developer-guide/server-deployment.md
@@ -92,11 +92,16 @@ There are three ways to get it, in order of how most people should.
 
 ```bash
 docker pull ghcr.io/kartoza/decisiontheatre:0.4.0   # an immovable version pin
-docker pull ghcr.io/kartoza/decisiontheatre:latest  # the newest release
+docker pull ghcr.io/kartoza/decisiontheatre:latest  # the newest stable release
 ```
 
-Every release publishes both tags, along with the image tarball, its SBOM and its
-vulnerability scan as release assets.
+Every release publishes its version tag, along with the image tarball, its SBOM and
+its vulnerability scan as release assets. `:latest` follows the newest **stable**
+release: a pre-release tag such as `v2.4.0-rc1` publishes `:2.4.0-rc1` and leaves
+`:latest` where it is, so an unpinned pull never lands on a release candidate.
+
+Prefer the version pin for anything you are running in earnest — `:latest` moves
+under you on the next release, and `docker compose up -d` will pick that up.
 
 !!! note "The image path is lowercase"
     GHCR rejects an uppercase path, and this repository is `kartoza/DecisionTheatre`.

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        version = "0.4.0";
+        version = "0.5.0";
 
         # MkDocs environment for requirements documentation
         mkdocsEnv = pkgs.python3.withPackages (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decision-theatre-frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
**No release since v0.2.0 has carried a single platform artefact.** v2.3.0 has
three assets — the container image, its SBOM and its scan — and nothing else.

The cause is one line:

```bash
pip install mkdocs mkdocs-material mkdocs-minify-plugin pygments pymdown-extensions
```

`mkdocs.yml` declares the `macros` plugin; that list omits
`mkdocs-macros-plugin`. Every one of the five platform builds ran it, so the
first runner to reach the step aborted with

```
ERROR   -  Config value 'plugins': The "macros" plugin is not installed
```

`fail-fast` cancelled the other four, and the `release` job — which needs all
five — never ran. The `container` job depends on none of that, so it succeeded
alone and created the GitHub release by itself. That is why the release exists,
and why its notes only ever carried the container section.

Fixes #166

## The fix is to stop keeping a second dependency list

`flake.nix` has declared the correct set in `mkdocsEnv` all along, and
`docs.yml` already builds the site with `nix build .#docs`. The release workflow
was the last place restating it by hand — the same failure the hand-maintained
Dockerfile had, which `flake.nix` records in a comment a few lines above the
environment that would have prevented this one.

A `docs` job now builds the site once with `nix build .#docs` and uploads it;
the five platform builds download and embed it. No runner in the release
workflow installs Python, and there is no package list to drift.

The build matrix also no longer fails fast. Every platform is required for the
release, so cancelling the rest when one fails only hides how much is broken —
it took one run per platform to learn that.

## Nothing else was quietly missing

Reading the packaging jobs against what `releasing.md` promises turned up three
more defects, each of which would have cost a platform on its own:

- **AppImages, both architectures.** `appimagetool` is itself a type-2 AppImage
  and mounts itself with libfuse2, which the `ubuntu-24.04` runner images no
  longer carry, so it dies on `dlopen(): libfuse.so.2`. Now runs with
  `APPIMAGE_EXTRACT_AND_RUN=1` — no root, no extra package.
- **The arm64 AppImage** was built with the *x86_64* tool and `ARCH=aarch64`,
  which does not produce a working aarch64 AppImage; the embedded runtime is the
  tool's own architecture. Now built on `ubuntu-24.04-arm` with the aarch64
  tool. Its icon was a zero-byte file, so `Icon=decision-theatre` resolved to
  nothing; it now uses the brand favicon already in the repository.
- **The snap was versioned `git`.** `version: git` is a core20-era keyword that
  `core24` does not interpret — the literal three characters were taken as the
  version. The release tag is substituted at build time.

## And a gate, so this cannot recur silently

The release job now verifies that every artefact `releasing.md` promises is
present, and fails naming what is missing. The checksum step used to end in
`2>/dev/null … || true`, so an absent package was swallowed there and nothing
else looked.

That gate is what makes the difference between this being fixed and being
believed to be fixed.

## `:latest` follows stable releases only

`:latest` was already published on every release. It is now published only for
stable ones: a tag carrying a pre-release identifier — anything with a hyphen
after the version, `v2.4.0-rc1` — publishes its version tag and leaves `:latest`
where it is. Whatever `:latest` points at is what an unpinned `docker pull`
deploys, so a release candidate must never land there. The release is marked as
a pre-release on GitHub to match, and the determination is made once and reused,
so the push and the notes cannot disagree.

The release notes gained a container row and now name both tags, saying on a
pre-release which one did *not* move.

The `container` job is now sequenced after `release` rather than beside it. It
appends its section to a release body that `release` sets outright; run
concurrently, whichever finished last won, and the container section lost about
half the time. **This does mean a failed pipeline now publishes no image
either** — which is the intended reading of "do not publish a partial release",
but it is a change in behaviour worth knowing about.

## Pull request container images

Every CI build came out as `decision-theatre:4.0.0` — the flake version,
regardless of commit — so images from two pull requests were indistinguishable
and loading one replaced the other. They are now tagged
`decision-theatre:<flake version>-<commit>`.

The pull request comment says plainly that these are run artefacts and there is
nothing to `docker pull`, gives the `gh run download` command instead of asking
you to click through and unzip, and points at GHCR for released images.

## Verification

`mkdocs build --strict` is clean, both workflows parse, and every `bash` block
in them passes `bash -n`. The artefact gate was exercised against fabricated
complete and incomplete sets, including the case that motivated the existence
check: an exact filename with no wildcard is never subject to `nullglob`, so a
first cut of it counted missing files as present.

What is **not** verified is a real release. The next tag is the test. A
throwaway pre-release is the cheap way to run it: it publishes its version tag,
leaves `:latest` on 2.3.0, and the gate names anything still missing.

Two failures from before the docs list broke everything are visible in the run
history and are not addressed here, because nothing in the logs says what they
were: v0.2.2 died at `Package (unix)` on macOS arm64, and v0.2.0 and v0.2.1 died
in an unnamed macOS arm64 step. With `fail-fast` off, the next run reports
whether either is still live.

## Version

Bumped to `0.5.0` — this fixes a P1 but also adds the artefact gate and the
pre-release policy. It does not attempt to reconcile `flake.nix` with the `v2.x`
tag sequence; that is the *Version drifts across five sources of truth* ticket.
