### PR TITLE
fix(ci): pin WiX, which started charging for itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,7 +489,20 @@ jobs:
           Expand-Archive -Path dist\decision-theatre-windows-amd64.zip -DestinationPath dist\
 
       - name: Install WiX
-        run: dotnet tool install --global wix
+        # Pinned, and it has to stay pinned. WiX v6 introduced the Open Source
+        # Maintenance Fee and v7 enforces it by refusing every command until
+        # the EULA is accepted — so an unpinned `dotnet tool install` rolled
+        # onto v7 on its own and every MSI build since has died with
+        #   error WIX7015: You must accept the Open Source Maintenance Fee
+        #   (OSMF) EULA to use WiX Toolset v7
+        # No commit caused that and none could have prevented it. 5.0.2 is the
+        # last release before the fee; it reads the v4 schema that
+        # packaging/windows/product.wxs is written against.
+        #
+        # Moving to v6 or v7 is a licensing decision, not a version bump:
+        # organisations over $10,000 annual revenue must sponsor the wixtoolset
+        # GitHub organisation to satisfy the fee. See docs.firegiant.com/wix/osmf/.
+        run: dotnet tool install --global wix --version 5.0.2
 
       - name: Build MSI
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inheriting rather than by remembering.
 
 ### Fixed
+- **The Windows installer, for the first time.** No release has ever carried an
+  `.msi` — not since v0.2.0 — and until now the failure was invisible, hidden
+  behind the macOS and documentation faults that stopped the run earlier. With
+  those gone it became the only thing standing between a tagged release and its
+  artefacts, and the cause turned out not to be the packaging at all:
+
+      error WIX7015: You must accept the Open Source Maintenance Fee (OSMF)
+      EULA to use WiX Toolset v7
+
+  `dotnet tool install --global wix` names no version, so the job installed
+  whatever was newest on the day it ran. WiX v6 introduced the maintenance fee
+  and v7 enforces it by refusing every command until the EULA is accepted, so
+  the build broke without a commit — and no commit could have prevented it.
+  WiX is now pinned to 5.0.2, the last release before the fee, which reads the
+  v4 schema `packaging/windows/product.wxs` is already written against.
+
+  Adopting v6 or v7 later is a licensing decision rather than a version bump:
+  organisations over $10,000 in annual revenue must sponsor the wixtoolset
+  GitHub organisation to satisfy the fee.
+
 
 - **The table view no longer offers a screen it cannot fill.** Table view is a
   per-site breakdown, so with no site selected it renders "No catchment data


### PR DESCRIPTION
## What happened

v2.6.0 published its container image but shipped **no platform packages**.
`package-windows` failed, and `release` needs it:

```
error WIX7015: You must accept the Open Source Maintenance Fee (OSMF)
EULA to use WiX Toolset v7
```

Nothing in this repository changed. The job runs:

```yaml
run: dotnet tool install --global wix    # no version
```

WiX **v6 introduced** the Open Source Maintenance Fee and **v7 enforces** it by
refusing every command until the EULA is accepted. The unpinned install rolled
onto v7 on its own. The build broke on someone else's release schedule, and no
commit here could have prevented it.

## The fix

```diff
- run: dotnet tool install --global wix
+ run: dotnet tool install --global wix --version 5.0.2
```

5.0.2 is the last release before the fee. It reads the v4 schema that
`packaging/windows/product.wxs` is already written against, so the packaging is
untouched.

## This is deferred, not settled

| Option | Cost |
|---|---|
| **5.0.2 (this PR)** | Free, MIT. No further fixes to that line. |
| v6 / v7 | Organisations over **$10,000 annual revenue must sponsor the `wixtoolset` GitHub org**. |
| Drop the MSI | Free. Windows users get the portable `.zip`, which already builds. |

Worth a decision on its own timeline — see [docs.firegiant.com/wix/osmf](https://docs.firegiant.com/wix/osmf/).

## Not a regression

**No release has ever shipped an `.msi`**, going back to v0.2.0. It was hidden
behind the macOS and docs failures that stopped the run earlier; clearing those
left it as the only thing between a tag and its artefacts.

## Verification

YAML parses. Beyond that this can only be proven by a tag — `package-windows`
runs on `windows-latest` and cannot be exercised locally. The next release is
the test.
