### PR TITLE
chore: declare 2.6.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        version = "2.6.0";
+        version = "2.6.1";
 
         # MkDocs environment for requirements documentation
         mkdocsEnv = pkgs.python3.withPackages (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decision-theatre-frontend",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Pre-flight for the v2.6.1 release, which tests the WiX pin from #176.

## Why

The container reads its version from `flake.nix`, not from the git ref. Main
declares `2.6.0`; the next tag is `v2.6.1`. Tag without this and the image
misreports itself — exactly what #175 fixed for 2.6.0.

```diff
- flake.nix:19            version = "2.6.0";
+ flake.nix:19            version = "2.6.1";
- frontend/package.json   "version": "2.6.0",
+ frontend/package.json   "version": "2.6.1",
```

## What is deliberately not here

`frontend/package-lock.json`. Its root version is stale and nothing reads it;
editing it changes the manifest digest recorded in `nix/manifest-lock.json` and
fails the flake lock-step check for no gain. That cost #175 a round trip — see
`46a8ce0`.

## Checks

`sync-flake.sh --check` ✓ both hashes, 240 frontend tests, every Go package.

## The recurring cost

This is the second one-line version PR in two releases, and there will be one
before every future release. `.github/workflows/release.yml` already stamps the
platform binaries with `-X main.version=${{ github.ref_name }}`; only the
container takes its version from the declaration. Worth closing that gap
properly once the release pipeline is proven green — there is a
`fix/version-single-source` branch that went the other way, making the
declaration authoritative, which does not remove this step.
