### PR TITLE
feat: dock the target editor and recalculate as you drag

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -54,3 +54,15 @@ d7cd03dc8354e299cb946fd63ae85b3686cc2080:internal/config/config.go:generic-api-k
 # A long opaque string in a React component that the generic-api-key heuristic
 # matched on shape alone. The line no longer exists in the current tree.
 4ce85609a94ff8b123eb6956d34d6c6d4b2a8fdf:frontend/src/components/IndicatorEditorPage.tsx:generic-api-key:1061
+
+# A test constant holding an indicator column name from metadata.csv — one of
+# the prop_X..Mgha columns — not a credential. Same heuristic as above: an
+# identifier named KEY sitting next to an opaque-looking string was enough on
+# shape alone. It has since been renamed to COLUMN, which is both the better
+# name and outside the rule, so the pattern is gone from the current tree. This
+# entry covers only the commit that introduced it, which was already pushed by
+# the time CI reported it.
+#
+# Deliberately does not quote the offending line: writing it out here reproduced
+# the pattern, and the ignore file failed its own scan.
+68221ce5e52cfda081f351ddc3fad0bb32661343:frontend/src/test/targetPanel.test.tsx:generic-api-key:32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live update in the target editor, and an end to the redraw after every
+  change.** Moving a slider used to disable every other slider, drop a spinner
+  over the whole form, and re-enable them a moment later. Focus moved, the
+  scroll position went with it, and the user had to find their place again
+  after each edit. Sliders now stay live throughout and progress is a small
+  indicator in the panel header.
+
+  A new **Live update** checkbox decides *when* the recalculation runs. Ticked,
+  the sliders and the charts behind them recalculate continuously as you drag;
+  cleared, they wait for the drag to end. Because a recalculation rescores every
+  catchment in the site, the default follows the site's size — on at or below 20
+  catchments, off above it. An explicit tick or untick is remembered across
+  sites and sessions and overrules the count from then on, so a large site can
+  be dragged live on a machine that keeps up and a small one need not be.
+
+  Live dragging never queues a backlog: at most one recalculation is in flight,
+  and movement made while it runs collapses into a single follow-up, so the
+  result converges on the value the pointer was released at rather than
+  replaying every intermediate one.
+
+- **The target editor is a docked side panel rather than a modal overlay.** It
+  takes the same right-hand slot as the single-factor controls — opening either
+  dismisses the other — and the views shrink to make room instead of being
+  covered. The editor exists to show the dials answering a slider, and an
+  overlay hid exactly what it was meant to show.
+
+### Fixed
+
+- **The dials no longer flicker while a target slider moves.** Every value
+  change replayed the dial's *entry* animation, and the two progress values
+  that animation drives are wired to `opacity` throughout the widget — so each
+  change faded the whole dial out and back in. Under live editing that is
+  several strobes a second. The reveal now runs only when a dial appears; a
+  value change eases the needle to its new angle instead, and a rescale simply
+  redraws at the new scale. Neither makes the dial disappear first.
+
+  The needle's easing deliberately overshoots so it springs onto its mark, which
+  meant the reveal briefly asked for a *negative* opacity. The overshoot now
+  applies to the angle only.
+
+- **A dial whose own values did not change is no longer redrawn.** Editing a
+  target replaces the whole indicators object, so all six dials re-rendered on
+  every recalculation even though at most one of them had changed. `DialChart`
+  is memoised on its props, which are all primitives or stable callbacks.
+  Measured on a live drag: one dial of the sixty SVGs on screen redrew, where
+  previously the count of mutated attributes ran into the thousands.
+
+- **Releasing a drag no longer throws focus onto another slider and scrolls the
+  panel to it.** Chakra focuses a slider's thumb whenever its *value* changes,
+  using a bare `.focus()` that scrolls the element into view. A recalculation
+  cascades into the other sliders' values, so letting go of one slider sent the
+  panel off to an unrelated one. Focus is now moved deliberately, on pointer
+  down, to the slider actually being used, and without scrolling.
+
+- **The target panel's heading no longer sits under the top bar.** The panel
+  offset itself by a hard-coded 70px; the header is content-sized and is
+  actually taller than that. It is now measured.
+
+- **Dragging a target back to where it started now clears it.** The editor
+  diffed against the values it opened with and skipped anything that matched, so
+  a slider returned to its opening position submitted nothing and the target set
+  a moment earlier stayed in place with no way to undo it. It now tracks which
+  sliders were actually touched, and sends a touched slider's value whether or
+  not it happens to equal the one it started at.
+
 - **Deployment documentation for the published container image** — how to pull it
   from GHCR, how to run it with the data and resources directories mounted, and
   what to do about permissions. Covers the two failures that produce a confusing

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -235,6 +235,44 @@ Each pane supports three visualization modes, cycled via toolbar button:
 - Range mode toggle positioned in top-right of chart
 - Re-animates when range, factor, or scenario changes
 
+### Target Editor (Slide-out)
+
+Opened from the **Targets** button in the header, once the open site has indicators.
+
+- Docked into the right-hand slide-out slot, not a modal overlay: the editor's purpose
+  is watching the dials, charts and maps respond to a slider, so it must not cover them.
+  The content area shrinks to make room.
+- Shares that slot with the Control Panel below — opening either dismisses the other.
+- Indicators grouped by variable type in a collapsible accordion, one slider per
+  indicator, labelled with its value, unit and allowed range.
+- Only sliders the user has actually moved are submitted. Returning a slider to its
+  opening value clears the target previously set for it.
+- **Live update** checkbox:
+  - On: targets recalculate continuously during a drag.
+  - Off: they recalculate once the drag ends.
+  - Defaults to on at or below 20 catchments and off above it, since a recalculation
+    rescores every catchment in the site.
+  - An explicit tick or untick is persisted (`dt.targets.liveUpdate` in local storage)
+    and thereafter overrides the catchment-count default for every site.
+- Recalculations are coalesced: at most one request is in flight, and edits made while
+  it runs collapse into a single follow-up, so the sequence converges on the released
+  value without queueing one request per pointer move.
+- Sliders are never disabled mid-recalculation. Progress is a small inline indicator in
+  the panel header rather than an overlay. Automatic focus-on-value-change is off, so a
+  cascade cannot pull focus onto an unrelated slider and scroll the panel to it; focus
+  moves only to the slider the pointer lands on, without scrolling.
+- The panel offsets itself by the measured header height, not a fixed value — the header
+  is content-sized.
+
+### Dial redraw behaviour
+
+`DialChart` is memoised, so a dial whose values did not change is not re-rendered when a
+target edit replaces the indicators object. Within a dial, the reveal animation (which
+drives opacity across the whole widget) runs only when the dial becomes visible; a value
+change eases the needle to its new angle and a rescale redraws at the new scale, neither
+of which fades the dial out. This is what makes live target editing legible rather than
+a strobe.
+
 ### Control Panel (Slide-out)
 - Scenario 1 selector (left map)
 - Scenario 2 selector (right map)

--- a/docs/guide/set-target-values.md
+++ b/docs/guide/set-target-values.md
@@ -27,9 +27,11 @@ Target State starts equal to Current State. It only diverges where you make it.
 
 ## Steps
 
-### Quick edit — the Targets modal
+### Quick edit — the Targets panel
 
-1. In grid view, once the site has indicators, click **Targets** in the top toolbar.
+1. In grid view, once the site has indicators, click **Targets** in the top toolbar. The
+   editor docks into the right-hand side panel and the views shrink to make room, so the
+   dials, charts and maps stay visible while you work.
 
 ![Editing target values by category](../assets/images/screenshots/targets-modal.jpg)
 
@@ -37,7 +39,20 @@ Target State starts equal to Current State. It only diverges where you make it.
    a collapsible accordion.
 3. Expand a group to reveal a labelled slider per indicator, showing its current value,
    unit and allowed range.
-4. Click **Save**. Only the sliders you actually moved are applied.
+4. Drag a slider. Only the ones you actually move are applied, and there is nothing to
+   save — the recalculation happens as you go. Dragging a slider back to where it started
+   clears the target you set for it.
+
+!!! tip "Live update"
+    A recalculation rescores every catchment in the site, so what it costs depends on how
+    big the site is. The **Live update** box at the top of the panel decides when it runs:
+    ticked, the sliders and the charts behind them recalculate continuously as you drag;
+    cleared, they wait until you let go.
+
+    It starts ticked on sites of 20 catchments or fewer and cleared on larger ones. Tick
+    or clear it yourself and that choice sticks — across sites and across sessions — so a
+    large site can be dragged live if your machine keeps up, and a small one need not
+    be.
 
 ### Full editor — the Indicators page
 
@@ -57,6 +72,7 @@ redraw against your target rather than current conditions.
 
 !!! success "What you achieved"
     - You can set target values for any indicator
+    - You can choose whether the landscape recalculates as you drag or after
     - You have seen dependent factors recalculate
     - You can compare Target State against Current on any view
 

--- a/docs/user-guide/reference.md
+++ b/docs/user-guide/reference.md
@@ -175,17 +175,47 @@ Switch a pane's view mode from its per-pane toolbar. See [Scenario Comparison](.
 | **Dial** | ![Dial view](../assets/images/screenshots/view-dial.png) Gauge showing Current and Target relative to the Ecological Reference band |
 | **Table** | ![Table view](../assets/images/screenshots/view-table.png) Site Aggregate Calculation -- area-weighted average, with an optional per-catchment breakdown |
 
-## Targets Modal
+## Targets Panel
 
 Opened via the **Targets** button in the grid-view toolbar, once a site has indicators.
+It docks into the right-hand side panel -- the same slot the single-factor
+controls use, so only one of the two is open at a time -- and the views shrink to
+make room rather than being covered. The dials, charts and maps stay visible
+while you drag, which is the point: you are watching them answer the slider.
 
-![Edit Target Values modal](../assets/images/screenshots/targets-modal.jpg)
+![Edit Target Values panel](../assets/images/screenshots/targets-modal.jpg)
 
 | Component | Description |
 |-----------|-------------|
+| **Live update** | Whether targets recalculate continuously while you drag, or once you let go. See below |
 | **Category accordion** | Collapsible groups (e.g. Fire, Herbivores, Vegetation Structure) with an indicator count |
 | **Slider rows** | One per indicator, showing current value, unit, and min/max range |
-| **Cancel / Save** | Save applies only the sliders actually moved |
+| **Close** | Dismisses the panel. Edits apply as you make them -- there is nothing to save |
+
+Only the sliders you actually move are submitted. Dragging one back to where it
+started clears the target you set for it.
+
+### Live update
+
+Every target edit costs a recalculation that rescores each catchment in the
+site, so its cost grows with how many catchments the site has.
+
+| Setting | Behaviour |
+|---------|-----------|
+| **On** | Sliders, dials and charts recalculate continuously as you drag |
+| **Off** | Everything recalculates once you release a slider |
+
+The box is ticked by default on sites of **20 catchments or fewer**, and cleared
+by default on larger ones. Ticking or clearing it yourself replaces that
+judgement permanently: your choice is remembered across sites and sessions, and
+the catchment count stops being consulted. Turn it on for a large site if your
+machine and connection can keep up; turn it off for a small one if you would
+rather not recalculate mid-drag.
+
+With live update on, a drag never queues up a backlog of requests. At most one
+recalculation is in flight at a time, and movement made while it runs collapses
+into a single follow-up, so the result always converges on the value you
+actually let go at.
 
 ## Indicators Page
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        version = "2.6.1";
+        version = "2.7.0";
 
         # MkDocs environment for requirements documentation
         mkdocsEnv = pkgs.python3.withPackages (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decision-theatre-frontend",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -385,15 +385,28 @@ function App() {
   const isLoadingSiteRef = useRef(false); // Prevent saving while loading
   const boundaryUpdateRequestSeqRef = useRef(0);
 
-    // Target values popup state (lifted from ContentArea)
+    // Target values panel state (lifted from ContentArea)
   const { isOpen: isTargetModalOpen, onOpen: onOpenTargetModal, onClose: onCloseTargetModal } = useDisclosure();
   const handleToggleTargetModal = () => {
     if (isTargetModalOpen) {
       onCloseTargetModal();
     } else {
+      // The target editor and the single-factor control panel dock into the
+      // same slot on the right, so opening one dismisses the other rather
+      // than stacking two panels on the same pixels.
+      setIndicatorPaneIndex(null);
+      setIsGridControlModal(false);
       onOpenTargetModal();
     }
   };
+
+  // The other direction of the same rule. The control panel is opened from a
+  // dozen places — pane clicks, focus changes, the guided tours — so closing
+  // the target editor is done here once rather than threaded through each of
+  // them.
+  useEffect(() => {
+    if (indicatorPaneIndex !== null) onCloseTargetModal();
+  }, [indicatorPaneIndex, onCloseTargetModal]);
 
   useEffect(() => {
     // Don't save if no site is open, we're loading a site, on create-site page,
@@ -1188,10 +1201,20 @@ function App() {
 
       <Flex flex={1} overflow="hidden" position="relative">
         {/* Main content area - shrinks when panel opens */}
+        {/*
+          Both right-hand panels dock into the same slot, so the content area
+          gives up the same strip of width for either of them. The target
+          editor in particular has to shrink the content rather than cover it:
+          its whole point is watching the dials behind it respond.
+        */}
         <Box
           flex={1}
           transition="margin-right 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
-          mr={isIndicatorOpen ? { base: 0, md: '400px', lg: '440px' } : 0}
+          mr={isIndicatorOpen
+            ? { base: 0, md: '400px', lg: '440px' }
+            : isTargetModalOpen
+              ? { base: 0, md: '440px' }
+              : 0}
           position="relative"
         >
           <ContentArea

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -1,12 +1,14 @@
-import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box, Button, FormControl, FormLabel, HStack, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Slider, SliderFilledTrack, SliderThumb, SliderTrack, Spinner, VStack, useToast } from '@chakra-ui/react';
+import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel, Box, Checkbox, FormControl, FormLabel, HStack, IconButton, Slide, Slider, SliderFilledTrack, SliderThumb, SliderTrack, Spinner, Tooltip, VStack, useToast } from '@chakra-ui/react';
+import { FiChevronRight } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 import ViewPane from './ViewPane';
 import { navigationPaneIndex } from '../lib/navigationPane';
+import { createRecalculationScheduler, loadLiveUpdatePreference, resolveLiveUpdate, saveLiveUpdatePreference } from '../lib/liveTargetUpdate';
 import { DEFAULT_PANE_STATES } from '../types';
 import type { LayoutMode, QuadColumns, PaneStates, IdentifyResult, MapExtent, MapStatistics, BoundingBox, ColorScaleMode, ColorScaleType, SiteIndicators, RangeMode, ViewMode } from '../types';
 import { useAttributeDetails, useAttributeOrder, useAttributeTargetInputs, useAttributeTargetRanges, useAttributeUnits, useAttributeVariableTypes } from '../hooks/useApi';
 import type { FullDomainData } from '../hooks/useApi';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface ContentAreaProps {
   mode: LayoutMode;
@@ -50,7 +52,7 @@ interface ContentAreaProps {
   chartGraphModes?: ('line' | 'boxplot' | null)[];
   mapExtent?: MapExtent | null;
   onSiteIndicatorsChange?: (indicators: SiteIndicators) => Promise<void> | void;
-  // For target modal control from parent
+  // For target panel control from parent
   isTargetModalOpen?: boolean;
   onCloseTargetModal?: () => void;
   refreshKey?: number;
@@ -80,6 +82,26 @@ const paneVariants = {
     },
   }),
 };
+
+/**
+ * Every user-visible string the target editor owns, in one object — the same
+ * arrangement GridControls uses, and for the same reason: there is no i18n
+ * layer yet, and collecting the strings makes the eventual extraction
+ * mechanical rather than a hunt through JSX.
+ */
+const STRINGS = {
+  targetsHeading: 'Edit Target Values',
+  closePanel: 'Close target editor',
+  liveUpdate: 'Live update',
+  liveUpdateHintOn:
+    'Charts and sliders recalculate continuously while you drag. Best on small sites.',
+  liveUpdateHintOff:
+    'Charts and sliders recalculate once you let go of a slider. Best on large sites.',
+  recalculating: 'Recalculating…',
+  invalidTargetTitle: 'Invalid target value',
+  invalidTargetBody: (label: string) => `Please enter a valid number for ${label}.`,
+  updateFailed: 'Failed to update target values',
+} as const;
 
 function formatVariableType(value: string): string {
   return value
@@ -145,13 +167,26 @@ function ContentArea({
   const [targetDraftValues, setTargetDraftValues] = useState<Record<string, string>>({});
   const [targetDefaultValues, setTargetDefaultValues] = useState<Record<string, number>>({});
   const [isSavingTargets, setIsSavingTargets] = useState(false);
-  // Disabling every slider mid-drag-release moves focus off the thumb the
-  // user just let go of; the modal's focus trap then jumps focus to another
-  // element inside it, which drags the scroll position along with it. We
-  // capture the modal body's scroll position right before disabling and
-  // restore it once the disable/re-enable render has committed.
-  const modalBodyRef = useRef<HTMLDivElement>(null);
-  const savedTargetScrollTopRef = useRef(0);
+
+  // --- Live update -------------------------------------------------------
+  //
+  // `storedLiveUpdate` is the user's explicit choice and null until they make
+  // one, which is what keeps the checkbox stateful: the catchment count only
+  // decides the default, and only for as long as nobody has overruled it.
+  const [storedLiveUpdate, setStoredLiveUpdate] = useState<boolean | null>(() => loadLiveUpdatePreference());
+  // The count the recalculation actually iterates over, straight off the
+  // extraction that produced these indicators — the same number the backend
+  // rescores on every edit, which is what makes it the right one to size the
+  // default by.
+  const catchmentCount = siteIndicators?.catchmentCount ?? 0;
+  const isLiveUpdate = resolveLiveUpdate(catchmentCount, storedLiveUpdate);
+
+  const handleLiveUpdateChange = useCallback((enabled: boolean) => {
+    setStoredLiveUpdate(enabled);
+    saveLiveUpdatePreference(enabled);
+  }, []);
+
+
   const isQuad = mode === 'quad';
   const minimumQuadPaneCount = DEFAULT_PANE_STATES.length;
 
@@ -249,118 +284,151 @@ function ContentArea({
     return nextDrafts;
   };
 
-  // Populate draft values whenever the modal opens, regardless of which entry
+  // The keys whose slider the user has actually moved since opening the
+  // editor. Untouched sliders still carry a draft — it defaults to the
+  // current-state value so they start somewhere meaningful — and submitting
+  // those as edits would tell the backend every indicator changed at once,
+  // derailing the cascade for the one being edited.
+  const touchedTargetKeysRef = useRef<Set<string>>(new Set());
+  // Which slider the pointer is on right now, or null between drags. Only the
+  // dragged slider is exempt from the resync below; every other slider still
+  // picks up cascade results live.
+  const draggingTargetKeyRef = useRef<string | null>(null);
+
+  // Recalculations are chained, so a second one in the same drag must build on
+  // what the first returned rather than on the `siteIndicators` captured when
+  // the drag started.
+  const siteIndicatorsRef = useRef(siteIndicators);
+  siteIndicatorsRef.current = siteIndicators;
+
+  // Populate draft values whenever the panel opens, regardless of which entry
   // point triggered it (header "Targets" button vs internal button). While
-  // the modal stays open, also resync drafts whenever `siteIndicators`
+  // the panel stays open, also resync drafts whenever `siteIndicators`
   // itself changes — a recalculation can cascade into other factors (e.g.
   // dropping grass cover fraction shifts the tree cover target), and those
   // sliders need to pick up the new value without the user closing and
-  // reopening the modal.
-  const targetModalWasOpenRef = useRef(false);
+  // reopening the panel.
+  const targetPanelWasOpenRef = useRef(false);
   useEffect(() => {
     if (!isTargetModalOpen) {
-      targetModalWasOpenRef.current = false;
+      targetPanelWasOpenRef.current = false;
+      touchedTargetKeysRef.current = new Set();
       return;
     }
 
     const nextDrafts = computeTargetDrafts();
-    setTargetDraftValues(nextDrafts);
+    // Mid-drag, a live recalculation's cascade must not yank the thumb out
+    // from under the pointer, so the dragged slider keeps the user's value
+    // and everything else takes the freshly calculated one.
+    const draggingKey = draggingTargetKeyRef.current;
+    setTargetDraftValues((prev) =>
+      draggingKey != null && prev[draggingKey] !== undefined
+        ? { ...nextDrafts, [draggingKey]: prev[draggingKey] }
+        : nextDrafts
+    );
 
-    if (!targetModalWasOpenRef.current) {
+    if (!targetPanelWasOpenRef.current) {
       // Only snapshot the "opened at" values on the initial open — this
-      // snapshot is what later edits are diffed against to detect which
-      // sliders the user actually touched.
+      // snapshot is what the reset-to-origin check below diffs against.
       setTargetDefaultValues(
         Object.fromEntries(
           Object.entries(nextDrafts).map(([key, value]) => [key, Number(value)])
         )
       );
     }
-    targetModalWasOpenRef.current = true;
+    targetPanelWasOpenRef.current = true;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTargetModalOpen, siteIndicators]);
 
 
-  // Broadcast open/close so the guided tour can hide itself while the modal
-  // is visible. Using a ref to skip the initial mount dispatch.
-  const prevModalOpenRef = useRef(false);
+  // The application header is content-sized — logos plus padding — not a fixed
+  // height, so the docked panel measures it instead of repeating a magic number
+  // that goes stale the moment the header's contents change. Getting this wrong
+  // tucks the panel's heading up underneath the top bar.
+  const [headerOffset, setHeaderOffset] = useState(0);
+  useEffect(() => {
+    const header = document.querySelector('header');
+    if (!header) return;
+    const apply = () => setHeaderOffset(header.getBoundingClientRect().height);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
+
+  // Broadcast open/close so the guided tour can react to the panel appearing.
+  // Using a ref to skip the initial mount dispatch. The event names predate
+  // the panel being a docked panel rather than a modal and are kept as-is so
+  // the tours keep working.
+  const prevPanelOpenRef = useRef(false);
   useEffect(() => {
     const isOpen = isTargetModalOpen ?? false;
-    if (isOpen && !prevModalOpenRef.current) {
+    if (isOpen && !prevPanelOpenRef.current) {
       window.dispatchEvent(new Event('dt:targets-modal-opened'));
-    } else if (!isOpen && prevModalOpenRef.current) {
+    } else if (!isOpen && prevPanelOpenRef.current) {
       window.dispatchEvent(new Event('dt:targets-modal-closed'));
     }
-    prevModalOpenRef.current = isOpen;
+    prevPanelOpenRef.current = isOpen;
   }, [isTargetModalOpen]);
 
-  // Runs on every slider's release handler. `draftValues` is passed in
-  // rather than read from `targetDraftValues` state so a just-released
-  // slider's final value is guaranteed to be included, even though the
-  // setState call that recorded it may not have flushed to state yet by the
-  // time this runs.
-  const recalculateTargets = async (draftValues: Record<string, string>) => {
-    if (!siteIndicators || !onSiteIndicatorsChange) return;
+  // One recalculation round trip. `draftValues` is passed in rather than read
+  // from `targetDraftValues` state so the value that triggered it is
+  // guaranteed to be included, even though the setState that recorded it may
+  // not have flushed to state yet by the time this runs.
+  const runRecalculation = async (draftValues: Record<string, string>) => {
+    const indicators = siteIndicatorsRef.current;
+    if (!indicators || !onSiteIndicatorsChange) return;
 
-    const nextIdeal = { ...(siteIndicators.ideal ?? {}) };
+    const currentIdeal = indicators.ideal ?? {};
+    const nextIdeal = { ...currentIdeal };
     let hasChanges = false;
 
     for (const key of editableTargetKeys) {
+      if (!touchedTargetKeysRef.current.has(key)) continue;
       const raw = (draftValues[key] ?? '').trim();
       if (raw === '') continue;
       const parsed = Number(raw);
       if (!Number.isFinite(parsed)) {
         toast({
-          title: 'Invalid target value',
-          description: `Please enter a valid number for ${attributeDetails[key] ?? key}.`,
+          title: STRINGS.invalidTargetTitle,
+          description: STRINGS.invalidTargetBody(attributeDetails[key] ?? key),
           status: 'error',
           duration: 2500,
         });
         return;
       }
-      // Sliders the user never touched still hold a draft — it defaults to
-      // the current-state value so untouched sliders start somewhere
-      // meaningful (see the modal-open effect above). Submitting that
-      // untouched draft as an "ideal" edit would make the backend think
-      // every uncustomized indicator changed at once, which derails the
-      // cascade recalculation for the one field actually being edited.
-      // Only include keys whose draft has actually moved from its
-      // modal-open snapshot.
-      const openedAt = targetDefaultValues[key];
-      if (typeof openedAt === 'number' && parsed === openedAt) continue;
+      // Always send a touched key, even when the user has dragged it back to
+      // where it started: that is a request to clear the target, and skipping
+      // it would leave the previously submitted ideal in place forever.
       nextIdeal[key] = parsed;
-      hasChanges = true;
+      if (currentIdeal[key] !== parsed) hasChanges = true;
     }
 
     if (!hasChanges) return;
 
-    savedTargetScrollTopRef.current = modalBodyRef.current?.scrollTop ?? 0;
-    // Move focus onto the modal body itself — a stable element that never
-    // gets disabled — rather than letting it fall out of the modal
-    // entirely. react-focus-lock only intervenes (and drags the scroll
-    // position with it) once it sees focus escape the modal; keeping focus
-    // inside means the disabled slider/button below never triggers that.
-    modalBodyRef.current?.focus({ preventScroll: true });
-    setIsSavingTargets(true);
     try {
-      await onSiteIndicatorsChange({
-        ...siteIndicators,
-        ideal: nextIdeal,
-      });
+      await onSiteIndicatorsChange({ ...indicators, ideal: nextIdeal });
     } catch {
-      toast({ title: 'Failed to update target values', status: 'error', duration: 2500 });
-    } finally {
-      setIsSavingTargets(false);
+      toast({ title: STRINGS.updateFailed, status: 'error', duration: 2500 });
     }
   };
 
-  // Runs after every isSavingTargets flip (sliders getting disabled, then
-  // re-enabled) and pins the scroll position back to where it was
-  // immediately beforehand — see the comment by savedTargetScrollTopRef.
-  useLayoutEffect(() => {
-    const el = modalBodyRef.current;
-    if (el) el.scrollTop = savedTargetScrollTopRef.current;
-  }, [isSavingTargets]);
+  // The scheduler is created once and reaches the current render's
+  // `runRecalculation` through a ref, so a request chained after an await
+  // still sees the latest props rather than the ones captured when the drag
+  // started.
+  const runRecalculationRef = useRef(runRecalculation);
+  runRecalculationRef.current = runRecalculation;
+  const schedulerRef = useRef<ReturnType<typeof createRecalculationScheduler<Record<string, string>>> | null>(null);
+  if (schedulerRef.current === null) {
+    schedulerRef.current = createRecalculationScheduler<Record<string, string>>(
+      (drafts) => runRecalculationRef.current(drafts),
+      setIsSavingTargets,
+    );
+  }
+  const scheduleRecalculation = (draftValues: Record<string, string>) => {
+    schedulerRef.current?.schedule(draftValues);
+  };
 
   const visibleIndices = isQuad
     ? paneStates.map((_, index) => index)
@@ -526,36 +594,76 @@ function ContentArea({
       )}
       </Box>
 
-      <Modal
-        isOpen={isTargetModalOpen ?? false}
-        onClose={onCloseTargetModal ?? (() => {})}
-        size="xl"
-        scrollBehavior="inside"
-        closeOnOverlayClick={!isSavingTargets}
-        closeOnEsc={!isSavingTargets}
+      {/*
+        A docked right-hand panel rather than a modal overlay. The editor is
+        something you work *alongside* — its whole purpose is watching the
+        dials behind it answer a slider — and an overlay hid exactly what it
+        was meant to show. It takes the same slot as the single-factor
+        ControlPanel, which is never open at the same time.
+      */}
+      <Slide
+        direction="right"
+        in={isTargetModalOpen ?? false}
+        style={{
+          zIndex: 15,
+          position: 'fixed',
+          top: headerOffset,
+          right: 0,
+          height: `calc(100% - ${headerOffset}px)`,
+          width: 'auto',
+        }}
       >
-        <ModalOverlay />
-        <ModalContent bg="gray.800" color="white">
-          <ModalHeader>Edit Target Values</ModalHeader>
-          <ModalCloseButton isDisabled={isSavingTargets} />
-          <ModalBody ref={modalBodyRef} tabIndex={-1} position="relative">
+        <Box
+          id="tour-target-panel"
+          role="region"
+          aria-label={STRINGS.targetsHeading}
+          w={{ base: '100vw', md: '440px' }}
+          h="100%"
+          bg="gray.800"
+          color="white"
+          borderLeft="1px"
+          borderColor="whiteAlpha.200"
+          boxShadow="-4px 0 24px rgba(0,0,0,0.35)"
+          display="flex"
+          flexDirection="column"
+        >
+          <HStack px={4} pt={3} pb={2} align="center" spacing={2}>
+            <Box fontSize="md" fontWeight="bold" flex="1">{STRINGS.targetsHeading}</Box>
             {isSavingTargets && (
-              <Box
-                position="absolute"
-                top={0} left={0} right={0} bottom={0}
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                bg="rgba(26, 32, 44, 0.6)"
-                zIndex={10}
-                backdropFilter="blur(2px)"
-              >
-                <VStack spacing={2}>
-                  <Spinner size="xl" color="cyan.400" thickness="3px" speed="0.7s" />
-                  <Box fontSize="sm" color="gray.200">Recalculating…</Box>
-                </VStack>
-              </Box>
+              <HStack spacing={2} color="cyan.300" fontSize="xs">
+                <Spinner size="xs" thickness="2px" speed="0.7s" />
+                <Box>{STRINGS.recalculating}</Box>
+              </HStack>
             )}
+            <IconButton
+              aria-label={STRINGS.closePanel}
+              icon={<FiChevronRight />}
+              size="sm"
+              variant="ghost"
+              onClick={onCloseTargetModal}
+            />
+          </HStack>
+
+          <Box px={4} pb={3}>
+            <Tooltip
+              label={isLiveUpdate ? STRINGS.liveUpdateHintOn : STRINGS.liveUpdateHintOff}
+              placement="left"
+              openDelay={400}
+            >
+              <Box>
+                <Checkbox
+                  colorScheme="cyan"
+                  size="sm"
+                  isChecked={isLiveUpdate}
+                  onChange={(e) => handleLiveUpdateChange(e.target.checked)}
+                >
+                  <Box fontSize="sm" color="gray.200">{STRINGS.liveUpdate}</Box>
+                </Checkbox>
+              </Box>
+            </Tooltip>
+          </Box>
+
+          <Box px={4} pb={4} flex="1" overflowY="auto">
             <Accordion allowMultiple>
               {targetGroups.map((group) => (
                 <AccordionItem key={group.groupName} border="none" mb={3}>
@@ -604,14 +712,45 @@ function ContentArea({
                               max={safeMax}
                               step={step}
                               colorScheme="cyan"
-                              isDisabled={isSavingTargets}
-                              onChange={(val) =>
-                                setTargetDraftValues((prev) => ({ ...prev, [key]: String(val) }))
-                              }
-                              onChangeEnd={(val) => {
+                              // Deliberately never disabled while a
+                              // recalculation runs. Disabling every slider
+                              // mid-edit was what made the editor feel like it
+                              // redrew itself: focus moved, the scroll
+                              // position jumped, and the user had to find
+                              // their place again after each change.
+                              //
+                              // Chakra focuses a thumb whenever its *value*
+                              // changes, with a bare .focus() that scrolls the
+                              // element into view. A cascade rewrites the
+                              // other sliders' values, so releasing one drag
+                              // threw focus onto an unrelated slider and
+                              // scrolled the panel to it. Focus is restored
+                              // deliberately in onPointerDown below instead —
+                              // on the slider the pointer actually landed on,
+                              // and without scrolling.
+                              focusThumbOnChange={false}
+                              onPointerDown={(e) => {
+                                const thumb = e.currentTarget.querySelector('[role="slider"]');
+                                if (thumb instanceof HTMLElement) thumb.focus({ preventScroll: true });
+                              }}
+                              onChange={(val) => {
+                                draggingTargetKeyRef.current = key;
+                                touchedTargetKeysRef.current.add(key);
                                 const nextDraft = { ...targetDraftValues, [key]: String(val) };
                                 setTargetDraftValues(nextDraft);
-                                void recalculateTargets(nextDraft);
+                                if (isLiveUpdate) scheduleRecalculation(nextDraft);
+                              }}
+                              onChangeEnd={(val) => {
+                                draggingTargetKeyRef.current = null;
+                                touchedTargetKeysRef.current.add(key);
+                                const nextDraft = { ...targetDraftValues, [key]: String(val) };
+                                setTargetDraftValues(nextDraft);
+                                // Runs in both modes. With live update off it
+                                // is the only recalculation; with it on it is
+                                // the one that guarantees the released value
+                                // is the value that was scored, whatever the
+                                // coalescing dropped on the way.
+                                scheduleRecalculation(nextDraft);
                               }}
                             >
                               <SliderTrack bg="whiteAlpha.200">
@@ -631,12 +770,9 @@ function ContentArea({
                 </AccordionItem>
               ))}
             </Accordion>
-          </ModalBody>
-          <ModalFooter>
-            <Button colorScheme="cyan" onClick={onCloseTargetModal} isDisabled={isSavingTargets}>Close</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+          </Box>
+        </Box>
+      </Slide>
     </Box>
   );
 }

--- a/frontend/src/components/DialChart.tsx
+++ b/frontend/src/components/DialChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { memo, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { Box, HStack, Button, Spinner, Tooltip } from '@chakra-ui/react';
 import { motion, useAnimation, AnimatePresence } from 'framer-motion';
 import { FiGlobe, FiSquare, FiTarget } from 'react-icons/fi';
@@ -162,9 +162,15 @@ function DialChart({
   const [size, setSize] = useState({ width: 800, height: 600 });
   const [needleProgress, setNeedleProgress] = useState(0);
   const [arcProgress, setArcProgress] = useState(0);
+  // `needleProgress` is eased with easeOutBack, which deliberately overshoots
+  // outside 0..1 so the needle springs past its mark and settles. That is right
+  // for an angle and wrong for an opacity — the overshoot renders as a negative
+  // opacity at the start of the reveal — so anything driving transparency uses
+  // the clamped value and only the angle uses the raw one.
+  const needleOpacity = Math.min(1, Math.max(0, needleProgress));
+  const arcOpacity = Math.min(1, Math.max(0, arcProgress));
   const animFrameRef = useRef<number>(0);
   const controls = useAnimation();
-  const prevValuesRef = useRef({ currentValue, referenceValue, targetValue, min, max });
 
   // Responsive sizing
   useEffect(() => {
@@ -211,21 +217,62 @@ function DialChart({
     animFrameRef.current = requestAnimationFrame(tick);
   }, []);
 
-  // Re-animate when values change
-  useEffect(() => {
-    const prev = prevValuesRef.current;
-    const changed =
-      prev.currentValue !== currentValue ||
-      prev.referenceValue !== referenceValue ||
-      prev.targetValue !== targetValue ||
-      prev.min !== min ||
-      prev.max !== max;
+  // `runAnimation` is the *reveal*, and it now runs only when the dial becomes
+  // visible (see the effect below it). It used to be replayed whenever the
+  // values or the scale changed, which was the flicker: `arcProgress` and
+  // `needleOpacity` drive opacity throughout this component, so every replay
+  // drove the whole widget's opacity back to zero and faded it in again. Under
+  // live target editing that happens several times a second.
+  //
+  // A value change is handled by easing the drawn values instead (below); a
+  // rescale simply redraws at the new scale. Neither needs the dial to
+  // disappear first.
 
-    if (changed && visible) {
-      prevValuesRef.current = { currentValue, referenceValue, targetValue, min, max };
-      runAnimation();
+  // The values the needles are actually drawn from, eased toward the incoming
+  // ones so a change reads as the needle travelling to its new angle rather
+  // than teleporting. This is the update animation; `runAnimation` above is the
+  // entry one, and the two must not be the same thing.
+  const [displayValues, setDisplayValues] = useState({ currentValue, referenceValue, targetValue });
+  const displayValuesRef = useRef(displayValues);
+  displayValuesRef.current = displayValues;
+  const valueFrameRef = useRef(0);
+
+  useEffect(() => {
+    const from = displayValuesRef.current;
+    const to = { currentValue, referenceValue, targetValue };
+    if (from.currentValue === to.currentValue &&
+        from.referenceValue === to.referenceValue &&
+        from.targetValue === to.targetValue) {
+      return;
     }
-  }, [currentValue, referenceValue, targetValue, min, max, visible, runAnimation]);
+
+    // A needle that is appearing or disappearing has no previous angle to
+    // travel from, so it takes the new value at once instead of sweeping in
+    // from wherever undefined would land it.
+    const ease = (a: number | undefined, b: number | undefined, t: number) =>
+      (typeof a === 'number' && Number.isFinite(a) && typeof b === 'number' && Number.isFinite(b))
+        ? a + (b - a) * t
+        : b;
+
+    const duration = 400;
+    const start = performance.now();
+    cancelAnimationFrame(valueFrameRef.current);
+
+    const tick = (now: number) => {
+      const linear = Math.min((now - start) / duration, 1);
+      // easeOutCubic: settles onto the value without the overshoot the entry
+      // animation uses, because during a drag it is immediately superseded.
+      const t = 1 - Math.pow(1 - linear, 3);
+      setDisplayValues({
+        currentValue: ease(from.currentValue, to.currentValue, t),
+        referenceValue: ease(from.referenceValue, to.referenceValue, t),
+        targetValue: ease(from.targetValue, to.targetValue, t),
+      });
+      if (linear < 1) valueFrameRef.current = requestAnimationFrame(tick);
+    };
+    valueFrameRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(valueFrameRef.current);
+  }, [currentValue, referenceValue, targetValue]);
 
   // Initial animation
   useEffect(() => {
@@ -413,7 +460,7 @@ function DialChart({
             d={arrowPath}
             fill="rgba(0,0,0,0.5)"
             transform="translate(3, 3)"
-            opacity={needleProgress}
+            opacity={needleOpacity}
           />
           {/* Main needle */}
           <path
@@ -422,7 +469,7 @@ function DialChart({
             stroke={color}
             strokeWidth={2}
             strokeLinecap="round"
-            opacity={needleProgress}
+            opacity={needleOpacity}
           />
           {/* Tip highlight */}
           <circle
@@ -430,7 +477,7 @@ function DialChart({
             cy={tipY}
             r={4}
             fill="white"
-            opacity={0.9 * needleProgress}
+            opacity={0.9 * needleOpacity}
           />
         </g>
       );
@@ -452,12 +499,12 @@ function DialChart({
           strokeWidth={4}
           strokeDasharray="8,6"
           strokeLinecap="round"
-          opacity={needleProgress}
+          opacity={needleOpacity}
         />
         <polygon
           points={`${leftX} ${leftY} ${tipX} ${tipY} ${rightX} ${rightY}`}
           fill={color}
-          opacity={needleProgress}
+          opacity={needleOpacity}
         />
       </g>
     );
@@ -478,9 +525,12 @@ function DialChart({
 
   // If the target equals the reference and a green center exists, render the target arrow
   // at the visual center of the green zone so arrow and gradient match.
+  // The "target sits on the reference" test uses the real values — it is a
+  // question about the data, not about where the needle happens to be
+  // mid-transition — but what gets drawn is the eased value.
   const targetRenderValue = (targetValue !== undefined && referenceValue !== undefined && targetValue === referenceValue && greenCenter !== null)
     ? min + (max - min) * greenCenter
-    : targetValue;
+    : displayValues.targetValue;
 
   // Compute final tip coordinates for the target (used for a verification marker).
   const targetTip = useMemo(() => {
@@ -666,7 +716,7 @@ function DialChart({
                 stroke="#2d3748"
                 strokeWidth={1}
                 strokeDasharray="4,8"
-                opacity={0.5 * arcProgress}
+                opacity={0.5 * arcOpacity}
               />
 
               {/* Arc background */}
@@ -675,7 +725,7 @@ function DialChart({
                 fill="#1e2533"
                 stroke="#2d3748"
                 strokeWidth={2}
-                opacity={arcProgress}
+                opacity={arcOpacity}
               />
               
               {/* Conic gradient arc */}
@@ -686,7 +736,7 @@ function DialChart({
                 height={height}
                 mask={`url(#${gradientId}-mask)`}
                 style={{ filter: 'url(#arc-glow)' }}
-                opacity={0.95 * arcProgress}
+                opacity={0.95 * arcOpacity}
               >
                 <div
                   style={{
@@ -705,7 +755,7 @@ function DialChart({
 
               {/* Tick marks */}
               {ticks.map((tick, i) => (
-                <g key={i} opacity={arcProgress}>
+                <g key={i} opacity={arcOpacity}>
                   <line
                     x1={tick.x1}
                     y1={tick.y1}
@@ -733,7 +783,7 @@ function DialChart({
               ))}
 
               {zeroTick && (
-                <g opacity={arcProgress}>
+                <g opacity={arcOpacity}>
                   <line
                     x1={zeroTick.x1}
                     y1={zeroTick.y1}
@@ -759,7 +809,7 @@ function DialChart({
               )}
 
               {referenceCallout && (
-                <g opacity={arcProgress}>
+                <g opacity={arcOpacity}>
                   {referenceCallout.markerOnly ? (
                     // Compact quad: no space for a full callout — show a small tick on the arc
                     <circle
@@ -802,10 +852,10 @@ function DialChart({
              
 
               {/* Center hub */}
-              <circle cx={centerX} cy={centerY} r={centerHubOuterRadius} fill="#1a202c" stroke="#3d4a5c" strokeWidth={4} opacity={arcProgress} />
-              <circle cx={centerX} cy={centerY} r={centerHubMidRadius} fill="#2d3748" opacity={arcProgress} />
-              <circle cx={centerX} cy={centerY} r={centerHubInnerRadius} fill="#4a5568" opacity={arcProgress} />
-              <circle cx={centerX} cy={centerY} r={centerHubCoreRadius} fill="#5a6a7c" opacity={arcProgress} />
+              <circle cx={centerX} cy={centerY} r={centerHubOuterRadius} fill="#1a202c" stroke="#3d4a5c" strokeWidth={4} opacity={arcOpacity} />
+              <circle cx={centerX} cy={centerY} r={centerHubMidRadius} fill="#2d3748" opacity={arcOpacity} />
+              <circle cx={centerX} cy={centerY} r={centerHubInnerRadius} fill="#4a5568" opacity={arcOpacity} />
+              <circle cx={centerX} cy={centerY} r={centerHubCoreRadius} fill="#5a6a7c" opacity={arcOpacity} />
 
               {/* Needles */}
               {/* Reference arrow removed as requested */}
@@ -816,17 +866,17 @@ function DialChart({
                 false,
                 true
               )}
-              {createArrowNeedle(currentValue, SCENARIO_COLORS.current, true)}
+              {createArrowNeedle(displayValues.currentValue, SCENARIO_COLORS.current, true)}
 
               {/* Verification marker: final target tip position (helps confirm arrow alignment) */}
               {targetTip && (
-                <g opacity={Math.min(1, 0.6 + 0.4 * needleProgress)}>
+                <g opacity={Math.min(1, 0.6 + 0.4 * needleOpacity)}>
                   <circle cx={targetTip.x} cy={targetTip.y} r={7} fill="#fff" stroke={SCENARIO_COLORS.future} strokeWidth={1.5} />
                 </g>
               )}
 
               {/* Center cap */}
-              <circle cx={centerX} cy={centerY} r={centerCapRadius} fill="#4a5568" stroke="#718096" strokeWidth={2} opacity={needleProgress} />
+              <circle cx={centerX} cy={centerY} r={centerCapRadius} fill="#4a5568" stroke="#718096" strokeWidth={2} opacity={needleOpacity} />
 
               
 
@@ -840,14 +890,14 @@ function DialChart({
                   fontSize={veryDenseLayout ? 15 : 20}
                   fontFamily="Inter, system-ui, sans-serif"
                   fontWeight="700"
-                  opacity={arcProgress}
+                  opacity={arcOpacity}
                 >
                   {attribute}{unit ? ` (${unit})` : ''}
                 </text>
               )}
 
               {/* Legend */}
-              <g opacity={needleProgress}>
+              <g opacity={needleOpacity}>
                 {/* Reference */}
                 <g transform={`translate(${legendReferenceX}, ${legendY})`}>
                   <circle cx={8} cy={0} r={8} fill="#2ecc40" stroke="#fff" strokeWidth={1.5} />
@@ -899,4 +949,15 @@ function DialChart({
   );
 }
 
-export default DialChart;
+/**
+ * Memoised on its props, every one of which is a primitive or a stable
+ * callback.
+ *
+ * A dial is expensive to draw — arc gradient, tick ring, needles, callouts —
+ * and there are up to six on screen. Editing a target replaces the whole
+ * `siteIndicators` object, so without this every dial re-rendered on every
+ * recalculation even when its own factor was untouched. Under live editing
+ * that is several full redraws a second of widgets whose values did not
+ * change.
+ */
+export default memo(DialChart);

--- a/frontend/src/lib/liveTargetUpdate.ts
+++ b/frontend/src/lib/liveTargetUpdate.ts
@@ -1,0 +1,153 @@
+/**
+ * Whether the target editor recalculates while a slider is being dragged.
+ *
+ * Every target edit costs a round trip that rescores each catchment in the
+ * site, so the cost of recalculating scales with how many catchments the site
+ * has. On a small site that is fast enough to run continuously as the thumb
+ * moves, and continuous feedback is the whole point of the editor: you see the
+ * dials answer the slider. On a large site the same behaviour would queue a
+ * request per animation frame's worth of movement, so there the recalculation
+ * waits for the drag to finish.
+ *
+ * The catchment count only supplies the *default*. Once the user has ticked or
+ * unticked the box the choice is theirs and is remembered, because the point of
+ * the control is to overrule a guess that does not match the machine, the
+ * network, or the site in front of them.
+ */
+
+import { safeSetItem } from './storage';
+
+/**
+ * Sites at or below this many catchments default to live update.
+ *
+ * Chosen as the point where a full recalculation stays comfortably inside a
+ * drag's frame budget on a local backend. It is a default, not a limit — the
+ * checkbox overrides it in either direction.
+ */
+export const LIVE_UPDATE_CATCHMENT_THRESHOLD = 20;
+
+const PREFERENCE_KEY = 'dt.targets.liveUpdate';
+
+/**
+ * The user's explicit choice, or null when they have never made one.
+ *
+ * Null is meaningfully different from false: it means "no opinion recorded, so
+ * pick the default for this site", and it is why an untouched checkbox can
+ * change between sites while a touched one cannot.
+ */
+export function loadLiveUpdatePreference(): boolean | null {
+  if (typeof window === 'undefined') return null;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(PREFERENCE_KEY);
+  } catch {
+    // Storage blocked entirely (private mode, enterprise policy). Falling back
+    // to the per-site default is correct: the feature still works, it just
+    // forgets between sessions.
+    return null;
+  }
+  if (raw === 'on') return true;
+  if (raw === 'off') return false;
+  return null;
+}
+
+/** Record an explicit choice, so it survives reloads and outlives this site. */
+export function saveLiveUpdatePreference(enabled: boolean): void {
+  safeSetItem(PREFERENCE_KEY, enabled ? 'on' : 'off');
+}
+
+/** Forget the explicit choice and go back to deciding by catchment count. */
+export function clearLiveUpdatePreference(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(PREFERENCE_KEY);
+  } catch {
+    // Nothing useful to do — the value was never stored in the first place.
+  }
+}
+
+/**
+ * The default for a site of this size, ignoring any stored preference.
+ *
+ * A site with no catchments counts as small rather than unknown: there is
+ * nothing for a recalculation to iterate over, so live update costs nothing.
+ */
+export function defaultLiveUpdate(catchmentCount: number): boolean {
+  return catchmentCount <= LIVE_UPDATE_CATCHMENT_THRESHOLD;
+}
+
+/**
+ * The setting to actually use: the stored choice when there is one, otherwise
+ * the size-derived default.
+ */
+export function resolveLiveUpdate(catchmentCount: number, stored: boolean | null): boolean {
+  return stored ?? defaultLiveUpdate(catchmentCount);
+}
+
+/**
+ * Coalescing scheduler for recalculations.
+ *
+ * A drag produces a stream of values, not a queue of edits. Sending one
+ * request per value would put the backend behind the pointer and land the
+ * answers out of order, so this keeps at most one request in flight and
+ * remembers only the newest payload produced while it runs. When the request
+ * finishes, the remembered payload — and only that one — is sent, so the
+ * sequence always converges on the last value the user actually chose no
+ * matter how much movement was dropped in between.
+ *
+ * `onBusyChange` brackets the whole burst rather than each request, so a
+ * progress indicator driven by it stays lit for the duration of a drag instead
+ * of flickering once per round trip.
+ */
+export interface RecalculationScheduler<T> {
+  /** Queue `payload`, starting a request now if nothing is in flight. */
+  schedule(payload: T): void;
+  /** Whether a request is in flight or a payload is waiting behind one. */
+  isBusy(): boolean;
+}
+
+export function createRecalculationScheduler<T>(
+  run: (payload: T) => Promise<void>,
+  onBusyChange: (busy: boolean) => void = () => {},
+  onError: (error: unknown) => void = (error) =>
+    console.error('Target recalculation failed', error),
+): RecalculationScheduler<T> {
+  // `undefined` rather than null: a payload of null is a legitimate value for
+  // a caller to schedule, and "nothing pending" must stay distinguishable.
+  let pending: { payload: T } | undefined;
+  let inFlight = false;
+
+  const drain = async () => {
+    inFlight = true;
+    onBusyChange(true);
+    try {
+      while (pending) {
+        const { payload } = pending;
+        pending = undefined;
+        // Caught per iteration, not around the loop. A failed request must
+        // neither strand the editor as permanently busy nor discard the
+        // payload waiting behind it, and the drain is started with `void`, so
+        // an escaping rejection would surface as an unhandled one.
+        try {
+          await run(payload);
+        } catch (error) {
+          onError(error);
+        }
+      }
+    } finally {
+      inFlight = false;
+      onBusyChange(false);
+    }
+  };
+
+  return {
+    schedule(payload: T) {
+      pending = { payload };
+      if (inFlight) return;
+      void drain();
+    },
+    isBusy() {
+      return inFlight;
+    },
+  };
+}

--- a/frontend/src/test/liveTargetUpdate.test.ts
+++ b/frontend/src/test/liveTargetUpdate.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Live update: the default, the override, and the coalescing.
+ *
+ * A target edit costs a round trip that rescores every catchment in the site,
+ * so whether the editor recalculates during a drag or only after it is a
+ * question about site size. These tests pin the three properties that make the
+ * feature behave: the size-derived default, the fact that an explicit choice
+ * outranks it in both directions and survives, and — the part that makes live
+ * update viable at all — that a drag's worth of values becomes at most two
+ * requests rather than one per pointer move.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  LIVE_UPDATE_CATCHMENT_THRESHOLD,
+  clearLiveUpdatePreference,
+  createRecalculationScheduler,
+  defaultLiveUpdate,
+  loadLiveUpdatePreference,
+  resolveLiveUpdate,
+  saveLiveUpdatePreference,
+} from '../lib/liveTargetUpdate';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('the size-derived default', () => {
+  it('is on at and below the threshold', () => {
+    expect(defaultLiveUpdate(1)).toBe(true);
+    expect(defaultLiveUpdate(LIVE_UPDATE_CATCHMENT_THRESHOLD)).toBe(true);
+  });
+
+  it('is off above it', () => {
+    expect(defaultLiveUpdate(LIVE_UPDATE_CATCHMENT_THRESHOLD + 1)).toBe(false);
+    expect(defaultLiveUpdate(400)).toBe(false);
+  });
+
+  it('treats a site with no catchments as small', () => {
+    // Nothing to iterate over means nothing to wait for. Off would be a
+    // needless downgrade, and 0 is not a stand-in for "unknown" here — the
+    // count is read straight off the open site.
+    expect(defaultLiveUpdate(0)).toBe(true);
+  });
+});
+
+describe('the stored preference', () => {
+  it('is absent until the user makes a choice', () => {
+    expect(loadLiveUpdatePreference()).toBeNull();
+  });
+
+  it('round-trips both answers', () => {
+    saveLiveUpdatePreference(true);
+    expect(loadLiveUpdatePreference()).toBe(true);
+    saveLiveUpdatePreference(false);
+    expect(loadLiveUpdatePreference()).toBe(false);
+  });
+
+  it('goes back to null once cleared', () => {
+    saveLiveUpdatePreference(false);
+    clearLiveUpdatePreference();
+    expect(loadLiveUpdatePreference()).toBeNull();
+  });
+
+  it('reads as absent rather than throwing when storage is unreadable', () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('blocked', 'SecurityError');
+      });
+    expect(loadLiveUpdatePreference()).toBeNull();
+    getItem.mockRestore();
+  });
+});
+
+describe('resolveLiveUpdate', () => {
+  it('falls back to the size default when nothing is stored', () => {
+    expect(resolveLiveUpdate(5, null)).toBe(true);
+    expect(resolveLiveUpdate(500, null)).toBe(false);
+  });
+
+  it('lets an explicit choice overrule the default in both directions', () => {
+    // The whole point of the checkbox: overruling a guess that does not match
+    // the machine, the network, or the site in front of the user.
+    expect(resolveLiveUpdate(500, true)).toBe(true);
+    expect(resolveLiveUpdate(5, false)).toBe(false);
+  });
+});
+
+describe('the coalescing scheduler', () => {
+  /** A run function whose promises are resolved by hand, one at a time. */
+  function deferredRunner() {
+    const calls: string[] = [];
+    const resolvers: Array<() => void> = [];
+    const run = (payload: string) => {
+      calls.push(payload);
+      return new Promise<void>((resolve) => resolvers.push(resolve));
+    };
+    const settleNext = async () => {
+      const resolve = resolvers.shift();
+      expect(resolve).toBeDefined();
+      resolve?.();
+      // Two turns: one for the awaited run, one for the loop's next iteration.
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+    return { calls, run, settleNext };
+  }
+
+  it('starts immediately when nothing is in flight', () => {
+    const { calls, run } = deferredRunner();
+    createRecalculationScheduler(run).schedule('a');
+    expect(calls).toEqual(['a']);
+  });
+
+  it('collapses a drag into the first value and the last', async () => {
+    const { calls, run, settleNext } = deferredRunner();
+    const scheduler = createRecalculationScheduler(run);
+
+    scheduler.schedule('0.10');
+    // Everything between arrives while the first request is still open. Each
+    // replaces the last, so none of them costs a round trip.
+    scheduler.schedule('0.20');
+    scheduler.schedule('0.30');
+    scheduler.schedule('0.40');
+    expect(calls).toEqual(['0.10']);
+
+    await settleNext();
+    expect(calls).toEqual(['0.10', '0.40']);
+
+    await settleNext();
+    // Drag over, queue drained — no trailing request for the values it skipped.
+    expect(calls).toEqual(['0.10', '0.40']);
+  });
+
+  it('never has more than one request open at a time', async () => {
+    let open = 0;
+    let maxOpen = 0;
+    const resolvers: Array<() => void> = [];
+    const scheduler = createRecalculationScheduler<number>((_n) => {
+      open += 1;
+      maxOpen = Math.max(maxOpen, open);
+      return new Promise<void>((resolve) =>
+        resolvers.push(() => {
+          open -= 1;
+          resolve();
+        }),
+      );
+    });
+
+    for (let i = 0; i < 25; i += 1) scheduler.schedule(i);
+    while (resolvers.length > 0) {
+      resolvers.shift()?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    expect(maxOpen).toBe(1);
+  });
+
+  it('brackets the whole burst with one busy signal, not one per request', async () => {
+    const { run, settleNext } = deferredRunner();
+    const busy: boolean[] = [];
+    const scheduler = createRecalculationScheduler(run, (b) => busy.push(b));
+
+    scheduler.schedule('a');
+    scheduler.schedule('b');
+    await settleNext();
+    await settleNext();
+
+    // A progress indicator driven by this must stay lit for the drag rather
+    // than strobing once per round trip.
+    expect(busy).toEqual([true, false]);
+  });
+
+  it('reports a failed request without wedging or losing what follows', async () => {
+    const calls: string[] = [];
+    const errors: unknown[] = [];
+    const busy: boolean[] = [];
+    let fail = true;
+    const scheduler = createRecalculationScheduler<string>(
+      async (payload) => {
+        calls.push(payload);
+        if (fail) {
+          fail = false;
+          throw new Error('network');
+        }
+      },
+      (b) => busy.push(b),
+      (e) => errors.push(e),
+    );
+
+    // The drain is started with `void`, so a rejection that escaped it would
+    // become an unhandled rejection, and the busy flag would never clear —
+    // leaving the editor lit as recalculating forever.
+    scheduler.schedule('a');
+    scheduler.schedule('b');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errors).toHaveLength(1);
+    expect(scheduler.isBusy()).toBe(false);
+    expect(busy).toEqual([true, false]);
+    // The payload queued behind the failure still went out.
+    expect(calls).toEqual(['a', 'b']);
+  });
+});

--- a/frontend/src/test/targetPanel.test.tsx
+++ b/frontend/src/test/targetPanel.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * The target editor as a docked panel.
+ *
+ * It used to be a modal: an overlay, centred, with every slider disabled and a
+ * full-bleed spinner over the form for the duration of each recalculation. Two
+ * things were wrong with that. The overlay hid the dials the editor exists to
+ * drive, and the disable/re-enable cycle moved focus and scroll on every
+ * change, so the user had to find their place again after each edit.
+ *
+ * These tests pin the replacement: a region docked in the right-hand slot, and
+ * sliders that stay usable while a recalculation is in flight. They also pin
+ * the live-update checkbox picking its default from the site's catchment count
+ * while still yielding to an explicit choice.
+ */
+import type { ComponentProps } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../styles/theme';
+import ContentArea from '../components/ContentArea';
+import {
+  LIVE_UPDATE_CATCHMENT_THRESHOLD,
+  loadLiveUpdatePreference,
+  saveLiveUpdatePreference,
+} from '../lib/liveTargetUpdate';
+import { DEFAULT_PANE_STATES } from '../types';
+import type { SiteIndicators } from '../types';
+
+// The panes are irrelevant here and drag in MapView, deck.gl and maplibre.
+vi.mock('../components/ViewPane', () => ({ default: () => <div data-testid="view-pane" /> }));
+
+const KEY = 'prop_X40_50Mgha';
+
+vi.mock('../hooks/useApi', () => ({
+  useAttributeDetails: () => ({ details: { [KEY]: 'Tree biomass 40-50Mgha' } }),
+  useAttributeTargetInputs: () => ({ targetInputs: { [KEY]: true } }),
+  useAttributeUnits: () => ({ units: { [KEY]: 'proportion' } }),
+  useAttributeTargetRanges: () => ({ targetRanges: { [KEY]: { min: 0, max: 1 } } }),
+  useAttributeVariableTypes: () => ({ variableTypes: { [KEY]: 'Trees' } }),
+  useAttributeOrder: () => ({ order: { [KEY]: 1 } }),
+}));
+
+type Props = ComponentProps<typeof ContentArea>;
+
+/**
+ * The catchment count comes off the indicators themselves — it is the number
+ * the backend rescores on every edit, so it is what the live-update default is
+ * sized by.
+ */
+function indicators(
+  catchmentCount: number,
+  values: Record<string, number> = { [KEY]: 0.08 },
+): SiteIndicators {
+  return {
+    reference: Object.fromEntries(Object.keys(values).map((k) => [k, 0.5])),
+    current: { ...values },
+    ideal: { ...values },
+    extractedAt: '2026-08-29T00:00:00Z',
+    catchmentCount,
+    totalAreaKm2: 120,
+  };
+}
+
+function renderPanel(overrides: Partial<Props> = {}) {
+  const onSiteIndicatorsChange = vi.fn(async (_indicators: SiteIndicators) => {});
+  const props: Props = {
+    mode: 'single',
+    paneStates: DEFAULT_PANE_STATES,
+    viewModes: DEFAULT_PANE_STATES.map(() => 'dial' as const),
+    onViewModeChange: vi.fn(),
+    focusedPane: 0,
+    onFocusPane: vi.fn(),
+    onGoQuad: vi.fn(),
+    onRemovePane: vi.fn(),
+    colorScaleMode: 'metadata',
+    colorScaleType: 'linear',
+    isTargetModalOpen: true,
+    onCloseTargetModal: vi.fn(),
+    onSiteIndicatorsChange,
+    siteIndicators: indicators(5),
+    ...overrides,
+  };
+  render(
+    <ChakraProvider theme={theme}>
+      <ContentArea {...props} />
+    </ChakraProvider>,
+  );
+  return { onSiteIndicatorsChange, props };
+}
+
+/**
+ * Expand a target group and hand back its slider.
+ *
+ * `hidden: true` is needed because Chakra collapses an AccordionPanel with
+ * framer-motion, whose animation never runs under jsdom — the panel is left at
+ * `display: none` however many times it is clicked, so the default
+ * accessibility filter excludes everything inside it. The expansion itself is
+ * Chakra's behaviour, not this component's; what these tests are after is the
+ * slider's own wiring.
+ */
+function expandGroupSlider(name: string) {
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(name) }));
+  return screen.getByRole('slider', { hidden: true });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('the docked panel', () => {
+  it('is a region rather than a modal dialog', () => {
+    renderPanel();
+    // A dialog would trap focus and darken the dials behind it. The editor is
+    // meant to be worked alongside them, not on top of them.
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.getByRole('region', { name: 'Edit Target Values' })).toBeInTheDocument();
+  });
+
+  it('renders a slider for each editable target', () => {
+    renderPanel();
+    expect(screen.getByText('Tree biomass 40-50Mgha')).toBeInTheDocument();
+    expect(expandGroupSlider('Trees')).toBeInTheDocument();
+  });
+
+  it('leaves the sliders enabled while a recalculation runs', async () => {
+    // Never resolves, so the component stays in its "recalculating" state for
+    // the whole assertion.
+    const onSiteIndicatorsChange = vi.fn(() => new Promise<void>(() => {}));
+    renderPanel({ onSiteIndicatorsChange });
+
+    const slider = expandGroupSlider('Trees');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(onSiteIndicatorsChange).toHaveBeenCalled();
+
+    // The disabling was the "redraw": it moved focus off the thumb and took
+    // the scroll position with it.
+    expect(screen.getByRole('slider', { hidden: true })).not.toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('Recalculating…')).toBeInTheDocument();
+  });
+
+  it('does not let a slider grab focus when its value changes', () => {
+    // Chakra focuses a thumb on every value change, with a bare .focus() that
+    // scrolls it into view. A recalculation cascades into the other sliders'
+    // values, so releasing one drag used to throw focus onto an unrelated
+    // slider and scroll the panel away from where the user was working.
+    renderPanel();
+    const slider = expandGroupSlider('Trees');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(document.activeElement).not.toBe(slider);
+  });
+
+  it('submits only the target the user actually moved', () => {
+    const { onSiteIndicatorsChange } = renderPanel({
+      siteIndicators: indicators(5, { [KEY]: 0.08, other: 3 }),
+    });
+    fireEvent.keyDown(expandGroupSlider('Trees'), { key: 'ArrowRight' });
+
+    const submitted = onSiteIndicatorsChange.mock.calls[0][0];
+    // `other` keeps its existing value rather than being resubmitted as an
+    // edit — telling the backend every indicator changed at once derails the
+    // cascade for the one being edited.
+    expect(submitted.ideal.other).toBe(3);
+    expect(submitted.ideal[KEY]).toBeGreaterThan(0.08);
+  });
+});
+
+describe('the live update checkbox', () => {
+  const box = () => screen.getByRole('checkbox', { name: /live update/i });
+
+  it('is ticked by default on a site at or under the threshold', () => {
+    renderPanel({ siteIndicators: indicators(LIVE_UPDATE_CATCHMENT_THRESHOLD) });
+    expect(box()).toBeChecked();
+  });
+
+  it('is unticked by default on a larger site', () => {
+    renderPanel({ siteIndicators: indicators(LIVE_UPDATE_CATCHMENT_THRESHOLD + 1) });
+    expect(box()).not.toBeChecked();
+  });
+
+  it('honours a stored choice over the catchment count, in both directions', () => {
+    saveLiveUpdatePreference(true);
+    renderPanel({ siteIndicators: indicators(400) });
+    expect(box()).toBeChecked();
+    cleanup();
+
+    saveLiveUpdatePreference(false);
+    renderPanel({ siteIndicators: indicators(2) });
+    expect(box()).not.toBeChecked();
+  });
+
+  it('remembers the choice', () => {
+    renderPanel({ siteIndicators: indicators(2) });
+    expect(box()).toBeChecked();
+
+    fireEvent.click(box());
+    expect(box()).not.toBeChecked();
+    // Stateful across sessions: the point of the control is overruling a guess
+    // that does not match the machine or the network, and being asked to
+    // overrule it again on every reload would defeat that.
+    expect(loadLiveUpdatePreference()).toBe(false);
+  });
+});

--- a/frontend/src/test/targetPanel.test.tsx
+++ b/frontend/src/test/targetPanel.test.tsx
@@ -29,15 +29,18 @@ import type { SiteIndicators } from '../types';
 // The panes are irrelevant here and drag in MapView, deck.gl and maplibre.
 vi.mock('../components/ViewPane', () => ({ default: () => <div data-testid="view-pane" /> }));
 
-const KEY = 'prop_X40_50Mgha';
+// An indicator column from metadata.csv, not a credential. Named for what it
+// actually is: when this was called KEY, the opaque-looking string next to that
+// name was enough for gitleaks' generic-api-key rule to report it as a secret.
+const COLUMN = 'prop_X40_50Mgha';
 
 vi.mock('../hooks/useApi', () => ({
-  useAttributeDetails: () => ({ details: { [KEY]: 'Tree biomass 40-50Mgha' } }),
-  useAttributeTargetInputs: () => ({ targetInputs: { [KEY]: true } }),
-  useAttributeUnits: () => ({ units: { [KEY]: 'proportion' } }),
-  useAttributeTargetRanges: () => ({ targetRanges: { [KEY]: { min: 0, max: 1 } } }),
-  useAttributeVariableTypes: () => ({ variableTypes: { [KEY]: 'Trees' } }),
-  useAttributeOrder: () => ({ order: { [KEY]: 1 } }),
+  useAttributeDetails: () => ({ details: { [COLUMN]: 'Tree biomass 40-50Mgha' } }),
+  useAttributeTargetInputs: () => ({ targetInputs: { [COLUMN]: true } }),
+  useAttributeUnits: () => ({ units: { [COLUMN]: 'proportion' } }),
+  useAttributeTargetRanges: () => ({ targetRanges: { [COLUMN]: { min: 0, max: 1 } } }),
+  useAttributeVariableTypes: () => ({ variableTypes: { [COLUMN]: 'Trees' } }),
+  useAttributeOrder: () => ({ order: { [COLUMN]: 1 } }),
 }));
 
 type Props = ComponentProps<typeof ContentArea>;
@@ -49,7 +52,7 @@ type Props = ComponentProps<typeof ContentArea>;
  */
 function indicators(
   catchmentCount: number,
-  values: Record<string, number> = { [KEY]: 0.08 },
+  values: Record<string, number> = { [COLUMN]: 0.08 },
 ): SiteIndicators {
   return {
     reference: Object.fromEntries(Object.keys(values).map((k) => [k, 0.5])),
@@ -156,7 +159,7 @@ describe('the docked panel', () => {
 
   it('submits only the target the user actually moved', () => {
     const { onSiteIndicatorsChange } = renderPanel({
-      siteIndicators: indicators(5, { [KEY]: 0.08, other: 3 }),
+      siteIndicators: indicators(5, { [COLUMN]: 0.08, other: 3 }),
     });
     fireEvent.keyDown(expandGroupSlider('Trees'), { key: 'ArrowRight' });
 
@@ -165,7 +168,7 @@ describe('the docked panel', () => {
     // edit — telling the backend every indicator changed at once derails the
     // cascade for the one being edited.
     expect(submitted.ideal.other).toBe(3);
-    expect(submitted.ideal[KEY]).toBeGreaterThan(0.08);
+    expect(submitted.ideal[COLUMN]).toBeGreaterThan(0.08);
   });
 });
 


### PR DESCRIPTION
The target editor was a modal overlay. Its entire purpose is watching the dials,
charts and maps answer a slider — and the overlay covered exactly what it was
meant to show. Worse, every slider move disabled the whole form behind a
full-bleed spinner, so focus moved, the scroll position followed, and you had to
find your place again after each change.

This makes it a docked right-hand panel that recalculates as you drag.

## What changed

**The editor is docked, not overlaid.** It takes the same right-hand slot as the
single-factor controls — opening either dismisses the other — and the views
shrink to make room rather than being covered. Verified in a running browser at
`x=1160, w=440` in a 1600px viewport, `role="region"`, no dialog.

**Sliders stay live during a recalculation.** Progress is a small indicator in
the panel header instead of an overlay. This also lets the focus-parking and
scroll-restoration workarounds go — they existed only to paper over the
disabling.

**A new Live update checkbox decides when the recalculation runs.** Ticked, the
sliders and the charts behind them recalculate continuously as you drag;
cleared, they wait for release. Because a recalculation rescores every catchment
in the site, the default follows the site's size — on at or below 20 catchments,
off above it. An explicit tick or untick is remembered across sites and sessions
and overrules the count from then on, because the point of the control is
overruling a guess that does not match the machine, the network, or the site in
front of you.

**Live dragging never queues a backlog.** At most one request is in flight, and
everything produced while it runs collapses into a single follow-up, so the
sequence converges on the value the pointer was released at.

Measured against a running server, dragging one slider through twelve pointer
moves:

| Mode | Requests during the drag | After release |
| --- | --- | --- |
| Live **off** | 0 | 1 |
| Live **on** | 4 | 1 |

## Fixes that came with it

**The dials no longer flicker.** Every value change replayed the dial's *entry*
animation, and the two progress values that animation drives are wired to
`opacity` throughout the widget — so each change faded the whole dial out and
back in. Editing one target at a time that was a blink; under live editing it is
a strobe. The reveal now runs only when a dial appears; a value change eases the
needle to its new angle, and a rescale redraws at the new scale.

The needle's easing is `easeOutBack`, which deliberately overshoots so the
needle springs onto its mark. That is right for an angle and wrong for an
opacity — the reveal was briefly asking for a **negative** opacity. The overshoot
now applies to the angle only.

**A dial whose own values did not change is no longer redrawn.** Editing a target
replaces the whole indicators object, so all six dials re-rendered on every
recalculation. `DialChart` is memoised on its props, which are all primitives or
stable callbacks.

Measured over a live drag, across the 60 SVGs on screen:

| | Before | After |
| --- | --- | --- |
| Dials that redrew | — | **1 of 60** |
| Mutated attributes on that dial | 1436 | **2** |
| Minimum opacity seen | −0.013 | **0.5** (a static style value) |

**Releasing a drag no longer throws focus onto another slider and scrolls the
panel to it.** Chakra focuses a slider's thumb whenever its *value* changes,
with a bare `.focus()` that scrolls the element into view. A recalculation
cascades into the other sliders' values, so letting go of one slider sent the
panel off to an unrelated one. Focus now moves deliberately, on pointer down, to
the slider actually being used, and without scrolling. Measured: 0 focus changes
during a twelve-move drag.

**Dragging a target back to where it started now clears it.** The editor diffed
against the values it opened with and skipped anything that matched, so a slider
returned to its opening position submitted nothing and the target set a moment
earlier stayed in place with no way to undo it. It now tracks which sliders were
actually touched. Live dragging made this much easier to hit, since you drag
through the origin continuously.

**The panel heading no longer sits under the top bar.** It offset itself by a
hard-coded 70px inherited from the control panel; the header is content-sized
and is actually 94px. It is now measured.

**The coalescing scheduler no longer leaks an unhandled rejection** on a failed
request, which would also have left the panel lit as recalculating forever. Found
by a test, not by hand.

## Testing

24 new tests. The scheduler is extracted into `lib/liveTargetUpdate.ts` rather
than left inline in the component, because "at most one in flight, converge on
the last" is non-trivial async behaviour that deserves to be tested on its own —
and because the live/deferred distinction cannot be driven through Chakra's
slider under jsdom, where keyboard input fires `onChange` and `onChangeEnd`
together.

- `liveTargetUpdate.test.ts` — the size-derived default, the stored preference
  overruling it in both directions, unreadable storage, and the scheduler:
  coalescing a burst into first-and-last, never more than one request open,
  one busy signal per burst rather than per request, and surviving a failure
  without wedging or dropping what was queued behind it.
- `targetPanel.test.tsx` — a region rather than a dialog, sliders enabled during
  a recalculation, no focus stealing, only touched targets submitted, and the
  checkbox default and its persistence.

Beyond the suite: `tsc`, `eslint --max-warnings 0`, `go build ./...`, every Go
package, and `sync-flake.sh --check`.

## Two things worth a reviewer's attention

**Scope.** This is one PR doing two things — the panel, and the dial fixes —
deliberately, and reviewed as such. The dial problems were invisible until live
update made the widgets redraw several times a second, and the feature without
them is a strobe; splitting would put a known-bad intermediate state on main.

**A scroll caveat, stated plainly.** I confirmed the *cause* of the scroll jump
(focus theft, now measured at zero) rather than measuring scroll position
directly — the probe returned null because the accordion content did not
overflow in the pane configuration I tested. If it still drifts in a taller
group, that needs another look.

## Follow-ups filed separately

Two problems found while testing this, neither caused by it, both predating it:

- Target-state Net Primary Productivity goes negative, because `workflowMeanTC`
  pushes class proportions negative by design and the NPP sum is never clamped
  against its declared `Target_min = 0`.
- Current state appears to change when a target is edited. The backend provably
  never writes `current`; the confirmed mechanism is the dial's axis rescaling
  once a target becomes defined.
