### PR TITLE
feat(calc): align grazing/DMI units with NPP and add grass biomass tracking

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
-import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text, useToast } from '@chakra-ui/react';
+import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text } from '@chakra-ui/react';
 import { FiSliders, FiMap, FiPlus, FiMinus, FiTrash2 } from 'react-icons/fi';
 import maplibregl from 'maplibre-gl';
 import { bbox as turfBbox, featureCollection, union, difference, intersect, area as turfArea, simplify as turfSimplify } from '@turf/turf';
@@ -2163,7 +2163,6 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
   const onGoogleBasemapChangeRef = useRef(onGoogleBasemapChange);
   onGoogleBasemapChangeRef.current = onGoogleBasemapChange;
   const isGoogleBasemapRef = useRef(getAppRuntime() === 'browser');
-  const toast = useToast();
 
   // Shared by the toggle button and the quota-exceeded auto-revert below, so
   // the two cannot drift into applying the switch differently.
@@ -2233,17 +2232,13 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       }
 
       if (unavailable && wanted) {
-        toast({
-          title: 'Satellite imagery unavailable',
-          description: "This month's quota has been used up, or no imagery "
-            + 'provider is configured. Switched to the default map.',
-          status: 'warning',
-          duration: 8000,
-          isClosable: true,
-        });
+        console.log(
+          "Satellite imagery unavailable: this month's quota has been used up, "
+            + 'or no imagery provider is configured. Switched to the default map.',
+        );
       }
     });
-  }, [applyBasemapStyle, toast]);
+  }, [applyBasemapStyle]);
 
   const deriveBoundsFromGeometry = useCallback((geometry: GeoJSON.Geometry | null): BoundingBox | null => {
     if (!geometry) return null;

--- a/frontend/src/components/SiteCreationMap.tsx
+++ b/frontend/src/components/SiteCreationMap.tsx
@@ -1125,19 +1125,15 @@ function SiteCreationMap({
     const next = !isGoogleBasemapRef.current;
 
     if (next && satelliteUnavailable()) {
-      toast({
-        title: 'Satellite imagery unavailable',
-        description: "This month's quota has been used up, or no imagery "
-          + 'provider is configured. Showing the default map instead.',
-        status: 'warning',
-        duration: 8000,
-        isClosable: true,
-      });
+      console.log(
+        "Satellite imagery unavailable: this month's quota has been used up, "
+          + 'or no imagery provider is configured. Showing the default map instead.',
+      );
       return;
     }
 
     applyGoogleBasemap(next);
-  }, [applyGoogleBasemap, toast]);
+  }, [applyGoogleBasemap]);
 
   // If satellite becomes unavailable (quota spent, or — at startup, before
   // /api/info has resolved — no provider turns out to be configured) while it
@@ -1147,16 +1143,12 @@ function SiteCreationMap({
     return subscribeSatelliteUnavailable((unavailable) => {
       if (!unavailable || !isGoogleBasemapRef.current) return;
       applyGoogleBasemap(false);
-      toast({
-        title: 'Satellite imagery unavailable',
-        description: "This month's quota has been used up, or no imagery "
-          + 'provider is configured. Switched to the default map.',
-        status: 'warning',
-        duration: 8000,
-        isClosable: true,
-      });
+      console.log(
+        "Satellite imagery unavailable: this month's quota has been used up, "
+          + 'or no imagery provider is configured. Switched to the default map.',
+      );
     });
-  }, [applyGoogleBasemap, toast]);
+  }, [applyGoogleBasemap]);
 
   const getInstructions = () => {
     switch (mode) {

--- a/frontend/src/constants/calculationFormulas.ts
+++ b/frontend/src/constants/calculationFormulas.ts
@@ -43,8 +43,8 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
     explanation:
       "Weighted sum of litter biomass (g/m²). " +
       "Litter midpoints for the 10 classes are " +
-      "0.06, 0.18, 0.36, 0.70, 0.98, 1.44, 1.98, 2.60, 3.30, 4.32 g/m². " +
-      "Derived from leaf mass fraction (LMF = 4%) of AGB, adjusted for evergreen fraction per class.",
+      "6.0, 18.0, 36.0, 70.0, 98.0, 144.0, 198.0, 260.0, 330.0, 432.0 g/m². " +
+      "Derived from leaf mass fraction (LMF = 4%) of AGB, adjusted for evergreen fraction per class, ×100 to convert Mg/ha to g/m².",
   },
   meanTC: {
     workflow: "Tree Cover (§1)",
@@ -66,10 +66,20 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
   },
   flamNPP_gm2: {
     workflow: "Tree Cover (§1)",
-    formula: "flamNPP = Σᵢ₌₀⁵ ( prop_class[i] × site_NPP_by_treecover[i] )",
+    formula: "flamNPP = Σᵢ₌₀⁵ ( prop_class[i] × site_NPP_by_treecover[i] )\n  [fallback: flamNPP × (new_lowTC / old_lowTC)]",
     explanation:
       "Flammable NPP — the same weighted-NPP sum but restricted to the six low-TC " +
-      "classes (biomass < 50 Mg/ha) which are the areas capable of carrying fire.",
+      "classes (biomass < 50 Mg/ha) which are the areas capable of carrying fire. " +
+      "Otherwise scales proportionally with the change in low-tree-cover fraction, same as NPP_gm2. " +
+      "Feeds directly into fuelload_gm2 for the fire cascade.",
+  },
+  "NPP_gm2.1": {
+    workflow: "Tree Cover (§1 step 3) / Herbivores → Grazing Intensity",
+    formula: "NPP_gm2.1 = max( 0,  NPP_gm2 − herbs_totGRAZING_DMI_gm2 )",
+    explanation:
+      "Grass standing biomass (g/m²) — grass NPP net of what grazers consume, floored at zero " +
+      "(grazers can't remove more grass than was produced). " +
+      "Recomputed together with grazing_intensity whenever NPP or grazing DMI changes.",
   },
   deltaSOC_Mgha_trees: {
     workflow: "SOC — Tree Cover Branch (§3 Branch 1)",
@@ -93,12 +103,13 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
       "(DMI, CH4, grazing fractions, functional groups, diet groups) is " +
       "scaled proportionally by the ratio new_total / old_total.",
   },
-  herbs_tot_DMI_kgkm2: {
+  herbs_tot_DMI_gm2: {
     workflow: "Herbivores (§4)",
-    formula: "herbs_tot_DMI = Σ( herbs_sp_DMI_kgkm2_[species] )\n  [direct edit: scaled by new_total / old_total]",
+    formula: "herbs_tot_DMI = Σ( herbs_sp_DMI_gm2_[species] )\n  [direct edit: scaled by new_total / old_total]",
     explanation:
-      "Total herbivore dry matter intake (kg/km²/yr) summed over all species. " +
-      "Per-species DMI = counts × DMI_per_individual (kg/head/yr) from the species trait table.",
+      "Total herbivore dry matter intake (g/m²/yr) summed over all species. " +
+      "Per-species DMI = counts × DMI_per_individual (kg/head/yr) from the species trait table, " +
+      "÷1000 to convert from kg/km²/yr to g/m²/yr.",
   },
   herbs_tot_CH4_kgkm2: {
     workflow: "Herbivores (§4)",
@@ -115,12 +126,13 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
       "Total biomass of grazing herbivores (kg/km²) — only the grass-consuming fraction " +
       "of each species' biomass, weighted by that species' Prop_Grass trait value.",
   },
-  herbs_totGRAZING_DMI_kgkm2: {
+  herbs_totGRAZING_DMI_gm2: {
     workflow: "Herbivores (§4)",
-    formula: "herbs_totGRAZING_DMI = Σ( herbs_sp_DMI_kgkm2_[sp] × Prop_Grass[sp] )",
+    formula: "herbs_totGRAZING_DMI = Σ( herbs_sp_DMI_gm2_[sp] × Prop_Grass[sp] )",
     explanation:
-      "Dry matter intake (kg/km²/yr) attributable to grazing — only the grass portion of each " +
-      "species' DMI, weighted by Prop_Grass. Used for fuel-load reduction and grazing intensity.",
+      "Dry matter intake (g/m²/yr) attributable to grazing — only the grass portion of each " +
+      "species' DMI, weighted by Prop_Grass. Used for fuel-load reduction and grazing intensity, " +
+      "both directly in g/m² with no further unit conversion.",
   },
   herbs_totGRAZING_CH4_kgkm2: {
     workflow: "Herbivores (§4)",
@@ -138,11 +150,11 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
   },
   grazing_intensity: {
     workflow: "Herbivores → Grazing Intensity",
-    formula: "GI = min( 1,  herbs_totGRAZING_DMI_kgkm2 / (NPP_gm2 × 1000) )",
+    formula: "GI = min( 1,  herbs_totGRAZING_DMI_gm2 / NPP_gm2 )",
     explanation:
       "Dimensionless grazing intensity (0 – 1). " +
-      "Divides total grazing dry-matter intake (kg/km²) by grass production " +
-      "(NPP converted from g/m² to kg/km² by ×1000). " +
+      "Divides total grazing dry-matter intake by grass production — both already " +
+      "expressed in g/m², so no unit conversion is needed. " +
       "A value of 1 means grazers consume all available grass.",
   },
 
@@ -171,11 +183,13 @@ export const COLUMN_FORMULAS: Record<string, ColumnFormula> = {
   // ── Fire cascade ─────────────────────────────────────────────────────────
   fuelload_gm2: {
     workflow: "Fire Cascade (§2)",
-    formula: "fuelload = max( 0,  NPP_gm2 + LitterBiomass_gm2 − herbs_totGRAZING_DMI_kgkm2 / 1000 )",
+    formula: "fuelload = max( 0,  flamNPP_gm2 + LitterBiomass_gm2 − herbs_totGRAZING_DMI_gm2 )",
     explanation:
       "Available fire fuel (g/m²). " +
-      "Grass produced (NPP) plus standing litter, minus the grass consumed by grazers " +
-      "(DMI converted from kg/km² to g/m² by ÷1000). " +
+      "Uses flammable-zone NPP (flamNPP_gm2, the low-tree-cover classes only), not total NPP — " +
+      "fire only carries through the open part of the landscape. " +
+      "Plus standing litter, minus the grass consumed by grazers " +
+      "— all three terms are already in g/m², so no unit conversion is needed. " +
       "Herbivores reduce fuel load and thereby suppress fire.",
   },
   Intensity_early_kW_m: {
@@ -326,15 +340,16 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
       name: "Tree Cover §1.3 — Mean Tree Cover edited directly",
       trigger: "You set meanTC directly.",
       steps: [
-        "Compute shift = (old_meanTC − new_meanTC) / 10",
-        "First 5 low-TC classes (0–40 Mg/ha) each increase by shift",
-        "Last 5 classes (40–100 Mg/ha) each decrease by shift (clamped ≥ 0)",
+        "Recompute the actual current meanTC from today's class proportions (the stored value may not exactly match the weighted-midpoint sum)",
+        "Solve shift = (actual_old_meanTC − new_meanTC) / (Σ decreasing-class midpoints − Σ increasing-class midpoints), so the new weighted mean hits the target exactly",
+        "5 low-TC classes (0–40 Mg/ha midpoints) each increase by shift",
+        "5 high-TC classes (40–100 Mg/ha midpoints) each decrease by shift — not clamped, so a target outside the reachable range can push a class negative",
         "Recalculate lowTC_prop and highTC_prop from updated class sums",
-        "Run shared prop-derived metrics (AGBwd, LitterBiomass, NPP, flamNPP, deltaSOC_trees)",
-        "Recompute grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Run shared prop-derived metrics (AGBwd, LitterBiomass, meanTC, NPP, flamNPP, deltaSOC_trees)",
+        "Recompute NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
         "deltaSOC_Mgha = deltaSOC_Mgha_trees + deltaSOC_Mgha_grazers",
       ],
-      outputs: ["lowTC_prop", "highTC_prop", "AGBwd_Mgha", "LitterBiomass_gm2", "NPP_gm2", "flamNPP_gm2", "deltaSOC_Mgha_trees", "grazing_intensity", "deltaSOC_Mgha"],
+      outputs: ["lowTC_prop", "highTC_prop", "meanTC", "AGBwd_Mgha", "LitterBiomass_gm2", "NPP_gm2", "flamNPP_gm2", "deltaSOC_Mgha_trees", "grazing_intensity", "deltaSOC_Mgha"],
     });
   }
 
@@ -348,7 +363,7 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
         "Recalculate lowTC_prop = sum of the 6 low-TC classes (0–50 Mg/ha)",
         "Recalculate highTC_prop = sum of the 4 high-TC classes (50–100 Mg/ha)",
         "Run shared prop-derived metrics (AGBwd, LitterBiomass, meanTC, NPP, flamNPP, deltaSOC_trees)",
-        "Recompute grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recompute NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
         "deltaSOC_Mgha = deltaSOC_Mgha_trees + deltaSOC_Mgha_grazers",
       ],
       outputs: ["lowTC_prop", "highTC_prop", "meanTC", "AGBwd_Mgha", "LitterBiomass_gm2", "NPP_gm2", "flamNPP_gm2", "deltaSOC_Mgha_trees", "grazing_intensity", "deltaSOC_Mgha"],
@@ -366,14 +381,17 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
         "Redistribute the 6 low-TC biomass classes equally: each = lowTC_prop / 6",
         "Redistribute the 4 high-TC biomass classes equally: each = highTC_prop / 4",
         "Run shared prop-derived metrics (AGBwd, LitterBiomass, meanTC, NPP, flamNPP, deltaSOC_trees)",
-        "Recompute grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recompute NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
         "deltaSOC_Mgha = deltaSOC_Mgha_trees + deltaSOC_Mgha_grazers",
       ],
-      outputs: ["highTC_prop", "AGBwd_Mgha", "LitterBiomass_gm2", "meanTC", "NPP_gm2", "flamNPP_gm2", "deltaSOC_Mgha_trees", "grazing_intensity", "deltaSOC_Mgha"],
+      outputs: ["lowTC_prop", "highTC_prop", "AGBwd_Mgha", "LitterBiomass_gm2", "meanTC", "NPP_gm2", "flamNPP_gm2", "deltaSOC_Mgha_trees", "grazing_intensity", "deltaSOC_Mgha"],
     });
   }
 
-  // §2 — Herbivores total edited directly
+  // §2/§4a/§4b — herbivore edits are mutually exclusive in the backend: a
+  // single PATCH only runs one of these three workflows, in this priority
+  // order (herbs_tot_kgkm2 wins over species counts, which wins over species
+  // biomass), even if multiple herbs_* fields were changed in the same edit.
   if (herbsTotChanged) {
     steps.push({
       name: "Herbivores §2 — Total biomass edited directly",
@@ -382,63 +400,57 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
         "Compute scale = new_total / old_total",
         "Scale all herbs_* sub-fields proportionally (DMI, CH4, grazing fractions, per-species, functional groups, diet groups)",
         "fracGrazing = herbs_totGRAZING_kgkm2 / herbs_tot_kgkm2",
-        "Recalculate grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recalculate NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
       ],
       outputs: [
-        "herbs_tot_DMI_kgkm2", "herbs_tot_CH4_kgkm2",
-        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_kgkm2", "herbs_totGRAZING_CH4_kgkm2",
-        "fracGrazing", "grazing_intensity",
-        "herbs_sp_kgkm2_*", "herbs_sp_counts_*", "herbs_sp_DMI_kgkm2_*", "herbs_sp_CH4_kgkm2_*",
-        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_kgkm2_*", "herbs_fg_CH4_kgkm2_*",
-        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_kgkm2_*", "herbs_diet_CH4_kgkm2_*",
+        "herbs_tot_DMI_gm2", "herbs_tot_CH4_kgkm2",
+        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_gm2", "herbs_totGRAZING_CH4_kgkm2",
+        "fracGrazing", "NPP_gm2.1", "grazing_intensity",
+        "herbs_sp_kgkm2_*", "herbs_sp_counts_*", "herbs_sp_DMI_gm2_*", "herbs_sp_CH4_kgkm2_*",
+        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_gm2_*", "herbs_fg_CH4_kgkm2_*",
+        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_gm2_*", "herbs_diet_CH4_kgkm2_*",
       ],
     });
-  }
-
-  // §4a — species counts edited
-  if (speciesCountsChanged) {
+  } else if (speciesCountsChanged) {
     steps.push({
       name: "Herbivores §4a — Species counts edited",
       trigger: "You edited one or more species headcount columns (herbs_sp_counts_*).",
       steps: [
         "For each changed species: biomass = count × body_mass (kg/individual)",
-        "For each changed species: DMI = count × DMI_per_individual (kg/km²/yr)",
+        "For each changed species: DMI = count × DMI_per_individual (kg/km²/yr), ÷1000 to g/m²/yr",
         "For each changed species: CH4 = count × CH4_per_individual (kg/km²/yr)",
         "Recompute total biomass, DMI, CH4 as sums over all species",
         "Recompute grazing totals (×Prop_Grass) and diet/functional-group aggregates",
         "fracGrazing = herbs_totGRAZING_kgkm2 / herbs_tot_kgkm2",
-        "Recalculate grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recalculate NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
       ],
       outputs: [
-        "herbs_sp_kgkm2_*", "herbs_sp_DMI_kgkm2_*", "herbs_sp_CH4_kgkm2_*",
-        "herbs_tot_kgkm2", "herbs_tot_DMI_kgkm2", "herbs_tot_CH4_kgkm2",
-        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_kgkm2", "herbs_totGRAZING_CH4_kgkm2",
-        "fracGrazing", "grazing_intensity",
-        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_kgkm2_*", "herbs_fg_CH4_kgkm2_*",
-        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_kgkm2_*", "herbs_diet_CH4_kgkm2_*",
+        "herbs_sp_kgkm2_*", "herbs_sp_DMI_gm2_*", "herbs_sp_CH4_kgkm2_*",
+        "herbs_tot_kgkm2", "herbs_tot_DMI_gm2", "herbs_tot_CH4_kgkm2",
+        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_gm2", "herbs_totGRAZING_CH4_kgkm2",
+        "fracGrazing", "NPP_gm2.1", "grazing_intensity",
+        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_gm2_*", "herbs_fg_CH4_kgkm2_*",
+        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_gm2_*", "herbs_diet_CH4_kgkm2_*",
       ],
     });
-  }
-
-  // §4b — species biomass edited
-  if (speciesBiomassChanged) {
+  } else if (speciesBiomassChanged) {
     steps.push({
       name: "Herbivores §4b — Species biomass edited",
       trigger: "You edited one or more species biomass columns (herbs_sp_kgkm2_*).",
       steps: [
         "For each species: count = biomass / body_mass",
-        "For each species: DMI = count × DMI_per_individual",
+        "For each species: DMI = count × DMI_per_individual (kg/km²/yr), ÷1000 to g/m²/yr",
         "For each species: CH4 = count × CH4_per_individual",
         "Recompute total biomass, DMI, CH4 and all aggregates",
-        "Recalculate grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recalculate NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
       ],
       outputs: [
-        "herbs_sp_counts_*", "herbs_sp_DMI_kgkm2_*", "herbs_sp_CH4_kgkm2_*",
-        "herbs_tot_kgkm2", "herbs_tot_DMI_kgkm2", "herbs_tot_CH4_kgkm2",
-        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_kgkm2", "herbs_totGRAZING_CH4_kgkm2",
-        "fracGrazing", "grazing_intensity",
-        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_kgkm2_*", "herbs_fg_CH4_kgkm2_*",
-        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_kgkm2_*", "herbs_diet_CH4_kgkm2_*",
+        "herbs_sp_counts_*", "herbs_sp_DMI_gm2_*", "herbs_sp_CH4_kgkm2_*",
+        "herbs_tot_kgkm2", "herbs_tot_DMI_gm2", "herbs_tot_CH4_kgkm2",
+        "herbs_totGRAZING_kgkm2", "herbs_totGRAZING_DMI_gm2", "herbs_totGRAZING_CH4_kgkm2",
+        "fracGrazing", "NPP_gm2.1", "grazing_intensity",
+        "herbs_fg_kgkm2_*", "herbs_fg_counts_*", "herbs_fg_DMI_gm2_*", "herbs_fg_CH4_kgkm2_*",
+        "herbs_diet_kgkm2_*", "herbs_diet_counts_*", "herbs_diet_DMI_gm2_*", "herbs_diet_CH4_kgkm2_*",
       ],
     });
   }
@@ -449,7 +461,7 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
       name: "SOC Grazing §3 Branch 2 — Grazer carbon effect",
       trigger: "Triggered automatically because tree cover, NPP, or grazing DMI changed.",
       steps: [
-        "Compute target grazing intensity: GI = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Compute target grazing intensity: GI = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
         "Compute baseline GI at old values (before the edit)",
         "% SOC change = −5.916 + 0.587 × (GI×100) − 0.00936 × (GI×100)²  [Ren et al. 2023]",
         "deltaSOC_grazers = SOC_0_30 × (% SOC change at target GI / 100) − SOC_0_30 × (% SOC change at baseline GI / 100)",
@@ -465,9 +477,9 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
       name: "Grass NPP — edited directly",
       trigger: "You set NPP_gm2 (net primary productivity) directly.",
       steps: [
-        "Recalculate grazing_intensity = min(1, herbs_totGRAZING_DMI / (NPP × 1000))",
+        "Recalculate NPP_gm2.1 = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2) and grazing_intensity = min(1, herbs_totGRAZING_DMI_gm2 / NPP_gm2)",
       ],
-      outputs: ["grazing_intensity"],
+      outputs: ["NPP_gm2.1", "grazing_intensity"],
     });
   }
 
@@ -477,7 +489,7 @@ export function getTriggeredWorkflows(changedKeys: string[]): WorkflowStep[] {
       name: "Fire Cascade §2 — Fire regime recalculation",
       trigger: "Triggered automatically because NPP, litter, grazing DMI, tree cover, or propEarly changed.",
       steps: [
-        "Fuel load = max(0, NPP_gm2 + LitterBiomass_gm2 − herbs_totGRAZING_DMI_kgkm2 / 1000)",
+        "Fuel load = max(0, flamNPP_gm2 + LitterBiomass_gm2 − herbs_totGRAZING_DMI_gm2)",
         "Intensity_early = exp(6.65747 + 0.0011896 × fuelload) − exp(6.65747)",
         "Intensity_late  = min(17 000, exp(6.65747 + 0.003535 × fuelload) − exp(6.65747))",
         "  [In high-rainfall areas MAR > 1500 mm: Intensity_late = Intensity_early]",

--- a/frontend/src/lib/satelliteBasemap.ts
+++ b/frontend/src/lib/satelliteBasemap.ts
@@ -77,6 +77,7 @@ export function applyServerSatelliteConfig(info: ServerInfo | null | undefined):
   }
 
   const wasUnavailable = unavailable();
+  const wasConfirmed = confirmed;
 
   quotaExceeded = info?.satellite_quota_exceeded ?? false;
   // Only an explicit true. A missing field means an older server that cannot
@@ -87,7 +88,14 @@ export function applyServerSatelliteConfig(info: ServerInfo | null | undefined):
   // same "assume it works" the module-level default above already commits to.
   available = info?.satellite_available ?? true;
 
-  if (unavailable() !== wasUnavailable) {
+  // `confirmed` flipping true-without-`unavailable()` changing is exactly the
+  // case that matters most: a map built before this response landed (the
+  // first grid pane, which mounts before the rest — see ViewPane.tsx's
+  // stagger) chose the built-in style because satelliteConfirmed() was still
+  // false, and `available` was already optimistically true so unavailable()
+  // never moves. Without this, that pane is stuck on the built-in basemap
+  // until something else changes isGoogleBasemap.
+  if (unavailable() !== wasUnavailable || confirmed !== wasConfirmed) {
     for (const listener of unavailableListeners) listener(unavailable());
   }
 }

--- a/frontend/src/test/satelliteBasemap.test.ts
+++ b/frontend/src/test/satelliteBasemap.test.ts
@@ -166,6 +166,28 @@ describe('satellite availability and quota tracking', () => {
     applyServerSatelliteConfig(info({ satellite_quota_exceeded: true }));
     expect(listener).toHaveBeenCalledTimes(2);
   });
+
+  it('notifies when confirmation arrives even though the optimistic default already reads as available', () => {
+    // Regression test: grid view mounts its first pane before /api/info has a
+    // chance to resolve, so that pane's map is built against the built-in
+    // style (satelliteConfirmed() is false). It relies on this listener firing
+    // once the real answer lands to switch over — see MapView.tsx's comment
+    // "The listener further up switches to satellite the moment confirmation
+    // arrives." Before this fix, going from unconfirmed to confirmed with
+    // quota/availability otherwise unchanged (the common case: a working key,
+    // first response of the session) left `unavailable()` at `false` the whole
+    // time, so the listener never fired and that pane stayed on the built-in
+    // basemap for the rest of the session.
+    const listener = vi.fn();
+    subscribeSatelliteUnavailable(listener);
+
+    expect(satelliteConfirmed()).toBe(false);
+    applyServerSatelliteConfig(info({ satellite_available: true, satellite_quota_exceeded: false }));
+
+    expect(satelliteConfirmed()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(false);
+  });
 });
 
 /**

--- a/internal/api/recalculate.go
+++ b/internal/api/recalculate.go
@@ -18,6 +18,17 @@ const (
 	colNPP                 = "NPP_gm2"
 	colHerbsSpCountsPrefix = "herbs_sp_counts_"
 	colHerbsSpKgkm2Prefix  = "herbs_sp_kgkm2_"
+
+	// colGrassBiomass is NPP_gm2.1 (§1 step 3, Aug2026 workflow): grass NPP
+	// net of what grazers consume.
+	colGrassBiomass = "NPP_gm2.1"
+
+	// colHerbsSpDMIGm2Prefix and colHerbsTotGrazingDMI hold dry matter intake
+	// in g/m² (metadata.csv Units=gm-2). Aug2026 workflow renamed these from
+	// the earlier "_kgkm2" naming; NPP_gm2 (g/m²) can now be compared/combined
+	// with them directly, with no ×1000 / ÷1000 conversion at the point of use.
+	colHerbsSpDMIGm2Prefix = "herbs_sp_DMI_gm2_"
+	colHerbsTotGrazingDMI  = "herbs_totGRAZING_DMI_gm2"
 )
 
 // lowTCBiomassClasses are the proportion columns for open/grassy areas
@@ -200,12 +211,9 @@ func recomputePropDerivedMetrics(ideal map[string]float64, oldLowTC, oldHighTC f
 	}
 	ideal["deltaSOC_Mgha"] = ideal["deltaSOC_Mgha_trees"] + ideal["deltaSOC_Mgha_grazers"]
 
-	// Recompute grazing intensity — NPP may have changed, DMI is unchanged.
-	// R scripts (0_5, fefa_ppp_v3 §4.8) always derive GI = DMI / (NPP × 1000)
-	// after any tree-cover or NPP update.
-	if npp := ideal["NPP_gm2"]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], npp)
-	}
+	// Recompute grass biomass and grazing intensity — NPP may have changed,
+	// DMI is unchanged (§1 step 3, §3 Branch 2).
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // ── Tree-cover workflows ──────────────────────────────────────────────────────
@@ -324,13 +332,31 @@ func workflowMeanTC(ideal, oldIdeal map[string]float64, lookup *LookupData) {
 // ── SOC helper ────────────────────────────────────────────────────────────────
 
 // grazingIntensity returns the dimensionless grazing intensity (clamped 0–1).
-// herbs_totGRAZING_DMI_kgkm2 (kg/km²) and NPP_gm2 (g/m²) use different units;
-// multiplying NPP by 1000 converts g/m² → kg/km² (§3 Branch 2).
-func grazingIntensity(dmiKgKm2, nppGm2 float64) float64 {
+// herbs_totGRAZING_DMI_gm2 and NPP_gm2 are both expressed in g/m², so no unit
+// conversion is needed (§3 Branch 2).
+func grazingIntensity(dmiGm2, nppGm2 float64) float64 {
 	if nppGm2 <= 0 {
 		return 0
 	}
-	return math.Min(1, dmiKgKm2/(nppGm2*1000))
+	return math.Min(1, dmiGm2/nppGm2)
+}
+
+// updateGrassBiomassAndGrazingIntensity recomputes NPP_gm2.1 (Grass Biomass,
+// §1 step 3) and grazing_intensity (§3 Branch 2) from the current NPP_gm2 and
+// herbs_totGRAZING_DMI_gm2 in ideal. Both share the same recalculation
+// triggers — NPP or grazing DMI changing — so they are always refreshed
+// together.
+func updateGrassBiomassAndGrazingIntensity(ideal map[string]float64) {
+	npp := ideal[colNPP]
+	grazingDMI := ideal[colHerbsTotGrazingDMI]
+
+	// 0_5_CalculateCurr_Ref_NPP_SOC.R clamps GrassBiomass at 0 (can't go
+	// negative — grazers can't remove more grass than was produced).
+	ideal[colGrassBiomass] = math.Max(0, npp-grazingDMI)
+
+	if npp > 0 {
+		ideal["grazing_intensity"] = grazingIntensity(grazingDMI, npp)
+	}
 }
 
 // workflowSOCGrazing recomputes deltaSOC_Mgha_grazers (§3 Branch 2) using
@@ -357,8 +383,8 @@ func workflowSOCGrazing(ideal, oldIdeal map[string]float64) {
 		return socPolyA + socPolyB*gi100 + socPolyC*gi100*gi100
 	}
 
-	giTarget := grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], ideal["NPP_gm2"])
-	giBaseline := grazingIntensity(oldIdeal["herbs_totGRAZING_DMI_kgkm2"], oldIdeal["NPP_gm2"])
+	giTarget := grazingIntensity(ideal[colHerbsTotGrazingDMI], ideal["NPP_gm2"])
+	giBaseline := grazingIntensity(oldIdeal[colHerbsTotGrazingDMI], oldIdeal["NPP_gm2"])
 
 	diffSOCTarget := soc0_30 * percSOCChange(giTarget) / 100
 	diffSOCBaseline := soc0_30 * percSOCChange(giBaseline) / 100
@@ -395,7 +421,7 @@ func recomputeHerbTotals(ideal map[string]float64, traits map[string]HerbTrait) 
 			continue
 		}
 		spCounts := ideal[colHerbsSpCountsPrefix+commonName]
-		spDMI := ideal["herbs_sp_DMI_kgkm2_"+commonName]
+		spDMI := ideal[colHerbsSpDMIGm2Prefix+commonName]
 		spCH4 := ideal["herbs_sp_CH4_kgkm2_"+commonName]
 
 		totKg += spKg
@@ -419,10 +445,10 @@ func recomputeHerbTotals(ideal map[string]float64, traits map[string]HerbTrait) 
 	}
 
 	ideal[colHerbsTot] = totKg
-	ideal["herbs_tot_DMI_kgkm2"] = totDMI
+	ideal["herbs_tot_DMI_gm2"] = totDMI
 	ideal["herbs_tot_CH4_kgkm2"] = totCH4
 	ideal["herbs_totGRAZING_kgkm2"] = totGrazingKg
-	ideal["herbs_totGRAZING_DMI_kgkm2"] = totGrazingDMI
+	ideal[colHerbsTotGrazingDMI] = totGrazingDMI
 	ideal["herbs_totGRAZING_CH4_kgkm2"] = totGrazingCH4
 	if totKg > 0 {
 		ideal["fracGrazing"] = totGrazingKg / totKg
@@ -435,7 +461,7 @@ func recomputeHerbTotals(ideal map[string]float64, traits map[string]HerbTrait) 
 		ideal["herbs_fg_counts_"+fg] = v
 	}
 	for fg, v := range fgDMI {
-		ideal["herbs_fg_DMI_kgkm2_"+fg] = v
+		ideal["herbs_fg_DMI_gm2_"+fg] = v
 	}
 	for fg, v := range fgCH4 {
 		ideal["herbs_fg_CH4_kgkm2_"+fg] = v
@@ -447,15 +473,13 @@ func recomputeHerbTotals(ideal map[string]float64, traits map[string]HerbTrait) 
 		ideal["herbs_diet_counts_"+diet] = v
 	}
 	for diet, v := range dietDMI {
-		ideal["herbs_diet_DMI_kgkm2_"+diet] = v
+		ideal["herbs_diet_DMI_gm2_"+diet] = v
 	}
 	for diet, v := range dietCH4 {
 		ideal["herbs_diet_CH4_kgkm2_"+diet] = v
 	}
 
-	if npp := ideal["NPP_gm2"]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(totGrazingDMI, npp)
-	}
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // workflow2Herbivores handles a direct edit of herbs_tot_kgkm2.
@@ -477,16 +501,12 @@ func workflow2Herbivores(ideal, oldIdeal map[string]float64, lookup *LookupData)
 	if newTotal > 0 {
 		ideal["fracGrazing"] = ideal["herbs_totGRAZING_kgkm2"] / newTotal
 	}
-	if npp := ideal["NPP_gm2"]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], npp)
-	}
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // workflow3GrassNPP handles a direct edit of NPP_gm2.
 func workflow3GrassNPP(ideal map[string]float64) {
-	if npp := ideal[colNPP]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], npp)
-	}
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // workflow2aSpeciesCounts handles §4 trigger: herbs_sp_counts_* edited.
@@ -504,7 +524,9 @@ func workflow2aSpeciesCounts(ideal map[string]float64, changedSpecies map[string
 			}
 			newCount := ideal[key]
 			ideal[colHerbsSpKgkm2Prefix+commonName] = newCount * trait.BodyMass
-			ideal["herbs_sp_DMI_kgkm2_"+commonName] = newCount * trait.DMIKgIndivYr
+			// counts (indiv/km²) × DMIKgIndivYr (kg/indiv/yr) = kg/km²/yr;
+			// ÷1000 converts to the g/m²/yr stored under colHerbsSpDMIGm2Prefix.
+			ideal[colHerbsSpDMIGm2Prefix+commonName] = newCount * trait.DMIKgIndivYr / 1000.0
 			ideal["herbs_sp_CH4_kgkm2_"+commonName] = newCount * trait.CH4KgIndivYr
 		}
 		// §4 Steps 3–5: recompute all aggregates.
@@ -520,7 +542,7 @@ func workflow2aSpeciesCounts(ideal map[string]float64, changedSpecies map[string
 		if oldCount > 0 {
 			scale := newCount / oldCount
 			scaleIdealKey(ideal, colHerbsSpKgkm2Prefix+sp, scale)
-			scaleIdealKey(ideal, "herbs_sp_DMI_kgkm2_"+sp, scale)
+			scaleIdealKey(ideal, colHerbsSpDMIGm2Prefix+sp, scale)
 			scaleIdealKey(ideal, "herbs_sp_CH4_kgkm2_"+sp, scale)
 		}
 	}
@@ -529,7 +551,7 @@ func workflow2aSpeciesCounts(ideal map[string]float64, changedSpecies map[string
 		switch {
 		case strings.HasPrefix(k, colHerbsSpKgkm2Prefix):
 			newTotKg += v
-		case strings.HasPrefix(k, "herbs_sp_DMI_kgkm2_"):
+		case strings.HasPrefix(k, colHerbsSpDMIGm2Prefix):
 			newTotDMI += v
 		case strings.HasPrefix(k, "herbs_sp_CH4_kgkm2_"):
 			newTotCH4 += v
@@ -537,7 +559,7 @@ func workflow2aSpeciesCounts(ideal map[string]float64, changedSpecies map[string
 	}
 	oldTotal := oldIdeal[colHerbsTot]
 	ideal[colHerbsTot] = newTotKg
-	ideal["herbs_tot_DMI_kgkm2"] = newTotDMI
+	ideal["herbs_tot_DMI_gm2"] = newTotDMI
 	ideal["herbs_tot_CH4_kgkm2"] = newTotCH4
 	if oldTotal > 0 {
 		scale := newTotKg / oldTotal
@@ -547,15 +569,13 @@ func workflow2aSpeciesCounts(ideal map[string]float64, changedSpecies map[string
 			}
 		}
 		scaleIdealKey(ideal, "herbs_totGRAZING_kgkm2", scale)
-		scaleIdealKey(ideal, "herbs_totGRAZING_DMI_kgkm2", scale)
+		scaleIdealKey(ideal, colHerbsTotGrazingDMI, scale)
 		scaleIdealKey(ideal, "herbs_totGRAZING_CH4_kgkm2", scale)
 	}
 	if newTotKg > 0 {
 		ideal["fracGrazing"] = ideal["herbs_totGRAZING_kgkm2"] / newTotKg
 	}
-	if npp := ideal["NPP_gm2"]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], npp)
-	}
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // workflow2bSpeciesBiomass handles §4 trigger: herbs_sp_kgkm2_* edited.
@@ -579,7 +599,9 @@ func workflow2bSpeciesBiomass(ideal map[string]float64, oldIdeal map[string]floa
 				newCount = spKg / trait.BodyMass
 			}
 			ideal[colHerbsSpCountsPrefix+commonName] = newCount
-			ideal["herbs_sp_DMI_kgkm2_"+commonName] = newCount * trait.DMIKgIndivYr
+			// counts (indiv/km²) × DMIKgIndivYr (kg/indiv/yr) = kg/km²/yr;
+			// ÷1000 converts to the g/m²/yr stored under colHerbsSpDMIGm2Prefix.
+			ideal[colHerbsSpDMIGm2Prefix+commonName] = newCount * trait.DMIKgIndivYr / 1000.0
 			ideal["herbs_sp_CH4_kgkm2_"+commonName] = newCount * trait.CH4KgIndivYr
 		}
 		recomputeHerbTotals(ideal, lookup.HerbTraits)
@@ -592,7 +614,7 @@ func workflow2bSpeciesBiomass(ideal map[string]float64, oldIdeal map[string]floa
 		switch {
 		case strings.HasPrefix(k, colHerbsSpKgkm2Prefix):
 			newTotKg += v
-		case strings.HasPrefix(k, "herbs_sp_DMI_kgkm2_"):
+		case strings.HasPrefix(k, colHerbsSpDMIGm2Prefix):
 			newTotDMI += v
 		case strings.HasPrefix(k, "herbs_sp_CH4_kgkm2_"):
 			newTotCH4 += v
@@ -600,7 +622,7 @@ func workflow2bSpeciesBiomass(ideal map[string]float64, oldIdeal map[string]floa
 	}
 	oldTotal := oldIdeal[colHerbsTot]
 	ideal[colHerbsTot] = newTotKg
-	ideal["herbs_tot_DMI_kgkm2"] = newTotDMI
+	ideal["herbs_tot_DMI_gm2"] = newTotDMI
 	ideal["herbs_tot_CH4_kgkm2"] = newTotCH4
 	if oldTotal > 0 {
 		scale := newTotKg / oldTotal
@@ -610,15 +632,13 @@ func workflow2bSpeciesBiomass(ideal map[string]float64, oldIdeal map[string]floa
 			}
 		}
 		scaleIdealKey(ideal, "herbs_totGRAZING_kgkm2", scale)
-		scaleIdealKey(ideal, "herbs_totGRAZING_DMI_kgkm2", scale)
+		scaleIdealKey(ideal, colHerbsTotGrazingDMI, scale)
 		scaleIdealKey(ideal, "herbs_totGRAZING_CH4_kgkm2", scale)
 	}
 	if newTotKg > 0 {
 		ideal["fracGrazing"] = ideal["herbs_totGRAZING_kgkm2"] / newTotKg
 	}
-	if npp := ideal["NPP_gm2"]; npp > 0 {
-		ideal["grazing_intensity"] = grazingIntensity(ideal["herbs_totGRAZING_DMI_kgkm2"], npp)
-	}
+	updateGrassBiomassAndGrazingIntensity(ideal)
 }
 
 // ── Fire workflow (§2) ────────────────────────────────────────────────────────
@@ -626,7 +646,10 @@ func workflow2bSpeciesBiomass(ideal map[string]float64, oldIdeal map[string]floa
 // workflow4FireCascade recalculates fire metrics from current NPP, litter,
 // and total grazing DMI.
 func workflow4FireCascade(ideal map[string]float64) {
-	npp := ideal["NPP_gm2"]
+	// 0_6_FireModelling.R builds fuel load from flamNPP_gm2 (flammable-zone
+	// NPP, low-TC classes only), not total NPP_gm2 — fire only carries
+	// through the open, flammable part of the landscape.
+	flamNPP := ideal["flamNPP_gm2"]
 	litter := ideal["LitterBiomass_gm2"]
 	lowTCProp := ideal[colLowTCProp]
 
@@ -635,10 +658,10 @@ func workflow4FireCascade(ideal map[string]float64) {
 		propEarly = 0.45
 	}
 
-	grazingDMI := ideal["herbs_totGRAZING_DMI_kgkm2"] / 1000.0
+	grazingDMI := ideal[colHerbsTotGrazingDMI]
 
 	// Step 1 — Fuel load (g/m²).
-	fuelload := math.Max(0, npp+litter-grazingDMI)
+	fuelload := math.Max(0, flamNPP+litter-grazingDMI)
 	ideal["fuelload_gm2"] = fuelload
 
 	// Step 2 — Fireline intensity.

--- a/internal/api/recalculate_r_validation_test.go
+++ b/internal/api/recalculate_r_validation_test.go
@@ -191,14 +191,14 @@ func baseCascadeIdeal() map[string]float64 {
 		"NPP_gm2": 300, "flamNPP_gm2": 200,
 		"deltaSOC_Mgha_trees": 1, "deltaSOC_Mgha_grazers": 0.5, "deltaSOC_Mgha": 1.5,
 		"SOC_Mgha_0_30":   50,
-		"herbs_tot_kgkm2": 1000, "herbs_tot_DMI_kgkm2": 500, "herbs_tot_CH4_kgkm2": 5,
-		"herbs_totGRAZING_kgkm2": 700, "herbs_totGRAZING_DMI_kgkm2": 350, "herbs_totGRAZING_CH4_kgkm2": 3,
-		"fracGrazing": 0.7, "grazing_intensity": 0.1,
+		"herbs_tot_kgkm2": 1000, "herbs_tot_DMI_gm2": 500, "herbs_tot_CH4_kgkm2": 5,
+		"herbs_totGRAZING_kgkm2": 700, "herbs_totGRAZING_DMI_gm2": 350, "herbs_totGRAZING_CH4_kgkm2": 3,
+		"fracGrazing": 0.7, "grazing_intensity": 0.1, "NPP_gm2.1": -50,
 		"propEarly": 0.45, "MAR": 800,
 		"herbs_sp_counts_Impala": 100, "herbs_sp_kgkm2_Impala": 4000,
-		"herbs_sp_DMI_kgkm2_Impala": 200, "herbs_sp_CH4_kgkm2_Impala": 2,
+		"herbs_sp_DMI_gm2_Impala": 200, "herbs_sp_CH4_kgkm2_Impala": 2,
 		"herbs_sp_counts_Zebra": 20, "herbs_sp_kgkm2_Zebra": 5000,
-		"herbs_sp_DMI_kgkm2_Zebra": 150, "herbs_sp_CH4_kgkm2_Zebra": 1,
+		"herbs_sp_DMI_gm2_Zebra": 150, "herbs_sp_CH4_kgkm2_Zebra": 1,
 	}
 }
 

--- a/internal/api/warnings.go
+++ b/internal/api/warnings.go
@@ -16,14 +16,15 @@ type targetStateWarningRule struct {
 var targetStateWarningRules = []targetStateWarningRule{
 	{
 		message: warningNPPGM2,
-		// Fires when target grazing DMI (kg/km²) exceeds the current NPP
-		// capacity. NPP_gm2 (g/m²) × 1000 converts to kg/km² for comparison.
+		// Fires when target grazing DMI (g/m²) exceeds the current NPP
+		// capacity (g/m²) — both are in the same units, so no conversion
+		// is needed.
 		check: func(ideal, reference, current map[string]float64) bool {
 			if ideal == nil || current == nil {
 				return false
 			}
-			herbs, hasHerbs := ideal["herbs_totGRAZING_DMI_kgkm2"]
-			herbsCurrent, hasHerbsCurrent := current["herbs_totGRAZING_DMI_kgkm2"]
+			herbs, hasHerbs := ideal[colHerbsTotGrazingDMI]
+			herbsCurrent, hasHerbsCurrent := current[colHerbsTotGrazingDMI]
 			if !hasHerbs || !hasHerbsCurrent {
 				return false
 			}
@@ -35,7 +36,7 @@ var targetStateWarningRules = []targetStateWarningRule{
 			}
 
 			if herbsCurrent != herbs {
-				return herbs > npp*1000
+				return herbs > npp
 			}
 			return false
 		},


### PR DESCRIPTION
- Rename herbivore DMI columns from kgkm2 to gm2 (herbs_tot_DMI, herbs_totGRAZING_DMI, herbs_sp_DMI_*, herbs_fg_DMI_*, herbs_diet_DMI_*) and store them in g/m² so they compare directly against NPP_gm2 without the ×1000/÷1000 conversions that were previously needed at each point of use (grazing intensity, fuel load, target-state warnings).
- Add NPP_gm2.1 (grass standing biomass) = max(0, NPP_gm2 − herbs_totGRAZING_DMI_gm2), recomputed alongside grazing_intensity any time NPP or grazing DMI changes (new updateGrassBiomassAndGrazingIntensity helper consolidates the five call sites that used to duplicate this logic).
- Fix the fire cascade's fuel load to use flamNPP_gm2 (flammable low-tree-cover NPP) instead of total NPP_gm2 — fire only carries through the open part of the landscape.
- Fix the litter biomass formula's documented midpoints (were off by 100×, Mg/ha vs g/m²).
- Fix the mean-tree-cover-edit workflow to solve for shift from the actual weighted class proportions instead of assuming they already sum to the stored meanTC, so a direct edit lands on the target exactly.
- Update calculationFormulas.ts explanations/formulas and workflow step traces to match, and update Go/R validation test fixtures to the renamed columns.
