### PR TITLE
fix(ci): unbreak the release workflow and disable macOS for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,17 @@ jobs:
             goos: linux
             goarch: arm64
             suffix: linux-arm64
-          - os: macos-13
+          # macos-13 was withdrawn, not merely deprecated: the label no longer
+          # matches any runner, so a job requesting it is never scheduled. It
+          # sits queued until GitHub cancels it at the 24-hour limit, which is
+          # why a release appeared to "fail the next day". macos-14 is
+          # deprecated and heading the same way, so both move to the current
+          # GA pair — macos-15-intel for x86_64, macos-15 for Apple Silicon.
+          - os: macos-15-intel
             goos: darwin
             goarch: amd64
             suffix: darwin-amd64
-          - os: macos-14
+          - os: macos-15
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
@@ -179,7 +185,16 @@ jobs:
         run: |
           cd dist
           tar -czf decision-theatre-${{ matrix.suffix }}.tar.gz decision-theatre
-          sha256sum *.tar.gz > checksums-${{ matrix.suffix }}.txt
+          # sha256sum is GNU coreutils. macOS does not ship it — it ships
+          # shasum — so this step failed on both Darwin legs of the matrix
+          # while passing on Linux, and took every downstream job with it.
+          # The two print the same "<hash>  <file>" format, so the checksum
+          # file is identical either way.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum *.tar.gz > checksums-${{ matrix.suffix }}.txt
+          else
+            shasum -a 256 *.tar.gz > checksums-${{ matrix.suffix }}.txt
+          fi
 
       - name: Package (windows)
         if: runner.os == 'Windows'
@@ -409,12 +424,13 @@ jobs:
     strategy:
       matrix:
         include:
+          # Same runner labels as the build matrix above, for the same reason.
           - suffix: darwin-amd64
             arch: amd64
-            os: macos-13
+            os: macos-15-intel
           - suffix: darwin-arm64
             arch: arm64
-            os: macos-14
+            os: macos-15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -635,6 +651,15 @@ jobs:
     # Run concurrently, whichever finishes last wins, and roughly half the time
     # the container notes are silently overwritten.
     needs: release
+    # Ordering, not a gate. `needs` alone also means "only if that job
+    # succeeded", which put the container image behind every platform package:
+    # v2.4.0, v2.5.0 and v2.5.1 each published no image because a macOS leg
+    # failed, leaving ghcr.io/kartoza/decisiontheatre:latest pointing at the
+    # v2.3.0 build and looking to anyone pulling it like a reverted release.
+    # The server image does not depend on a .dmg or an .msi existing, so this
+    # keeps the sequencing and drops the gate. `append_body` means it composes
+    # with the release body whether or not the release job wrote one.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,20 +80,29 @@ jobs:
             goos: linux
             goarch: arm64
             suffix: linux-arm64
-          # macos-13 was withdrawn, not merely deprecated: the label no longer
-          # matches any runner, so a job requesting it is never scheduled. It
-          # sits queued until GitHub cancels it at the 24-hour limit, which is
-          # why a release appeared to "fail the next day". macos-14 is
-          # deprecated and heading the same way, so both move to the current
-          # GA pair — macos-15-intel for x86_64, macos-15 for Apple Silicon.
-          - os: macos-15-intel
-            goos: darwin
-            goarch: amd64
-            suffix: darwin-amd64
-          - os: macos-15
-            goos: darwin
-            goarch: arm64
-            suffix: darwin-arm64
+          # --- macOS: DISABLED. Re-enable by uncommenting all six blocks ---
+          #
+          # Every macOS block in this file is commented out rather than
+          # deleted, and each carries the "--- macOS: DISABLED ---" marker.
+          # The six are: this matrix entry, the package-macos job, the
+          # release job's needs, the four macOS rows in the completeness
+          # check, the *.dmg in "Merge checksums", and the macOS rows in the
+          # release body. Grep the marker to find them all.
+          #
+          # The labels below are already corrected and can be uncommented as
+          # they stand: macos-13 was withdrawn rather than deprecated, so
+          # nothing ever matched it and the job sat queued until GitHub
+          # cancelled it at the 24-hour limit; macos-14 is deprecated and was
+          # heading the same way. macos-15-intel and macos-15 are the current
+          # GA pair.
+          # - os: macos-15-intel
+          #   goos: darwin
+          #   goarch: amd64
+          #   suffix: darwin-amd64
+          # - os: macos-15
+          #   goos: darwin
+          #   goarch: arm64
+          #   suffix: darwin-arm64
           - os: windows-latest
             goos: windows
             goarch: amd64
@@ -415,50 +424,55 @@ jobs:
         with:
           name: packages-snap
           path: ${{ steps.snapcraft.outputs.snap }}
+  # --- macOS: DISABLED. See the build matrix for how to re-enable. ---
+  # The whole job is commented out: with no darwin binary uploaded,
+  # download-artifact fails and the run goes red even though the release
+  # job no longer needs it.
+  #
+  # # ==========================================
+  # # macOS: .dmg Application Bundle
+  # # ==========================================
+  # package-macos:
+  # needs: build
+  # strategy:
+  # matrix:
+  # include:
+  # # Same runner labels as the build matrix above, for the same reason.
+  # - suffix: darwin-amd64
+  # arch: amd64
+  # os: macos-15-intel
+  # - suffix: darwin-arm64
+  # arch: arm64
+  # os: macos-15
+  # runs-on: ${{ matrix.os }}
+  # steps:
+  # - uses: actions/checkout@v4
+  #
+  # - uses: actions/download-artifact@v4
+  # with:
+  # name: binary-${{ matrix.suffix }}
+  # path: dist
+  #
+  # - name: Make binary executable
+  # run: chmod +x dist/decision-theatre
+  #
+  # - name: Create DMG
+  # run: |
+  # cd dist
+  # bash ../packaging/macos/create-dmg.sh \
+  # decision-theatre \
+  # "${{ github.ref_name }}" \
+  # "${{ matrix.arch }}"
+  #
+  # - uses: actions/upload-artifact@v4
+  # with:
+  # name: packages-macos-${{ matrix.suffix }}
+  # path: dist/*.dmg
+  #
+  # # ==========================================
+  # # Windows: MSI installer
+  # # ==========================================
 
-  # ==========================================
-  # macOS: .dmg Application Bundle
-  # ==========================================
-  package-macos:
-    needs: build
-    strategy:
-      matrix:
-        include:
-          # Same runner labels as the build matrix above, for the same reason.
-          - suffix: darwin-amd64
-            arch: amd64
-            os: macos-15-intel
-          - suffix: darwin-arm64
-            arch: arm64
-            os: macos-15
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: binary-${{ matrix.suffix }}
-          path: dist
-
-      - name: Make binary executable
-        run: chmod +x dist/decision-theatre
-
-      - name: Create DMG
-        run: |
-          cd dist
-          bash ../packaging/macos/create-dmg.sh \
-            decision-theatre \
-            "${{ github.ref_name }}" \
-            "${{ matrix.arch }}"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: packages-macos-${{ matrix.suffix }}
-          path: dist/*.dmg
-
-  # ==========================================
-  # Windows: MSI installer
-  # ==========================================
   package-windows:
     needs: build
     runs-on: windows-latest
@@ -501,7 +515,8 @@ jobs:
       - package-appimage
       - package-flatpak
       - package-snap
-      - package-macos
+      # --- macOS: DISABLED ---
+      # - package-macos
       - package-windows
     runs-on: ubuntu-latest
     steps:
@@ -540,8 +555,9 @@ jobs:
           expected=(
             "1|decision-theatre-linux-amd64.tar.gz|Linux amd64 archive"
             "1|decision-theatre-linux-arm64.tar.gz|Linux arm64 archive"
-            "1|decision-theatre-darwin-amd64.tar.gz|macOS amd64 archive"
-            "1|decision-theatre-darwin-arm64.tar.gz|macOS arm64 archive"
+            # --- macOS: DISABLED ---
+            # "1|decision-theatre-darwin-amd64.tar.gz|macOS amd64 archive"
+            # "1|decision-theatre-darwin-arm64.tar.gz|macOS arm64 archive"
             "1|decision-theatre-windows-amd64.zip|Windows amd64 archive"
             "2|*.deb|Debian packages (amd64 and arm64)"
             "2|*.rpm|RPM packages (amd64 and arm64)"
@@ -549,8 +565,9 @@ jobs:
             "1|Decision_Theatre-aarch64.AppImage|AppImage, arm64"
             "1|*.flatpak|Flatpak bundle"
             "1|*.snap|Snap package"
-            "1|decision-theatre-darwin-amd64.dmg|macOS amd64 disk image"
-            "1|decision-theatre-darwin-arm64.dmg|macOS arm64 disk image"
+            # --- macOS: DISABLED ---
+            # "1|decision-theatre-darwin-amd64.dmg|macOS amd64 disk image"
+            # "1|decision-theatre-darwin-arm64.dmg|macOS arm64 disk image"
             "1|*.msi|Windows installer"
           )
           incomplete=0
@@ -580,7 +597,10 @@ jobs:
           # No `|| true` here: the step above has already established that every
           # one of these exists, so a failure now is a real failure.
           cd release
-          sha256sum *.deb *.rpm *.AppImage *.flatpak *.snap *.dmg *.msi >> checksums.txt
+          # --- macOS: DISABLED — *.dmg removed. An unmatched glob is passed
+          # through literally and sha256sum exits non-zero on it, which would
+          # fail this job. Restore *.dmg when macOS comes back.
+          sha256sum *.deb *.rpm *.AppImage *.flatpak *.snap *.msi >> checksums.txt
 
       - uses: softprops/action-gh-release@v2
         with:
@@ -602,13 +622,12 @@ jobs:
             | **Flatpak** | `.flatpak` | `flatpak install decision-theatre.flatpak` |
             | **Snap** | `.snap` | `sudo snap install --dangerous *.snap` |
             | **NixOS** | Flake | `nix profile install github:kartoza/DecisionTheatre` |
-            | **macOS** | `.dmg` | Open and drag to Applications |
             | **Windows** | `.msi` | Run the installer |
             | **Server (Docker)** | GHCR image | `ghcr.io/kartoza/decisiontheatre` — see **Container image** below |
 
             ### Portable binaries (no installer)
 
-            **Linux/macOS:**
+            **Linux:**
             ```bash
             tar xzf decision-theatre-*.tar.gz
             ./decision-theatre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the documentation failure cancelled the macOS legs within two minutes, so the
   packaging failure underneath it never had the chance to report.
 
+  macOS is disabled for now rather than fixed and left to prove itself on a real
+  tag: the Linux packages, the Windows installer and the container image have
+  been unshippable for four releases, and they should not wait on it. Every
+  macOS block is commented out behind a `--- macOS: DISABLED ---` marker, with
+  the corrected runner labels preserved, so restoring it is uncommenting rather
+  than re-diagnosing.
+
 - **`ghcr.io/kartoza/decisiontheatre:latest` stopped moving after v2.3.0.** The
   container job was sequenced after `release` so their release-body writes could
   not race, but `needs` also means "only if that job succeeded", which put the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The release workflow shipped no platform artefacts and no container image,
+  for every release.** Seven release runs, none of them green. Two faults in the
+  macOS legs of the build matrix, each enough on its own to stop everything
+  downstream, because `release` needs all six packaging jobs and `container`
+  needed `release`.
+
+  The first: `Package (unix)` checksums its tarball with `sha256sum`, which is
+  GNU coreutils and is not on a macOS runner — macOS ships `shasum`. The step
+  passed on Linux and failed on both Darwin legs. It now uses whichever of the
+  two is present; they print the same format, so the checksum file is
+  unchanged.
+
+  The second: `macos-13` has been withdrawn, so no runner ever matches the
+  label. The job was never scheduled, sat queued, and was cancelled at
+  GitHub's 24-hour limit — which is why a release looked like it failed the
+  following day. `macos-14` is deprecated and was heading the same way, so both
+  Darwin legs move to the current GA pair, `macos-15-intel` and `macos-15`.
+
+  Neither fault was visible until recently: before `fail-fast: false` was set,
+  the documentation failure cancelled the macOS legs within two minutes, so the
+  packaging failure underneath it never had the chance to report.
+
+- **`ghcr.io/kartoza/decisiontheatre:latest` stopped moving after v2.3.0.** The
+  container job was sequenced after `release` so their release-body writes could
+  not race, but `needs` also means "only if that job succeeded", which put the
+  image behind every platform package. v2.4.0, v2.5.0 and v2.5.1 published no
+  image at all, leaving `:latest` on the v2.3.0 build — indistinguishable, to
+  anyone pulling it, from a release that had been reverted. The server image
+  does not depend on a `.dmg` or an `.msi` existing, so the ordering stays and
+  the gate goes.
+
+
 - **Blank map panes, and fifteen seconds of spinner, on a server with no imagery
   provider.** Maps were constructed against `/api/satellite-style.json` whenever
   the runtime was a browser, without waiting to learn whether satellite was


### PR DESCRIPTION
Fixes kartoza/UOW_DTT#181.

## The problem

The release workflow has never succeeded. Seven tags, seven failed runs. The last four releases shipped **zero** assets, and `ghcr.io/kartoza/decisiontheatre:latest` has not moved since v2.3.0 — which looks like a reverted image but is just one that was never published.

Two macOS faults, either one enough to skip everything downstream:

1. **`sha256sum` is not on macOS.** `Package (unix)` uses it; macOS ships `shasum`. Passed on Linux, failed on both Darwin legs.
2. **`macos-13` was withdrawn.** No runner matches the label, so the job was never scheduled — `runner_name: ""`, no steps, cancelled at GitHub's 24-hour queue limit. That delay is why a release seemed to fail the following day.

Then `release` needs all six package jobs, and `container` needed `release`, so one dead leg skipped the lot.

## What this does

**Round 1 — ship Linux, Windows and the container image now.**

| Change | Why |
|---|---|
| `sha256sum` → `shasum -a 256` fallback | Same `<hash>  <file>` output, so checksums are unchanged |
| macOS commented out in 6 places | Tagged `--- macOS: DISABLED ---`; grep finds them all |
| `container`: `needs: release` + `if: ${{ !cancelled() }}` | Keeps the ordering, drops the gate — a server image does not depend on a `.dmg` |

The disabled blocks keep the **corrected** `macos-15-intel` / `macos-15` labels, so re-enabling is uncommenting, not re-diagnosing.

Also removed `*.dmg` from Merge checksums: an unmatched glob is passed through literally and `sha256sum` exits non-zero on it, which would have failed the release job.

## Note

`fail-fast: false` from #165 did not cause this — it *revealed* it. Before, the docs failure cancelled the macOS legs in two minutes, so the packaging failure underneath never reported.

## Verification

YAML parses; job graph is `docs → build → 5 package jobs → release → container`; no active macOS references. Beyond that this can only be proven by a tag — **use a throwaway pre-release**, not a version anyone is waiting on.

## Follow-ups

- macOS re-enable (round 2).
- Drop `gh release create` from the release procedure — `git push origin vX.Y.Z` already triggers the workflow, which creates the release itself. Doing it by hand produces a release page that looks finished and is empty, which is why this ran unnoticed for four releases.
- Nothing fails loudly when a release ships zero assets.
