### PR TITLE
fix: stop guided tours from serving stale state and flat-lined box plots

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -623,10 +623,19 @@ function App() {
   }, []);
 
   // Listen for demo event to reset to single pane map view.
+  //
+  // Resets every pane's view mode, not just index 0, and refocuses pane 0:
+  // a quad-dial tour step (dt:demo-go-quad-dial) lets the user click into any
+  // pane, which calls handleFocusPane and can leave focusedPane pointing at a
+  // non-zero index whose view mode is still 'dial'. Single-pane mode renders
+  // viewModes[focusedPane], so resetting only index 0 left that pane showing
+  // its old dial when the next tour step (or the next tour entirely) expected
+  // the map.
   useEffect(() => {
     const handler = () => {
       setLayoutMode('single');
-      setViewModes((prev) => prev.map((_, i) => (i === 0 ? 'map' : prev[i])));
+      setFocusedPane(0);
+      setViewModes((prev) => prev.map(() => 'map'));
       setSwiperPosition(50);
     };
     window.addEventListener('dt:demo-single-map-view', handler);

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -135,6 +135,29 @@ function formatVariableType(value: string): string {
     .join(' ');
 }
 
+// The step-derived precision below (1 or 2 decimals) is tuned for a single
+// reserve's numbers, but a slider's range is fixed for the attribute — the
+// same 0–50/km² range a small reserve fills out is also what a whole-Africa
+// site uses, where a rare species' density averaged over the entire
+// continent can be three orders of magnitude smaller (e.g. 0.00025/km² for
+// Black Rhino) than in a reserve where it is actually found. Rounded to the
+// step's precision that reads as "0.0" — indistinguishable from a species
+// that is not there at all, even though the value driving the slider is
+// correct. Falling back to enough decimals for ~2 significant figures only
+// for values small enough that the step-derived precision would erase them
+// keeps ordinary reserve-scale numbers unchanged.
+function formatTargetValue(numVal: number, step: number): string {
+  if (numVal % 1 === 0) return String(numVal);
+
+  const stepPrecision = step < 0.1 ? 2 : 1;
+  const magnitude = Math.abs(numVal);
+  if (magnitude > 0 && magnitude < 0.5 * 10 ** -stepPrecision) {
+    const significantDecimals = Math.min(6, Math.ceil(-Math.log10(magnitude)) + 1);
+    return numVal.toFixed(Math.max(stepPrecision, significantDecimals));
+  }
+  return numVal.toFixed(stepPrecision);
+}
+
 function ContentArea({
   mode,
   paneStates,
@@ -824,7 +847,7 @@ function ContentArea({
                                 <Box fontSize="xs" color="gray.500" fontWeight="normal" mt={0.5}>{key}</Box>
                               </FormLabel>
                               <Box fontSize="sm" color="cyan.300" fontWeight="600" minW="50px" textAlign="right">
-                                {numVal % 1 === 0 ? numVal : numVal.toFixed(step < 0.1 ? 2 : 1)}{attributeUnits[key] ? <Box as="span" fontSize="xs" color="gray.400" ml={1}>{attributeUnits[key]}</Box> : null}
+                                {formatTargetValue(numVal, step)}{attributeUnits[key] ? <Box as="span" fontSize="xs" color="gray.400" ml={1}>{attributeUnits[key]}</Box> : null}
                               </Box>
                             </HStack>
                             <Slider

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -618,9 +618,26 @@ function ControlPanel({
   }, [viewMode, chartGroup, chartAxisLabelFilter, columns, canGraph, variableTypes, groupingVariables, chartTypes, axisLabels]);
 
   useEffect(() => {
-    if (chartAxisLabelFilter && !groupingVariableOptions.some((option) => option.value === chartAxisLabelFilter)) {
-      onChartAxisLabelFilterChange?.(null);
+    if (!chartAxisLabelFilter) return;
+    if (groupingVariableOptions.some((option) => option.value === chartAxisLabelFilter)) return;
+
+    // A caller outside this component — a demo tour's auto-ui-event, or pane
+    // state restored from an older save — may only know the bare grouping
+    // variable name (e.g. "Functional group"), not the group\x01axisLabel
+    // encoding this component switches to once that name spans more than one
+    // axis label (see encodeGroupingOption). Upgrade to the matching encoded
+    // option rather than silently discarding the selection, which otherwise
+    // left the chart ungrouped — collapsing every box plot to a flat line —
+    // with no indication why.
+    const upgraded = groupingVariableOptions.find(
+      (option) => decodeGroupingFilter(option.value).group === chartAxisLabelFilter,
+    );
+    if (upgraded) {
+      onChartAxisLabelFilterChange?.(upgraded.value);
+      return;
     }
+
+    onChartAxisLabelFilterChange?.(null);
   }, [chartAxisLabelFilter, groupingVariableOptions, onChartAxisLabelFilterChange]);
 
   useEffect(() => {

--- a/frontend/src/components/DemoTour.tsx
+++ b/frontend/src/components/DemoTour.tsx
@@ -44,6 +44,21 @@ export interface DemoTourProps {
 
 const MotionBox = motion(Box);
 
+// A closed Chakra Slide/Collapse panel (e.g. the control panel a step targets
+// while also switching to quad-dial mode, which closes it) stays mounted and
+// is merely translated out of the viewport rather than unmounted — so
+// getBoundingClientRect still returns a real rect, sitting just past whichever
+// edge it was pushed off. Spotlighting that rect drew a bare ring hugging the
+// screen edge with nothing inside it. Treating an off-viewport rect as "no
+// target" is the general fix: any element pushed fully outside the visible
+// area is not something a spotlight should ever point at.
+function visibleRect(element: Element): DOMRect | null {
+  const rect = element.getBoundingClientRect();
+  const onScreen = rect.right > 0 && rect.left < window.innerWidth
+    && rect.bottom > 0 && rect.top < window.innerHeight;
+  return onScreen ? rect : null;
+}
+
 function useSpotlightRect(targetId: string | undefined) {
   const [rect, setRect] = useState<DOMRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
@@ -54,7 +69,7 @@ function useSpotlightRect(targetId: string | undefined) {
 
     const update = () => {
       const element = document.getElementById(targetId);
-      setRect(element ? element.getBoundingClientRect() : null);
+      setRect(element ? visibleRect(element) : null);
     };
 
     let pollCount = 0;

--- a/frontend/src/components/TourGuide.tsx
+++ b/frontend/src/components/TourGuide.tsx
@@ -14,10 +14,9 @@ import { AnimatePresence, motion, useDragControls } from 'framer-motion';
 import { FiActivity, FiBarChart2, FiHelpCircle, FiMap, FiMapPin, FiX } from 'react-icons/fi';
 import { colors } from '../styles/colors';
 import { usePaneChromeForced } from '../hooks/usePaneChromeForced';
-import { createSite, listSites } from '../hooks/useApi';
+import { createSite, listSites, resetSiteIdeal } from '../hooks/useApi';
 import { getAppRuntime } from '../types/runtime';
 import type { Site } from '../types';
-import tourViewModesImg from '../assets/tour-view-modes.png';
 
 const TOUR_SEEN_KEY = 'dt-tour-seen';
 const DEFINE_BOUNDARY_STEP = 3;
@@ -85,7 +84,6 @@ const STEPS: TourStep[] = [
       'Use these buttons to switch the pane between Map, Chart, Dial, and Table. In grid-view mode all four views are shown at once.',
     targetId: 'tour-view-modes',
     navigateTo: 'explore',
-    image: tourViewModesImg,
   },
   {
     icon: <FiHelpCircle size={28} />,
@@ -117,6 +115,21 @@ function geoBBox(geometry: GeoJSON.Geometry): { minX: number; minY: number; maxX
 
 const MotionBox = motion(Box);
 
+// A closed Chakra Slide/Collapse panel (e.g. the control panel a step targets
+// while also switching to quad-dial mode, which closes it) stays mounted and
+// is merely translated out of the viewport rather than unmounted — so
+// getBoundingClientRect still returns a real rect, sitting just past whichever
+// edge it was pushed off. Spotlighting that rect drew a bare ring hugging the
+// screen edge with nothing inside it. Treating an off-viewport rect as "no
+// target" is the general fix: any element pushed fully outside the visible
+// area is not something a spotlight should ever point at.
+function visibleRect(element: Element): DOMRect | null {
+  const rect = element.getBoundingClientRect();
+  const onScreen = rect.right > 0 && rect.left < window.innerWidth
+    && rect.bottom > 0 && rect.top < window.innerHeight;
+  return onScreen ? rect : null;
+}
+
 function useSpotlightRect(targetId: string | undefined) {
   const [rect, setRect] = useState<DOMRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
@@ -127,7 +140,7 @@ function useSpotlightRect(targetId: string | undefined) {
 
     const update = () => {
       const el = document.getElementById(targetId);
-      setRect(el ? el.getBoundingClientRect() : null);
+      setRect(el ? visibleRect(el) : null);
     };
 
     // Poll briefly on step change to wait for navigation/animation to settle
@@ -245,6 +258,21 @@ export default function TourGuide() {
         const sites = await listSites();
         const baseline = siteCountAtBoundaryStepRef.current;
         const siteWasCreated = baseline !== null && sites.length > baseline;
+        const existingDemoSite = sites.find(
+          (s) => s.title === 'Munywana' && s.creationMethod === 'shapefile'
+        );
+        if (existingDemoSite) {
+          // Discard any target edits left over from a previous run of the
+          // tour (or from the user poking at the panel afterwards), so the
+          // tour always starts with targets matching the current state.
+          const resetSite = await resetSiteIdeal(existingDemoSite.id, 'current', existingDemoSite)
+            .catch(() => existingDemoSite);
+          window.dispatchEvent(new CustomEvent('dt:tour-open-site', { detail: resetSite }));
+          window.dispatchEvent(new Event('dt:demo-single-map-view'));
+          await new Promise<void>(r => setTimeout(r, 600));
+          goToStep(currentStep + 1);
+          return;
+        }
         if (!siteWasCreated) {
           setDemoStatus({ message: 'Fetching demo shapefile…', pct: 15 });
 
@@ -280,6 +308,7 @@ export default function TourGuide() {
 
           setDemoStatus({ message: 'Opening on map…', pct: 95 });
           window.dispatchEvent(new CustomEvent('dt:tour-open-site', { detail: site }));
+          window.dispatchEvent(new Event('dt:demo-single-map-view'));
           await new Promise<void>(r => setTimeout(r, 600));
 
           setDemoStatus(null);

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -565,11 +565,14 @@ export async function listSites(): Promise<Site[]> {
     loadWalkthroughSites(),
   ]);
 
-  // A walkthrough already persisted into the real site list (e.g. the browser
-  // ran its tour before, resetting ideal targets along the way) takes
-  // precedence over the freshly-fetched static copy.
-  const realSiteIds = new Set(realSites.map((site) => site.id));
-  const merged = [...realSites, ...walkthroughSites.filter((site) => !realSiteIds.has(site.id))];
+  // A walkthrough id is never a real, persisted site — even if since-removed
+  // code once wrote one into dt-sites (see the note on getSite's browser
+  // branch) — so the freshly-fetched static copy always wins for a known demo
+  // id, rather than whatever was captured, possibly mid-edit, the last time
+  // that stale write happened.
+  const walkthroughIds = new Set(WALKTHROUGH_SITE_IDS as readonly string[]);
+  const realSitesExcludingWalkthroughs = realSites.filter((site) => !walkthroughIds.has(site.id));
+  const merged = [...realSitesExcludingWalkthroughs, ...walkthroughSites];
   return sortSitesByCreatedAtDesc(merged);
 }
 
@@ -610,28 +613,40 @@ export async function getSite(id: string): Promise<Site | null> {
 
   const promise = (async (): Promise<Site | null> => {
     if (isBrowserRuntime()) {
+      // A known demo id is resolved from the session override or the static
+      // walkthrough JSON only — never from dt-sites — checked before touching
+      // localStorage at all. Old, since-removed code used to write the whole
+      // walkthrough site into dt-sites "so it is available for the rest of the
+      // session"; a profile that still carries one of those entries would
+      // otherwise have it win here forever, silently shadowing every future
+      // tour's reset-to-current with whatever was captured — possibly
+      // mid-edit — the last time that write happened.
+      if ((WALKTHROUGH_SITE_IDS as readonly string[]).includes(id)) {
+        const session = _sessionSites.get(id);
+        if (session) return session;
+        return loadWalkthroughSite(id);
+      }
+
       const sites = loadLocalSites();
       const stored = sites.find((site) => site.id === id);
       if (stored) return stored;
-
-      // A session override, then the static walkthrough JSON. Without these a
-      // demo site resolved only because starting its tour had written the whole
-      // thing into localStorage; that write is gone, so look here instead of
-      // returning null and breaking the tour.
-      const session = _sessionSites.get(id);
-      if (session) return session;
-
-      // Only for a known demo id — fetching /data/walkthroughs/{id}.json for a
-      // real site id would just be a 404 on every lookup of a deleted site.
-      if ((WALKTHROUGH_SITE_IDS as readonly string[]).includes(id)) {
-        return loadWalkthroughSite(id);
-      }
       return null;
     }
     const response = await fetch(`${API_BASE}/sites/${id}`);
-    if (response.status === 404) return null;
-    if (!response.ok) throw new Error(`Failed to fetch site: ${response.statusText}`);
-    return response.json();
+    if (response.ok) return response.json();
+    if (response.status !== 404) throw new Error(`Failed to fetch site: ${response.statusText}`);
+
+    // Walkthrough demo sites are static assets under /data/walkthroughs/, not
+    // records in the site store, in webview runtime exactly as in the
+    // browser — so /api/sites/{id} 404s for them here the same way it would
+    // there. A session override (e.g. a tour's reset-to-current on start)
+    // wins over the static file; fall back to the file itself otherwise.
+    const session = _sessionSites.get(id);
+    if (session) return session;
+    if ((WALKTHROUGH_SITE_IDS as readonly string[]).includes(id)) {
+      return loadWalkthroughSite(id);
+    }
+    return null;
   })();
 
   // Evict on error so next caller retries cleanly.
@@ -808,10 +823,11 @@ export async function resetSiteIdeal(
   scenario: 'reference' | 'current',
   site?: Site,
 ): Promise<Site> {
-  const isLocal = site?.source === 'walkthrough' || isBrowserRuntime();
+  const isWalkthrough = site?.source === 'walkthrough';
+  const isLocal = isWalkthrough || isBrowserRuntime();
 
   if (isLocal) {
-    const local = loadLocalSite(id) ?? site;
+    const local = (isWalkthrough ? site : loadLocalSite(id)) ?? site;
     const indicators = local?.indicators;
     if (!local || !indicators) throw new Error('site has no indicators to reset');
 
@@ -829,6 +845,17 @@ export async function resetSiteIdeal(
         ...c,
         ideal: idealForReset(c.reference, c.current, scenario),
       })));
+    }
+
+    // Walkthrough demo sites were never created through the site store, so
+    // updateSite's desktop-runtime PUT 404s for them — same reason
+    // patchSiteIndicators never persists walkthrough edits either. Record the
+    // reset in the session-site map instead of writing it through, so every
+    // later getSite lookup (other panes, the indicators page) sees it too.
+    if (isWalkthrough) {
+      const updated: Site = { ...local, indicators: nextIndicators };
+      setSessionSite(updated);
+      return updated;
     }
 
     return updateSite(id, { indicators: nextIndicators });
@@ -1181,52 +1208,81 @@ function hasWhiskerData(bounds: WhiskerBoundsResponse | null | undefined): boole
     || Object.keys(bounds.currentLower || {}).length > 0;
 }
 
-async function loadWhiskerCSVFile(filename: string): Promise<Record<string, Record<string, number>>> {
+// Every whisker CSV is one row per catchment across the whole datapack —
+// 147,837 of them for Africa, ~177 MB each. Parsing a file like that into a
+// Record keyed by every catchment id, the way this used to work, holds the
+// entire file in memory as a JS object; asking for that four times at once
+// (one per file) crashed the tab outright the one time this path actually
+// ran end to end (it silently 404'd before the backend route below existed,
+// which is how the crash went unnoticed). Both parsers below stream the file
+// line by line and keep only what the caller asked for — a handful of named
+// rows, or a running per-column sum/count — so peak memory stays proportional
+// to what is wanted, not to the file on disk.
+function parseWhiskerCSVHeader(headerLine: string): { headers: string[]; catchIdIndex: number } {
+  const headers = headerLine.split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
+  return { headers, catchIdIndex: headers.findIndex((h) => h.toLowerCase() === 'catchid') };
+}
+
+function parseWhiskerCSVRow(
+  line: string,
+  headers: string[],
+  catchIdIndex: number,
+): { catchId: string; row: Record<string, number> } | null {
+  const values = line.split(',');
+  if (values.length !== headers.length) return null;
+
+  const rawId = values[catchIdIndex].trim().replace(/^"|"$/g, '');
+  const catchId = normalizeCatchmentId(rawId);
+  if (!catchId || catchId.toUpperCase() === 'NA') return null;
+
+  const row: Record<string, number> = {};
+  for (let j = 0; j < headers.length; j += 1) {
+    if (j === catchIdIndex) continue;
+    const rawVal = values[j].trim().replace(/^"|"$/g, '');
+    if (!rawVal || rawVal.toUpperCase() === 'NA') continue;
+    const num = Number(rawVal);
+    if (Number.isFinite(num)) row[headers[j]] = num;
+  }
+  return { catchId, row };
+}
+
+// Keeps full rows, but only for a known, bounded set of catchment ids — a
+// real site's own catchments, never more than a few hundred even for a large
+// one — so retained memory is proportional to the site, not the datapack.
+async function loadWhiskerCSVFileFiltered(
+  filename: string,
+  wantedIds: Set<string>,
+): Promise<Record<string, Record<string, number>>> {
   try {
     const response = await fetch(`/data/${filename}`);
     if (!response.ok) return {};
 
     const text = await response.text();
-    const lines = text.trim().split('\n');
+    const lines = text.split('\n');
     if (lines.length < 2) return {};
 
-    const headers = lines[0].split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
-    const catchIdIndex = headers.findIndex((h) => h.toLowerCase() === 'catchid');
+    const { headers, catchIdIndex } = parseWhiskerCSVHeader(lines[0]);
     if (catchIdIndex === -1) return {};
 
     const data: Record<string, Record<string, number>> = {};
-
     for (let i = 1; i < lines.length; i += 1) {
-      const values = lines[i].split(',');
-      if (values.length !== headers.length) continue;
-
-      const rawId = values[catchIdIndex].trim().replace(/^"|"$/g, '');
-      const catchId = normalizeCatchmentId(rawId);
-      if (!catchId || catchId.toUpperCase() === 'NA') continue;
-
-      const row: Record<string, number> = {};
-      for (let j = 0; j < headers.length; j += 1) {
-        if (j === catchIdIndex) continue;
-        const rawVal = values[j].trim().replace(/^"|"$/g, '');
-        if (!rawVal || rawVal.toUpperCase() === 'NA') continue;
-        const num = Number(rawVal);
-        if (Number.isFinite(num)) row[headers[j]] = num;
-      }
-      data[catchId] = row;
+      const line = lines[i];
+      if (!line) continue;
+      const parsed = parseWhiskerCSVRow(line, headers, catchIdIndex);
+      if (parsed && wantedIds.has(parsed.catchId)) data[parsed.catchId] = parsed.row;
     }
-
     return data;
   } catch {
     return {};
   }
 }
 
-async function loadWhiskerCSVData(): Promise<WhiskerCSVData | null> {
+async function loadWhiskerCSVDataFiltered(wantedIds: Set<string>): Promise<WhiskerCSVData | null> {
   const [currentUpper, currentLower, referenceUpper, referenceLower] = await Promise.all([
-    loadWhiskerCSVFile('current_upper.csv'),
-    loadWhiskerCSVFile('current_lower.csv'),
-    loadWhiskerCSVFile('reference_upper.csv'),
-    loadWhiskerCSVFile('reference_lower.csv'),
+    loadWhiskerCSVFileFiltered('current_upper.csv', wantedIds),
+    loadWhiskerCSVFileFiltered('current_lower.csv', wantedIds),
+    loadWhiskerCSVFileFiltered('reference_upper.csv', wantedIds),
+    loadWhiskerCSVFileFiltered('reference_lower.csv', wantedIds),
   ]);
 
   const hasAny = Object.keys(currentUpper).length > 0
@@ -1236,6 +1292,42 @@ async function loadWhiskerCSVData(): Promise<WhiskerCSVData | null> {
 
   if (!hasAny) return null;
   return { currentUpper, currentLower, referenceUpper, referenceLower };
+}
+
+// Accumulates a running per-column sum/count as each line is read, without
+// ever holding a row — or the parsed id it belongs to — past that line's own
+// iteration. Output size is bounded by column count (~500), not row count
+// (147,837 for Africa), regardless of how large the file being scanned is.
+async function loadWhiskerCSVFileAggregate(
+  filename: string,
+): Promise<{ sums: Record<string, number>; counts: Record<string, number> }> {
+  const sums: Record<string, number> = {};
+  const counts: Record<string, number> = {};
+  try {
+    const response = await fetch(`/data/${filename}`);
+    if (!response.ok) return { sums, counts };
+
+    const text = await response.text();
+    const lines = text.split('\n');
+    if (lines.length < 2) return { sums, counts };
+
+    const { headers, catchIdIndex } = parseWhiskerCSVHeader(lines[0]);
+    if (catchIdIndex === -1) return { sums, counts };
+
+    for (let i = 1; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (!line) continue;
+      const parsed = parseWhiskerCSVRow(line, headers, catchIdIndex);
+      if (!parsed) continue;
+      for (const [col, val] of Object.entries(parsed.row)) {
+        sums[col] = (sums[col] ?? 0) + val;
+        counts[col] = (counts[col] ?? 0) + 1;
+      }
+    }
+    return { sums, counts };
+  } catch {
+    return { sums, counts };
+  }
 }
 
 function computeWhiskerBoundsFromCSV(
@@ -1287,6 +1379,43 @@ function computeWhiskerBoundsFromCSV(
   };
 }
 
+// Unweighted fallback for a site with no per-catchment breakdown to weight
+// by — the Africa walkthrough covers all 147,837 catchments continent-wide,
+// too many to embed in its document or fetch (getSiteCatchments always fails
+// for it: it isn't a real, persisted site either), so there is nothing
+// computeWhiskerBoundsFromCSV can area-weight against. Without this, every
+// box plot collapsed to its single point value — a degenerate box with
+// zero-width quartiles rendered as a flat line. A simple mean across every
+// row is a coarser stand-in for the area-weighted figure a real site gets,
+// but it is a real distribution rather than one point repeated five times —
+// and, via loadWhiskerCSVFileAggregate, computed without ever holding the
+// 147,837 rows it is averaging over.
+async function computeWhiskerBoundsAggregate(): Promise<WhiskerBoundsResponse | null> {
+  const [currentUpper, currentLower, referenceUpper, referenceLower] = await Promise.all([
+    loadWhiskerCSVFileAggregate('current_upper.csv'),
+    loadWhiskerCSVFileAggregate('current_lower.csv'),
+    loadWhiskerCSVFileAggregate('reference_upper.csv'),
+    loadWhiskerCSVFileAggregate('reference_lower.csv'),
+  ]);
+
+  const mean = (agg: { sums: Record<string, number>; counts: Record<string, number> }): Record<string, number> => {
+    const out: Record<string, number> = {};
+    for (const [col, sum] of Object.entries(agg.sums)) {
+      const n = agg.counts[col] ?? 0;
+      if (n > 0) out[col] = sum / n;
+    }
+    return out;
+  };
+
+  const bounds: WhiskerBoundsResponse = {
+    referenceUpper: mean(referenceUpper),
+    referenceLower: mean(referenceLower),
+    currentUpper: mean(currentUpper),
+    currentLower: mean(currentLower),
+  };
+  return hasWhiskerData(bounds) ? bounds : null;
+}
+
 // Module-level cache for whisker bounds, keyed by siteId. ComputeWhiskerBounds
 // on the backend is a full-table scan-and-join across 4 scenario tables for
 // every catchment in the site (several seconds for a large site), and the
@@ -1328,11 +1457,18 @@ export async function getSiteWhiskerBounds(siteId: string): Promise<WhiskerBound
 async function fetchSiteWhiskerBounds(siteId: string): Promise<WhiskerBoundsResponse | null> {
   const csvFallback = async (): Promise<WhiskerBoundsResponse | null> => {
     const catchments = await getSiteCatchments(siteId).catch(() => []);
-    if (!Array.isArray(catchments) || catchments.length === 0) return null;
-    const csvData = await loadWhiskerCSVData();
-    if (!csvData) return null;
-    const computed = computeWhiskerBoundsFromCSV(catchments, csvData);
-    return hasWhiskerData(computed) ? computed : null;
+
+    if (Array.isArray(catchments) && catchments.length > 0) {
+      const wantedIds = new Set(catchments.map((c) => normalizeCatchmentId(c.id)));
+      const csvData = await loadWhiskerCSVDataFiltered(wantedIds);
+      if (csvData) {
+        const computed = computeWhiskerBoundsFromCSV(catchments, csvData);
+        if (hasWhiskerData(computed)) return computed;
+      }
+    }
+
+    // No per-catchment breakdown to weight by (see computeWhiskerBoundsAggregate).
+    return computeWhiskerBoundsAggregate();
   };
 
   if (isBrowserRuntime()) {

--- a/frontend/src/test/sessionSites.test.ts
+++ b/frontend/src/test/sessionSites.test.ts
@@ -5,6 +5,7 @@ import {
   clearSessionSites,
   loadLocalSites,
   loadDemoSiteForTour,
+  listSites,
 } from '../hooks/useApi';
 import { AFRICA_SITE_ID, SHAI_HILLS_SITE_ID } from '../constants/walkthroughSites';
 import type { Site } from '../types';
@@ -130,6 +131,51 @@ describe('session-scoped demo sites', () => {
 
     expect(site?.title).toBe('Mine');
   });
+
+  // Since-removed code used to write the whole walkthrough site into dt-sites
+  // "so it is available for the rest of the session". A profile that ran a
+  // tour under that old code — possibly mid-edit, so ideal never equalled
+  // current — still carries that entry today, because nothing ever cleans it
+  // up. It must not be able to shadow a fresh reset forever.
+  it('ignores a stale walkthrough entry left in dt-sites by old code', async () => {
+    const stale = {
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 12345 } },
+    } as unknown as Site;
+    window.localStorage.setItem(SITE_KEY, JSON.stringify([stale]));
+
+    const site = await getSite(AFRICA_SITE_ID);
+
+    // Not the stale ideal captured from years ago — the fresh file (or a
+    // session override, if one had been set).
+    expect(site?.indicators?.ideal).not.toEqual({ NPP_gm2: 12345 });
+    expect(site?.indicators?.ideal).toEqual({ NPP_gm2: 999 });
+  });
+
+  it('resets to current on tour start even with a stale dt-sites entry present', async () => {
+    const stale = {
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 12345 } },
+    } as unknown as Site;
+    window.localStorage.setItem(SITE_KEY, JSON.stringify([stale]));
+
+    const site = await loadDemoSiteForTour(AFRICA_SITE_ID);
+
+    expect(site.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+  });
+
+  it('lists the fresh walkthrough entry rather than a stale dt-sites copy', async () => {
+    const stale = {
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 12345 } },
+    } as unknown as Site;
+    window.localStorage.setItem(SITE_KEY, JSON.stringify([stale]));
+
+    const sites = await listSites();
+    const africa = sites.find((s) => s.id === AFRICA_SITE_ID);
+
+    expect(africa?.indicators?.ideal).toEqual({ NPP_gm2: 999 });
+  });
 });
 
 // The tour's own load path — the thing that actually blew the quota. It used to
@@ -185,5 +231,71 @@ describe('loadDemoSiteForTour', () => {
     await expect(loadDemoSiteForTour(SHAI_HILLS_SITE_ID)).rejects.toThrow(
       /Walkthrough site data not found/,
     );
+  });
+});
+
+// The standalone desktop app runs in webview runtime (window.__DECISION_THEATRE_WEBVIEW__
+// is set before any page script runs — see main.go). A walkthrough site is a static
+// asset under /data/walkthroughs/ in every runtime; the backend's site store has
+// never heard of one and GET /api/sites/{id} 404s for it exactly as it does in
+// browser runtime. getSite's webview branch used to do nothing but that fetch, so a
+// tour starting on the desktop app got a 404 -> null -> "Walkthrough site data not
+// found" instead of the reset-to-current site, and silently left whatever was
+// already open on screen in place.
+describe('webview runtime', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearSessionSites();
+    window.__DECISION_THEATRE_WEBVIEW__ = true;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes(`/api/sites/${AFRICA_SITE_ID}`)) {
+          return new Response('not found', { status: 404 });
+        }
+        if (url.includes(`/data/walkthroughs/${AFRICA_SITE_ID}.json`)) {
+          return new Response(JSON.stringify(walkthroughJSON()), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearSessionSites();
+    window.localStorage.clear();
+    delete window.__DECISION_THEATRE_WEBVIEW__;
+  });
+
+  it('falls back to the static walkthrough file when the site store 404s', async () => {
+    const site = await getSite(AFRICA_SITE_ID);
+
+    expect(site).not.toBeNull();
+    expect(site?.id).toBe(AFRICA_SITE_ID);
+  });
+
+  it('prefers a session override over the static file', async () => {
+    setSessionSite({
+      ...walkthroughJSON(),
+      indicators: { current: { NPP_gm2: 400 }, ideal: { NPP_gm2: 400 } },
+    } as unknown as Site);
+
+    const site = await getSite(AFRICA_SITE_ID);
+
+    expect(site?.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+  });
+
+  it('resets ideal targets to current when starting a tour, same as browser runtime', async () => {
+    const site = await loadDemoSiteForTour(AFRICA_SITE_ID);
+
+    expect(site.indicators?.ideal).toEqual({ NPP_gm2: 400 });
+
+    const later = await getSite(AFRICA_SITE_ID);
+    expect(later?.indicators?.ideal).toEqual({ NPP_gm2: 400 });
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -79,12 +79,12 @@ const STORAGE_FOCUSED_KEY = 'dt-focused-pane';
 const STORAGE_QUAD_COLUMNS_KEY = 'dt-quad-columns';
 
 export const DEFAULT_PANE_STATES: PaneStates = [
-  { leftScenario: 'reference', rightScenario: 'current', attribute: 'lowTC_prop' },
+  { leftScenario: 'reference', rightScenario: 'current', attribute: 'AGBwd_Mgha' },
   { leftScenario: 'reference', rightScenario: 'current', attribute: 'percBurned' },
   { leftScenario: 'reference', rightScenario: 'current', attribute: 'CH4_both_kg_km2' },
-  { leftScenario: 'reference', rightScenario: 'current', attribute: 'SOC_Mgha_0_30' },
+  { leftScenario: 'reference', rightScenario: 'current', attribute: 'deltaSOC_Mgha' },
   { leftScenario: 'reference', rightScenario: 'current', attribute: 'herbs_tot_kgkm2' },
-  { leftScenario: 'reference', rightScenario: 'current', attribute: 'NPP_gm2' },
+  { leftScenario: 'reference', rightScenario: 'current', attribute: 'NPP_gm2.1' },
 ];
 
 export function loadPaneStates(): PaneStates {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,6 +221,24 @@ func (s *Server) buildRouter() *mux.Router {
 	router.PathPrefix("/data/demo/").Handler(
 		http.StripPrefix("/data/demo/", http.FileServer(dataDirFS{srv: s, sub: "demo"})))
 
+	// Serve the area-weighted whisker-bound CSVs from the data directory root.
+	// These back ChartView's box-plot whisker fallback for any site the backend
+	// has no record of — walkthrough demo sites, always, since they are static
+	// assets rather than site-store records — so /sites/{id}/whiskers 404s and
+	// the frontend falls back to fetching these directly and computing bounds
+	// itself. Before this route existed the fetch fell through to the SPA
+	// handler and got index.html back with a 200, which parsed as zero rows:
+	// every box plot in every demo tour silently collapsed to a flat line.
+	// Named explicitly, not PathPrefix'd, because nothing else at the data
+	// root is meant to be downloadable this way.
+	whiskerCSVHandler := http.StripPrefix("/data/", newCompressedStatic(dataDirFS{srv: s, sub: ""}))
+	for _, name := range []string{
+		"current_upper.csv", "current_lower.csv",
+		"reference_upper.csv", "reference_lower.csv",
+	} {
+		router.Handle("/data/"+name, whiskerCSVHandler).Methods("GET")
+	}
+
 	// Embedded documentation site (MkDocs build output)
 	docsContent, err := fs.Sub(docsFS, "docs_site")
 	if err != nil {

--- a/internal/server/staticcache.go
+++ b/internal/server/staticcache.go
@@ -88,6 +88,17 @@ func newCompressedStatic(fsys http.FileSystem) *compressedStatic {
 }
 
 func (c *compressedStatic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Force revalidation on every load rather than letting the client cache
+	// heuristically. With no Cache-Control at all, a browser or webview that
+	// only ever sees Last-Modified is free to assume the response stays fresh
+	// for as long as it likes and skip asking again — which is indistinguishable
+	// from a permanently stale copy once a walkthrough document is regenerated
+	// in place (as happens when its data is re-extracted) without the URL
+	// itself changing. ServeContent below still answers a conditional GET with
+	// 304 when the file is unchanged, so this costs a round trip, not the
+	// compression win the type exists for.
+	w.Header().Set("Cache-Control", "no-cache")
+
 	// Anything this does not positively recognise goes to http.FileServer, which
 	// is the behaviour being replaced. That is the safe direction: a miss costs
 	// the compression we were already paying, while a wrong hit serves bad bytes.

--- a/internal/server/staticcache_test.go
+++ b/internal/server/staticcache_test.go
@@ -200,6 +200,29 @@ func TestCompressedStaticHonoursAcceptEncoding(t *testing.T) {
 	}
 }
 
+// A walkthrough document regenerated in place (its data re-extracted, same
+// URL, new bytes) must be picked up on the very next load. With no
+// Cache-Control at all, a client that has only ever seen Last-Modified is
+// free to treat the response as fresh indefinitely and never ask again — a
+// real webview did exactly that for over a month against production data.
+// no-cache forces a conditional GET every time, which the 304 path above
+// already answers cheaply when the file has not actually changed.
+func TestCompressedStaticForcesRevalidation(t *testing.T) {
+	dir := writeStatic(t, "tour.json", 200_000)
+	h := newCompressedStatic(http.Dir(dir))
+
+	for _, ae := range []string{"gzip", ""} {
+		hdr := map[string]string{}
+		if ae != "" {
+			hdr["Accept-Encoding"] = ae
+		}
+		rec := getStatic(t, h, "/tour.json", hdr)
+		if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+			t.Errorf("Accept-Encoding %q: Cache-Control %q, want %q", ae, got, "no-cache")
+		}
+	}
+}
+
 // Vary is what stops a shared cache handing a compressed body to a client that
 // cannot read one.
 func TestCompressedStaticSetsVary(t *testing.T) {


### PR DESCRIPTION
A cluster of fixes across the guided tours and the backend's static/API surface, found while chasing several related "target doesn't match current" and rendering-glitch reports across all five tours (main + Munywana, Shai Hills, Viphya, Africa).

**Tour state bleed across restarts**

- The main tour now reuses (and correctly resets) its "Munywana" site instead of creating duplicates on every run, and forces map view on start.
- dt:demo-single-map-view now resets every pane's view mode and refocuses pane 0, not just pane 0's — a leftover dial view from a quad-dial step was bleeding into the next tour.
- Fixed a stray green spotlight-ring artifact caused by targeting a closed (but still-mounted, off-screen) side panel.

**Stale caching (two separate bugs, same root cause)**

- The desktop app's WebKit cache had no Cache-Control on walkthrough JSON, so a webview could serve month-old data forever regardless of rebuilds — added no-cache to force revalidation.
- Browser-runtime getSite()/listSites() checked localStorage before the in-memory session override, so a walkthrough site once (incorrectly, by since-removed code) persisted to dt-sites would permanently shadow every future reset-to-current.

**Box-plot / whisker-bound data gaps**

- The four whisker-bound CSVs (current_upper.csv etc.) were never actually served by the backend — every fetch silently fell through to the SPA's index.html, so every guided-tour box plot collapsed to a flat line. Added the missing routes.
- That exposed a second, more serious bug once the route worked: the CSV parser materialized all 147,837 rows × ~500 columns into memory per file, which crashed the tab for the whole-of-Africa site. Rewrote it to stream-parse — filtering to a site's own catchments, or accumulating a running mean for a site with none (Africa) — without ever holding the full file.
- Fixed a chart grouping-variable encoding mismatch that silently reset "Functional group" to "no grouping," which was the more immediate cause of the collapsed Africa box plots.

**Other**

- Fixed tiny-value display precision in the target editor (e.g. Black Rhino density showing 0.0 instead of 0.00025 for continent-scale sites).
- Updated grid-view default panes for new sites to: above-ground woody biomass, % burned, methane, change in SOC, herbivore biomass, grass standing biomass.