### PR TITLE
feat(ux): give the control panel one surface and the header three accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The control panel reads as one surface instead of a stack of boxes.** Reviewing
+  the panel against the map showed it drawing a frame around each section — the
+  factor card and both scenario cards — inside a panel that is already a container,
+  so every section carried a second edge that said nothing. Those frames are gone,
+  along with the rules between the factor and the scenarios, above the colour
+  scale, and above each scenario's min/mean/max row; the last of these had the
+  scenario description sitting on top of it. Three labels went with them: the
+  "Choose a factor to display in this view" hint under Indicator, the "COLOR SCALE
+  (Full)" heading whose only companion was a button group commented out some time
+  ago, and "Full Zone Statistics", which each scenario printed with the same
+  catchment count as the other and which repeated the zone the control above it
+  already names. That count now sits beside the Zone Range control it belongs to,
+  once. Zone Range is set as a heading like Indicator rather than as small grey
+  all-caps, and its Full/Extent/Site switch spans the panel instead of huddling at
+  the left edge under a full-width heading. The pane number moved off the panel
+  heading onto the factor card, which is the thing the pane number identifies.
+
+- **Each cluster of header controls carries the accent of what it acts on.** View,
+  colour range and map display sat in one row painted a single brand blue, which
+  made three separate decisions look like one long strip of icons. View keeps the
+  blue; colour range takes the Create Site orange; the map toggles take the site
+  green. Both new accents are set with dark text, because white on either falls
+  below the AA contrast floor.
+
+- **Buttons have one corner radius, set once.** The theme's default was `full`,
+  which made pills of controls that sit in dense rows, so individual controls had
+  begun overriding it one at a time — the header icon bar first, then Create Site,
+  the range switch and the aggregate table's toggle. The default is now `md` and
+  the seven overrides restating it are deleted, so a button is consistent by
+  inheriting rather than by remembering.
+
+### Fixed
+
+- **The table view no longer offers a screen it cannot fill.** Table view is a
+  per-site breakdown, so with no site selected it renders "No catchment data
+  available" and nothing else. The icon is now disabled in that state, with a
+  tooltip saying why, in the same way the Site range option already was.
+
+- **A disabled view could take the header's control groups out of the tab order.**
+  Each segmented group puts its single tab stop on the selected option, which is
+  correct until that option is itself disabled — reachable now that the table view
+  can be, by clearing the site while table view is open. The tab stop falls back to
+  the first enabled option, so the group stays reachable by keyboard.
+
+- **The scenario badge in the aggregate table was unreadable.** It asked Chakra for
+  a `colorScheme`, which in dark mode renders the subtle variant as muted olive and
+  grey rather than the brand's orange, green and blue. It now takes its colour from
+  the palette directly, as the scenario badges in the control panel already did.
+
 - **One set of map controls, in the header, instead of thirty-six buttons.** Three
   bands of controls competed for the most space-starved screen in the application.
   A full-width bar above the panes held the view-mode, range-mode, add-pane and

--- a/frontend/src/components/AggregateTable.tsx
+++ b/frontend/src/components/AggregateTable.tsx
@@ -3,6 +3,7 @@ import { Box, Table, Thead, Tbody, Tr, Th, Td, Text, HStack, VStack, Badge, Spin
 import { motion, AnimatePresence } from 'framer-motion';
 import type { CatchmentIndicators, Scenario, SiteIndicators } from '../types';
 import { getSiteCatchments, useAttributeDetails } from '../hooks/useApi';
+import { colors } from '../styles/colors';
 
 interface AggregateTableProps {
   visible: boolean;
@@ -188,7 +189,8 @@ function AggregateTable({
                   </VStack>
                   <HStack spacing={3}>
                     <Badge
-                      colorScheme={scenario === 'reference' ? 'orange' : scenario === 'future' ? 'green' : 'cyan'}
+                      bg={scenario === 'reference' ? colors.orange : scenario === 'future' ? colors.brightGreen : colors.blue}
+                      color={colors.dark}
                       fontSize="md"
                       px={4}
                       py={2}

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   Button,
   ButtonGroup,
+  Spacer,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -343,7 +344,6 @@ function ScenarioSelector({
   side,
   zoneStats,
   hideLabel,
-  zoneStatsLabel,
 }: {
   label: string;
   value: Scenario;
@@ -351,21 +351,11 @@ function ScenarioSelector({
   side: 'left' | 'right';
   zoneStats?: ZoneStats | null;
   hideLabel?: boolean;
-  zoneStatsLabel?: string;
 }) {
   const selectedInfo = SCENARIOS.find((s) => s.id === value);
-  const borderColor = useColorModeValue('gray.200', 'gray.600');
 
   return (
-    <Box
-      p={4}
-      borderRadius="lg"
-      border="1px"
-      borderColor={borderColor}
-      bg={useColorModeValue('white', 'gray.750')}
-      _hover={{ borderColor: selectedInfo?.color || 'brand.400' }}
-      transition="border-color 0.2s"
-    >
+    <Box>
       {!hideLabel && (
         <HStack mb={2}>
           <Badge
@@ -407,10 +397,7 @@ function ScenarioSelector({
 
       {/* Zone statistics for visible catchments */}
       {zoneStats && (
-        <Box mt={3} pt={3} borderTop="1px" borderColor={borderColor}>
-          <Text fontSize="xs" color="gray.500" mb={2}>
-            {zoneStatsLabel ?? 'Visible Zone Statistics'} ({zoneStats.count} catchments)
-          </Text>
+        <Box mt={3}>
           <HStack justify="space-between">
             <VStack spacing={0} align="start">
               <Text fontSize="10px" color="gray.500">Min</Text>
@@ -480,7 +467,6 @@ function ControlPanel({
   const { ignoreXGrouping } = useAttributeIgnoreXGrouping();
   const bgColor = useColorModeValue('gray.50', 'gray.800');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
-  const cardBg = useColorModeValue('white', 'gray.750');
 
   const [factorDerivedMode, setFactorDerivedMode] = useState(false);
   const [factorDerivedValue, setFactorDerivedValue] = useState('');
@@ -724,11 +710,6 @@ function ControlPanel({
     ? attributeColors[comparison.attribute]
     : undefined;
   const effectiveRangeMode: RangeMode = isSiteAggregationActive ? 'site' : rangeMode;
-  const zoneStatsLabel = effectiveRangeMode === 'domain'
-    ? 'Full Zone Statistics'
-    : effectiveRangeMode === 'extent'
-      ? 'Extent Zone Statistics'
-      : 'Site Zone Statistics';
   const leftZoneStatsRaw = effectiveRangeMode === 'domain'
     ? mapStatistics?.fullStats?.left ?? null
     : effectiveRangeMode === 'site'
@@ -763,6 +744,7 @@ function ControlPanel({
 
   const leftZoneStats = applySiteIndicatorOverrides(leftZoneStatsRaw, comparison.leftScenario);
   const rightZoneStats = applySiteIndicatorOverrides(rightZoneStatsRaw, comparison.rightScenario);
+  const zoneCatchmentCount = leftZoneStats?.count ?? rightZoneStats?.count ?? null;
 
   // The color scale is stretched to whichever zone is selected (Full/Extent/Site):
   // 'Full' uses the attribute's global domain across every catchment, while
@@ -773,9 +755,6 @@ function ControlPanel({
   const combinedDomainRange: { min: number; max: number } | null = mapStatistics?.domainRange
     ? { min: mapStatistics.domainRange.min, max: mapStatistics.domainRange.max }
     : null;
-  const colorScaleRangeLabel = effectiveRangeMode === 'domain'
-    ? 'Full'
-    : effectiveRangeMode === 'extent' ? 'Extent' : 'Site';
   const [panelWidth, setPanelWidth] = useState(440);
   const [isResizing, setIsResizing] = useState(false);
   const resizeOriginX = useRef(0);
@@ -818,11 +797,21 @@ function ControlPanel({
     setIsResizing(true);
   };
 
+  // The pane number identifies the card the factor belongs to, so it sits on
+  // that card rather than on the panel heading. Defined once: the chart view
+  // and the map/dial/table view each draw their own factor card, and this is
+  // the same badge in both.
+  const paneBadge = paneIndex !== null ? (
+    <Badge bg={colors.brightGreen} color={colors.dark} variant="subtle" fontSize="xs" borderRadius="full">
+      Pane {paneIndex + 1}
+    </Badge>
+  ) : null;
+
   const panelContent = (
     <VStack spacing={6} p={6} align="stretch">
           {/* Create Site button - shown prominently at top in explore mode */}
           {isExploreMode && onNavigateToCreateSite && (
-            <Box>
+            <Box pt={2}>
               <Button
                 size="lg"
                 width="100%"
@@ -846,19 +835,9 @@ function ControlPanel({
 
           {/* Title */}
           <Box>
-            <HStack mb={1}>
-              <Heading size="sm">
-                Indicator
-              </Heading>
-              {paneIndex !== null && (
-                <Badge bg={colors.brightGreen} color={colors.dark} variant="subtle" fontSize="xs" borderRadius="full">
-                  Pane {paneIndex + 1}
-                </Badge>
-              )}
-            </HStack>
-            <Text fontSize="sm" color="gray.500">
-              Choose a factor to display in this view.
-            </Text>
+            <Heading size="sm" mb={1}>
+              Indicator
+            </Heading>
           </Box>
 
           <Divider />
@@ -866,12 +845,20 @@ function ControlPanel({
           {!asModal && viewMode !== 'dial' && onRangeModeChange && (
             <Box>
               <HStack justify="space-between" align="center" mb={2}>
-                <Text fontSize="xs" fontWeight="600" color="gray.500">
-                  ZONE RANGE
-                </Text>
+                <Heading size="sm">
+                  Zone Range
+                </Heading>
+                {/* The count belongs to the zone, not to either scenario — both
+                    always reported the same number. */}
+                {zoneCatchmentCount !== null && (
+                  <Text fontSize="xs" color="gray.500">
+                    ({zoneCatchmentCount} catchments)
+                  </Text>
+                )}
               </HStack>
-              <ButtonGroup size="xs" isAttached variant="outline">
+              <ButtonGroup size="xs" isAttached variant="outline" width="100%">
                 <Button
+                  flex="1"
                   leftIcon={<FiGlobe size={12} />}
                   onClick={() => onRangeModeChange('domain')}
                   variant={rangeMode === 'domain' ? 'solid' : 'outline'}
@@ -882,6 +869,7 @@ function ControlPanel({
                   Full
                 </Button>
                 <Button
+                  flex="1"
                   leftIcon={<FiSquare size={12} />}
                   onClick={() => onRangeModeChange('extent')}
                   variant={rangeMode === 'extent' ? 'solid' : 'outline'}
@@ -892,6 +880,7 @@ function ControlPanel({
                   Extent
                 </Button>
                 <Button
+                  flex="1"
                   leftIcon={<FiTarget size={12} />}
                   onClick={() => onRangeModeChange('site')}
                   variant={rangeMode === 'site' ? 'solid' : 'outline'}
@@ -908,13 +897,7 @@ function ControlPanel({
 
           {/* Parent Group selector — chart view only */}
           {viewMode === 'chart' && (
-            <Box
-              p={4}
-              borderRadius="lg"
-              border="1px"
-              borderColor={borderColor}
-              bg={cardBg}
-            >
+            <Box>
               <HStack mb={2}>
                 <Badge bg={colors.pastelLightBlue} color={colors.dark} variant="subtle" fontSize="xs" borderRadius="full">
                   INDIVIDUAL FACTOR
@@ -924,6 +907,8 @@ function ControlPanel({
                     <FiInfo size={14} color="gray" />
                   </Box>
                 </Tooltip>
+                <Spacer />
+                {paneBadge}
               </HStack>
 
               <SearchableSelect
@@ -1116,18 +1101,7 @@ function ControlPanel({
           )}
 
           {viewMode !== 'chart' && (
-            <Box
-              id="demo-attribute-selector"
-              p={4}
-              borderRadius="lg"
-              border="1px"
-              borderColor={borderColor}
-              // cardBg, not a hook call: this sits inside a `viewMode !== 'chart'`
-              // conditional, so calling useColorModeValue here changed the number of
-              // hooks between renders — React's "rendered fewer hooks than expected".
-              // The component already computes this exact value at the top.
-              bg={cardBg}
-            >
+            <Box id="demo-attribute-selector">
               <HStack mb={2}>
                 <Badge bg={colors.brightGreen} color={colors.dark} variant="subtle" fontSize="xs" borderRadius="full">
                   FACTOR
@@ -1137,6 +1111,8 @@ function ControlPanel({
                     <FiInfo size={14} color="gray" />
                   </Box>
                 </Tooltip>
+                <Spacer />
+                {paneBadge}
               </HStack>
 
               <SearchableSelect
@@ -1161,8 +1137,6 @@ function ControlPanel({
             </Box>
           )}
 
-          {viewMode !== 'dial' && <Divider />}
-
           {viewMode !== 'dial' && !hideScenarioSelectors && (
             <>
               {/* Scenario 1 (Left) */}
@@ -1173,7 +1147,6 @@ function ControlPanel({
                 side="left"
                 zoneStats={leftZoneStats}
                 hideLabel={isSiteAggregationActive}
-                zoneStatsLabel={zoneStatsLabel}
               />
 
               {/* Scenario 2 (Right) */}
@@ -1184,38 +1157,14 @@ function ControlPanel({
                   onChange={onRightChange}
                   side="right"
                   zoneStats={rightZoneStats}
-                  zoneStatsLabel={zoneStatsLabel}
                 />
               )}
             </>
           )}
 
-          <Divider />
-
           {/* Legend */}
           {comparison.attribute && viewMode !== 'dial' && !hideColorScale && (
             <Box>
-              <HStack justify="space-between" align="center" mb={2}>
-                <Text fontSize="xs" fontWeight="600" color="gray.500">
-                  COLOR SCALE ({colorScaleRangeLabel})
-                </Text>
-                <ButtonGroup size="xs" isAttached variant="outline"> 
-                  {/* <Button
-                    onClick={() => onColorScaleModeChange('rainbow')}
-                    variant={colorScaleMode === 'rainbow' ? 'solid' : 'outline'}
-                    bg={colorScaleMode === 'rainbow' ? colors.pastelDarkGreen : undefined}
-                  >
-                    Rainbow
-                  </Button> */}
-                  {/* <Button
-                    onClick={() => onColorScaleModeChange('metadata')}
-                    variant={colorScaleMode === 'metadata' ? 'solid' : 'outline'}
-                    bg={colorScaleMode === 'metadata' ? colors.pastelDarkGreen : undefined}
-                  >
-                    Single
-                  </Button> */}
-                </ButtonGroup>
-              </HStack>
               <HStack justify="space-between" align="center" mb={2}>
                 <Text fontSize="xs" fontWeight="600" color="gray.500">
                   SCALE TYPE

--- a/frontend/src/components/GridControls.tsx
+++ b/frontend/src/components/GridControls.tsx
@@ -7,6 +7,7 @@ import {
   FiActivity, FiBarChart2, FiBox, FiColumns, FiEdit2, FiGlobe, FiInfo, FiMap,
   FiMoreHorizontal, FiPlus, FiSquare, FiTable, FiTarget,
 } from 'react-icons/fi';
+import { colors } from '../styles/colors';
 import type { RangeMode, ViewMode } from '../types';
 import { satelliteUnavailable, subscribeSatelliteUnavailable } from '../lib/satelliteBasemap';
 
@@ -33,6 +34,7 @@ import { satelliteUnavailable, subscribeSatelliteUnavailable } from '../lib/sate
  */
 const STRINGS = {
   viewGroupLabel: 'View for all panes',
+  noSiteTable: 'The table needs a site — create or select one first',
   rangeGroupLabel: 'Colour range',
   map: 'Map',
   chart: 'Chart',
@@ -86,6 +88,36 @@ const RANGE_MODES: { id: RangeMode; label: string; icon: React.ReactElement }[] 
 ];
 
 /**
+ * The accent a control group paints its active state with.
+ *
+ * The header carries three clusters — view, colour range, map display — and
+ * with one shared accent they read as a single undifferentiated row of icons.
+ * Giving each its own accent ties it to the thing it acts on: view keeps the
+ * brand blue, colour range takes the Create Site orange, and the map toggles
+ * take the site green. `selectedFg` is dark on the orange and the green because
+ * white on either sits below the AA contrast floor.
+ *
+ * Passing no tone leaves a group on the brand blue it had before.
+ */
+interface Tone {
+  selectedBg: string;
+  selectedFg: string;
+  underline: string;
+}
+
+const TONE_RANGE: Tone = {
+  selectedBg: colors.orange,
+  selectedFg: colors.dark,
+  underline: colors.pastelDarkOrange,
+};
+
+const TONE_MAP: Tone = {
+  selectedBg: colors.brightGreen,
+  selectedFg: colors.dark,
+  underline: colors.pastelLightGreen,
+};
+
+/**
  * An independent on/off control.
  *
  * Deliberately not a radio: these five are not a set of alternatives, they are
@@ -94,7 +126,7 @@ const RANGE_MODES: { id: RangeMode; label: string; icon: React.ReactElement }[] 
  * background, because colour alone is not a distinction everyone can see.
  */
 function ToggleButton({
-  label, icon, isOn, onToggle, isDisabled, disabledLabel,
+  label, icon, isOn, onToggle, isDisabled, disabledLabel, tone,
 }: {
   label: string;
   icon: React.ReactElement;
@@ -102,10 +134,14 @@ function ToggleButton({
   onToggle: () => void;
   isDisabled?: boolean;
   disabledLabel?: string;
+  tone?: Tone;
 }) {
-  const onBg = useColorModeValue('brand.500', 'brand.400');
+  const brandBg = useColorModeValue('brand.500', 'brand.400');
+  const brandUnderline = useColorModeValue('brand.700', 'brand.200');
   const offFg = useColorModeValue('gray.600', 'gray.300');
-  const underline = useColorModeValue('brand.700', 'brand.200');
+  const onBg = tone?.selectedBg ?? brandBg;
+  const onFg = tone?.selectedFg ?? 'white';
+  const underline = tone?.underline ?? brandUnderline;
   return (
     <Tooltip label={isDisabled ? disabledLabel ?? label : label} placement="bottom">
       {/* Tooltip needs a focusable child, so the disabled case wraps in a Box. */}
@@ -120,10 +156,9 @@ function ToggleButton({
           variant="ghost"
           minW={8}
           bg={isOn ? onBg : 'transparent'}
-          color={isOn ? 'white' : offFg}
+          color={isOn ? onFg : offFg}
           borderBottom="2px solid"
           borderColor={isOn ? underline : 'transparent'}
-          borderRadius="md"
           _hover={{ bg: isDisabled ? 'transparent' : isOn ? onBg : 'blackAlpha.100' }}
         />
       </Box>
@@ -174,6 +209,7 @@ function MapToggleCluster({
           onToggle={t.onToggle}
           isDisabled={t.isDisabled}
           disabledLabel={t.disabledLabel}
+          tone={TONE_MAP}
         />
       ))}
       <Tooltip label={STRINGS.zoomToSite} placement="bottom">
@@ -232,20 +268,26 @@ function SegmentedGroup<T extends string>({
   value,
   onChange,
   isOptionDisabled,
+  disabledLabel,
   renderLabel,
+  tone,
 }: {
   label: string;
   options: { id: T; label: string; icon: React.ReactElement }[];
   value: T | undefined;
   onChange: (id: T) => void;
   isOptionDisabled?: (id: T) => boolean;
+  disabledLabel?: string;
   renderLabel?: boolean;
+  tone?: Tone;
 }) {
   const refs = useRef<(HTMLButtonElement | null)[]>([]);
-  const selectedBg = useColorModeValue('brand.500', 'brand.400');
-  const selectedFg = 'white';
+  const brandBg = useColorModeValue('brand.500', 'brand.400');
+  const brandUnderline = useColorModeValue('brand.700', 'brand.200');
   const restFg = useColorModeValue('gray.600', 'gray.300');
-  const underline = useColorModeValue('brand.700', 'brand.200');
+  const selectedBg = tone?.selectedBg ?? brandBg;
+  const selectedFg = tone?.selectedFg ?? 'white';
+  const underline = tone?.underline ?? brandUnderline;
 
   // Arrow keys move within the group and wrap, which is what a radiogroup is
   // expected to do; Home and End jump to the ends.
@@ -284,6 +326,16 @@ function SegmentedGroup<T extends string>({
     onChange(options[next].id);
   }, [options, isOptionDisabled, onChange]);
 
+  // The selected option carries the group's only tab stop — unless it is
+  // itself disabled, which would take the whole group out of the tab order.
+  // That is reachable: the table view disables when the site is cleared, and it
+  // can be the selected view when that happens. The stop falls back to the
+  // first enabled option so the group stays usable from the keyboard.
+  const selectedIndex = options.findIndex((o) => o.id === value);
+  const tabStopIndex = selectedIndex >= 0 && !isOptionDisabled?.(options[selectedIndex].id)
+    ? selectedIndex
+    : options.findIndex((o) => !isOptionDisabled?.(o.id));
+
   return (
     <HStack role="radiogroup" aria-label={label} spacing={0.5}>
       {options.map((option, index) => {
@@ -296,9 +348,10 @@ function SegmentedGroup<T extends string>({
             role="radio"
             aria-checked={isSelected}
             aria-label={renderLabel ? undefined : option.label}
-            // One tab stop for the group: only the selected option is
-            // reachable by Tab, and the arrows move between them.
-            tabIndex={isSelected ? 0 : -1}
+            // One tab stop for the group, and the arrows move between the
+            // options from there. See tabStopIndex above for which option
+            // carries it.
+            tabIndex={index === tabStopIndex ? 0 : -1}
             isDisabled={disabled}
             onClick={() => !disabled && onChange(option.id)}
             onKeyDown={(e) => onKeyDown(e, index)}
@@ -312,7 +365,6 @@ function SegmentedGroup<T extends string>({
             color={isSelected ? selectedFg : restFg}
             borderBottom="2px solid"
             borderColor={isSelected ? underline : 'transparent'}
-            borderRadius="md"
             _hover={{ bg: disabled ? 'transparent' : isSelected ? selectedBg : 'blackAlpha.100' }}
           >
             {renderLabel
@@ -323,7 +375,7 @@ function SegmentedGroup<T extends string>({
         return (
           <Tooltip
             key={option.id}
-            label={disabled ? STRINGS.noSite : `${option.label}${renderLabel ? ` ${STRINGS.rangeSuffix}` : ''}`}
+            label={disabled ? disabledLabel ?? STRINGS.noSite : `${option.label}${renderLabel ? ` ${STRINGS.rangeSuffix}` : ''}`}
             placement="bottom"
           >
             {content}
@@ -357,6 +409,7 @@ function GridControls({
 }: GridControlsProps) {
   const dividerColor = useColorModeValue('gray.300', 'gray.600');
   const noSite = useCallback((id: RangeMode) => id === 'site' && !siteId, [siteId]);
+  const noSiteTable = useCallback((id: ViewMode) => id === 'table' && !siteId, [siteId]);
 
   // Satellite can become unavailable at runtime — quota spent, or no provider
   // configured once /api/info resolves. The button says so rather than offering
@@ -384,6 +437,8 @@ function GridControls({
           options={VIEW_MODES}
           value={viewMode}
           onChange={onViewModeChange}
+          isOptionDisabled={noSiteTable}
+          disabledLabel={STRINGS.noSiteTable}
         />
 
         {onRangeModeChange && (
@@ -395,6 +450,7 @@ function GridControls({
               onChange={onRangeModeChange}
               isOptionDisabled={noSite}
               renderLabel
+              tone={TONE_RANGE}
             />
           </HStack>
         )}
@@ -447,6 +503,8 @@ function GridControls({
           options={VIEW_MODES}
           value={viewMode}
           onChange={onViewModeChange}
+          isOptionDisabled={noSiteTable}
+          disabledLabel={STRINGS.noSiteTable}
         />
         {/*
           The toggles are icons already, so they still fit beside the view

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -55,7 +55,12 @@ export const theme = extendTheme({
   components: {
     Button: {
       baseStyle: {
-        borderRadius: 'full',
+        // The corner every button in the application inherits. This was 'full',
+        // which made pills of the controls that sit in dense rows — the header
+        // icon bar, the range switch, the aggregate table's toggle — so each of
+        // those had begun overriding it separately. Setting it here means a
+        // button is consistent by default rather than by remembering.
+        borderRadius: 'md',
         fontWeight: 'semibold',
         fontSize: 'sm',
         transition: 'all 0.2s',


### PR DESCRIPTION
## What this is

A pass over the control panel and the header, driven by two annotated
screenshots of the running application. Twenty marked points across the two,
plus three things found while working through them.

<img width="2550" height="1452" alt="image" src="https://github.com/user-attachments/assets/bab40769-45e4-472b-9f48-c3284fa1f7e4" />

