### PR TITLE
fix: stop the container health check from failing without curl

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -66,11 +66,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        # For the compose healthcheck. Debian slim ships neither curl nor
-        # wget, and without one docker has no way to ask whether this process
-        # is answering — only whether it has exited, which a wedged server has
-        # not.
-        curl \
         jq \
         libgtk-3-0 \
         libwebkit2gtk-4.1-0 \

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -52,7 +52,12 @@ services:
     # restart: unless-stopped only reacts to a process that exited. This is how
     # a process that is still running but no longer answering gets noticed.
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/health"]
+      # decision-theatre healthcheck rather than curl: the release image is
+      # built from the Nix flake, which carries only this binary's own
+      # runtime closure and no HTTP client. Using the app's own subcommand
+      # means one healthcheck command works against both that image and the
+      # one this Dockerfile builds.
+      test: ["CMD", "decision-theatre", "healthcheck", "--port", "8080"]
       # Generous: a cold start loads and indexes the datapack, and a health
       # check that fails during startup would restart the container forever.
       # start_period covers that window without weakening the steady-state check.

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
           # frontend/package-lock.json, so ANY change to that file — including
           # the version field — changes this hash. Recompute with:
           #   nix run nixpkgs#prefetch-npm-deps -- frontend/package-lock.json
-          npmDepsHash = "sha256-qCI5cEbDnuC4o4TfHoqZdarFskRRedCWd+ho98c+Tmo=";
+          npmDepsHash = "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=";
 
           # The build script (tsc && vite build) outputs to dist/
           buildPhase = ''
@@ -554,7 +554,7 @@
             inherit version;
             src = ./frontend;
             # Same source as the frontend package, so the same hash.
-            npmDepsHash = "sha256-qCI5cEbDnuC4o4TfHoqZdarFskRRedCWd+ho98c+Tmo=";
+            npmDepsHash = "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=";
             buildPhase = ''
               npm test
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -343,6 +343,12 @@
               # volume at /root/.config/decision-theatre expecting exactly this.
               "HOME=/root"
               "TZ=UTC"
+              # Entrypoint above uses the binary's absolute store path, which
+              # needs no PATH. Docker's HEALTHCHECK does not: it names the
+              # binary by argv[0] ("decision-theatre healthcheck"), resolved
+              # against PATH the same way a shell would, so the store path
+              # must be on it for that lookup to succeed.
+              "PATH=${decision-theatre}/bin"
             ];
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
           # frontend/package-lock.json, so ANY change to that file — including
           # the version field — changes this hash. Recompute with:
           #   nix run nixpkgs#prefetch-npm-deps -- frontend/package-lock.json
-          npmDepsHash = "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=";
+          npmDepsHash = "sha256-UjGkmOXqjEwkSluatKThLi9KcbXS3ixV5TjBcJc/2T8=";
 
           # The build script (tsc && vite build) outputs to dist/
           buildPhase = ''
@@ -554,7 +554,7 @@
             inherit version;
             src = ./frontend;
             # Same source as the frontend package, so the same hash.
-            npmDepsHash = "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=";
+            npmDepsHash = "sha256-UjGkmOXqjEwkSluatKThLi9KcbXS3ixV5TjBcJc/2T8=";
             buildPhase = ''
               npm test
             '';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8993,16 +8993,6 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
-    "node_modules/@types/geojson-vt": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
-      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/geokdbush": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@types/geokdbush/-/geokdbush-1.1.5.tgz",
@@ -9052,25 +9042,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
-      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
-      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "*",
-        "@types/mapbox__point-geometry": "*",
-        "@types/pbf": "*"
-      }
-    },
     "node_modules/@types/matter-js": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@types/matter-js/-/matter-js-0.20.2.tgz",
@@ -9103,13 +9074,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
-    },
-    "node_modules/@types/pbf": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
-      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/polylabel": {
       "version": "1.1.3",
@@ -9152,16 +9116,6 @@
       "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
     },
     "node_modules/@types/svg-arc-to-cubic-bezier": {
       "version": "3.2.3",
@@ -12654,13 +12608,6 @@
         "quickselect": "^1.0.1"
       }
     },
-    "node_modules/geojson-vt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
-      "integrity": "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/geokdbush": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/geokdbush/-/geokdbush-2.0.1.tgz",
@@ -12808,47 +12755,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
-      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ini": "^4.1.3",
-        "kind-of": "^6.0.3",
-        "which": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/global-prefix/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/globals": {
@@ -13357,16 +13263,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/interactjs": {
       "version": "1.10.27",
       "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
@@ -13756,16 +13652,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ktx-parse": {
@@ -14793,41 +14679,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/plotly.js/node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/plotly.js/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
-      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^4.0.0",
-        "minimist": "^1.2.8",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "tinyqueue": "^3.0.0"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/plotly.js/node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/plotly.js/node_modules/d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
@@ -14909,48 +14760,6 @@
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
       "license": "BSD-3-Clause",
       "peer": true
-    },
-    "node_modules/plotly.js/node_modules/maplibre-gl": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
-      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
-        "@types/geojson": "^7946.0.14",
-        "@types/geojson-vt": "3.2.5",
-        "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.0",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
-        "global-prefix": "^4.0.0",
-        "kdbush": "^4.0.2",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.3.0",
-        "potpack": "^2.0.0",
-        "quickselect": "^3.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
-      },
-      "engines": {
-        "node": ">=16.14.0",
-        "npm": ">=8.1.0"
-      },
-      "funding": {
-        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
-      }
     },
     "node_modules/png-js": {
       "version": "1.0.0",
@@ -15987,16 +15796,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
-    },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decision-theatre-frontend",
-  "version": "0.4.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "decision-theatre-frontend",
-      "version": "0.4.0",
+      "version": "2.9.0",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",
         "@deck.gl/core": "^9.2.6",
@@ -14,13 +14,14 @@
         "@deck.gl/mapbox": "^9.2.6",
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.2",
         "@turf/turf": "^7.3.4",
         "@types/geojson": "^7946.0.16",
         "@types/matter-js": "^0.20.2",
         "deck.gl": "^9.2.6",
         "fast-xml-parser": "4.5.5",
         "framer-motion": "^11.15.0",
-        "maplibre-gl": "^4.7.1",
+        "maplibre-gl": "^6.4.1",
         "matter-js": "^0.20.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2445,6 +2446,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
@@ -2461,11 +2463,12 @@
       "peer": true
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
@@ -2491,15 +2494,15 @@
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
-      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
@@ -2516,22 +2519,31 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
-      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.2.tgz",
+      "integrity": "sha512-6J0vZqMZvRAJKtdWJdDGHEh1YJ2ZHG08/GOur8gCArYhO8ZkM//OXqtI2AAEz4jc2G+Wq4MfcePg8qNK5TZ4Kg==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
+        "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -2540,11 +2552,49 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+    "node_modules/@maplibre/mlt": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.1.tgz",
+      "integrity": "sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/mlt/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/@math.gl/core": {
       "version": "4.1.0",
@@ -8948,6 +8998,7 @@
       "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
       "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -9005,13 +9056,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
       "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mapbox__vector-tile": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
       "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -9055,7 +9108,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/polylabel": {
       "version": "1.1.3",
@@ -9104,6 +9158,7 @@
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -9939,6 +9994,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -11627,9 +11691,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
@@ -12591,10 +12655,11 @@
       }
     },
     "node_modules/geojson-vt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
-      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "license": "ISC"
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
+      "integrity": "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/geokdbush": {
       "version": "2.0.1",
@@ -12669,6 +12734,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12749,6 +12815,7 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
       "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^4.1.3",
         "kind-of": "^6.0.3",
@@ -12759,12 +12826,13 @@
       }
     },
     "node_modules/global-prefix/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "license": "ISC",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/global-prefix/node_modules/which": {
@@ -12772,6 +12840,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -13293,6 +13362,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
       "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -13673,9 +13743,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -13693,6 +13763,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13997,37 +14068,29 @@
       "peer": true
     },
     "node_modules/maplibre-gl": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
-      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.9.0.tgz",
+      "integrity": "sha512-vFMwMK0Zs+NM/rOMSdtu8bO30DIexhBEVi5KC6f70/XtI+L/K2wC3LsDCAXFZ4s8ik5gAuDugfCNbpllpdJ9bA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
-        "@types/geojson": "^7946.0.14",
-        "@types/geojson-vt": "3.2.5",
-        "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.0",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
-        "global-prefix": "^4.0.0",
-        "kdbush": "^4.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.2",
+        "@maplibre/mlt": "^1.2.1",
+        "@maplibre/vt-pbf": "^4.3.2",
+        "@types/geojson": "^7946.0.16",
+        "bidi-js": "^1.1.0",
+        "earcut": "^3.2.3",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.3.0",
-        "potpack": "^2.0.0",
+        "pbf": "^5.1.2",
+        "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
+        "tinyqueue": "^3.0.0"
       },
       "engines": {
         "node": ">=16.14.0",
@@ -14035,6 +14098,35 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/marked": {
@@ -14701,6 +14793,41 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/plotly.js/node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/plotly.js/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/plotly.js/node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/plotly.js/node_modules/d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
@@ -14782,6 +14909,48 @@
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/plotly.js/node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
     },
     "node_modules/png-js": {
       "version": "1.0.0",
@@ -15351,6 +15520,15 @@
         "regl-scatter2d": "^3.2.3"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -15451,7 +15629,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -15814,6 +15993,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -17546,6 +17726,7 @@
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
       "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -17794,24 +17975,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,9 @@
     "react-plotly.js": "^2.6.0",
     "shpjs": "^6.2.0"
   },
+  "overrides": {
+    "maplibre-gl": "^6.4.1"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",
+    "@maplibre/maplibre-gl-style-spec": "^26.4.2",
     "@deck.gl/core": "^9.2.6",
     "@deck.gl/layers": "^9.2.6",
     "@deck.gl/mapbox": "^9.2.6",
@@ -24,7 +25,7 @@
     "deck.gl": "^9.2.6",
     "fast-xml-parser": "4.5.5",
     "framer-motion": "^11.15.0",
-    "maplibre-gl": "^4.7.1",
+    "maplibre-gl": "^6.4.1",
     "matter-js": "^0.20.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Box, IconButton, Tooltip, Icon, VStack, Button, Flex, Text } from '@chakra-ui/react';
 import { FiSliders, FiMap, FiPlus, FiMinus, FiTrash2 } from 'react-icons/fi';
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
+import type { ExpressionSpecification, FilterSpecification, SourceSpecification, StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { bbox as turfBbox, featureCollection, union, difference, intersect, area as turfArea, simplify as turfSimplify } from '@turf/turf';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import '../lib/maplibreWorker';
 import type { ComparisonState, Scenario, IdentifyResult, MapExtent, MapStatistics, ZoneStats, BoundingBox, DomainRange, ColorScaleMode, ColorScaleType, RangeMode, SiteIndicators } from '../types';
 import { SCENARIOS } from '../types';
 import { registerMap, unregisterMap, getLastMapView } from '../hooks/useMapSync';
@@ -89,14 +91,14 @@ interface MapViewProps {
 // Module-level style cache: fetch style.json exactly once across all MapView instances.
 // In grid view this cuts 8 identical HTTP requests down to 1.
 // _cachedStyle holds the resolved object so staggered panes can use it synchronously.
-let _cachedStyle: maplibregl.StyleSpecification | null = null;
-let _stylePromise: Promise<maplibregl.StyleSpecification> | null = null;
+let _cachedStyle: StyleSpecification | null = null;
+let _stylePromise: Promise<StyleSpecification> | null = null;
 function warmStyleCache(url: string): void {
   if (_stylePromise) return;
   _stylePromise = fetch(url)
     .then(r => {
       if (!r.ok) throw new Error(`style.json: ${r.status} ${r.statusText}`);
-      return r.json() as Promise<maplibregl.StyleSpecification>;
+      return r.json() as Promise<StyleSpecification>;
     })
     .then(s => { _cachedStyle = s; return s; })
     .catch(err => {
@@ -105,7 +107,7 @@ function warmStyleCache(url: string): void {
       throw err;
     });
 }
-function getStyleForMap(url: string): string | maplibregl.StyleSpecification {
+function getStyleForMap(url: string): string | StyleSpecification {
   // If the resolved style is already in memory (i.e. a prior pane already fetched it),
   // pass the object directly so MapLibre skips the HTTP request entirely.
   return _cachedStyle ?? url;
@@ -440,7 +442,7 @@ function filterDatasetByCatchmentIds(data: ChoroplethData | null, catchmentIds: 
 }
 
 function extractBoundaryGeometryFromStyleSource(
-  source: maplibregl.SourceSpecification | undefined,
+  source: SourceSpecification | undefined,
 ): GeoJSON.Geometry | null {
   if (!source || source.type !== 'geojson') return null;
 
@@ -859,7 +861,7 @@ function setCatchmentOutlinesSoftness(map: maplibregl.Map, soften: boolean) {
   if (!catchmentsOutlineOpacityRef.has(map)) return;
   const originalOpacity = catchmentsOutlineOpacityRef.get(map);
   if (originalOpacity !== undefined) {
-    map.setPaintProperty(CATCHMENTS_OUTLINES_LAYER_ID, 'line-opacity', originalOpacity as maplibregl.ExpressionSpecification | number);
+    map.setPaintProperty(CATCHMENTS_OUTLINES_LAYER_ID, 'line-opacity', originalOpacity as ExpressionSpecification | number);
   }
   catchmentsOutlineOpacityRef.delete(map);
 }
@@ -1301,7 +1303,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
       if (siteId && (!siteCatchmentIds || siteCatchmentIds.size === 0)) {
         const liveBoundarySource = leftMap.getSource(SITE_BOUNDARY_SOURCE) as (maplibregl.GeoJSONSource & {
-          serialize?: () => maplibregl.SourceSpecification;
+          serialize?: () => SourceSpecification;
         }) | undefined;
 
         const serializedBoundarySource = liveBoundarySource?.serialize ? liveBoundarySource.serialize() : undefined;
@@ -1331,7 +1333,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
       if (siteId) {
         const liveBoundarySource = leftMap.getSource(SITE_BOUNDARY_SOURCE) as (maplibregl.GeoJSONSource & {
-          serialize?: () => maplibregl.SourceSpecification;
+          serialize?: () => SourceSpecification;
         }) | undefined;
 
         const serializedBoundarySource = liveBoundarySource?.serialize ? liveBoundarySource.serialize() : undefined;
@@ -1693,7 +1695,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
       });
 
       const liveBoundarySource = leftMapRef.current?.getSource(SITE_BOUNDARY_SOURCE) as (maplibregl.GeoJSONSource & {
-        serialize?: () => maplibregl.SourceSpecification;
+        serialize?: () => SourceSpecification;
       }) | undefined;
       const serializedBoundarySource = liveBoundarySource?.serialize ? liveBoundarySource.serialize() : undefined;
       const boundaryGeometry =
@@ -1763,7 +1765,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
 
         const explicitCatchmentIds = new Set(catchmentIds);
         const liveBoundarySource = leftMapRef.current?.getSource(SITE_BOUNDARY_SOURCE) as (maplibregl.GeoJSONSource & {
-          serialize?: () => maplibregl.SourceSpecification;
+          serialize?: () => SourceSpecification;
         }) | undefined;
         const serializedBoundarySource = liveBoundarySource?.serialize ? liveBoundarySource.serialize() : undefined;
         const boundaryGeometry =
@@ -3799,7 +3801,7 @@ function MapView({ comparison, onOpenSettings, onIdentify, identifyResult, onMap
         ? { 'source-layer': CATCHMENT_TILE_SOURCE_LAYER }
         : {};
       const catchmentIdNum = parseInt(catchmentId, 10);
-      const idFilter: maplibregl.FilterSpecification =
+      const idFilter: FilterSpecification =
         ['==', ['to-number', ['get', CATCHMENT_ID_PROP]], catchmentIdNum];
 
       // Add outer glow layer (neon blue)

--- a/frontend/src/components/SiteCreationMap.tsx
+++ b/frontend/src/components/SiteCreationMap.tsx
@@ -16,7 +16,9 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
+import type { LayerSpecification, StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
+import '../lib/maplibreWorker';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FiCheck, FiGlobe, FiMapPin, FiRotateCcw, FiSearch, FiSquare, FiTrash2 } from 'react-icons/fi';
 import type { SiteCreationMethod, BoundingBox } from '../types';
@@ -87,21 +89,21 @@ const SATELLITE_ID_PREFIX = 'satellite-';
 // not fill/background: a translucent land-cover fill would just muddy the
 // imagery, which is the same reasoning already applied a few lines below to
 // the base style's own layers.
-function isHybridLayerWorthShowing(layer: maplibregl.LayerSpecification): boolean {
+function isHybridLayerWorthShowing(layer: LayerSpecification): boolean {
   return layer.type === 'raster' || layer.type === 'line' || layer.type === 'symbol';
 }
 
 // Fetched once per session and reused by every toggle and every map instance,
 // mirroring MapView.tsx's warmStyleCache for the vector basemap.
-let _cachedSatelliteStyle: maplibregl.StyleSpecification | null = null;
-let _satelliteStylePromise: Promise<maplibregl.StyleSpecification> | null = null;
-function loadSatelliteStyle(): Promise<maplibregl.StyleSpecification> {
+let _cachedSatelliteStyle: StyleSpecification | null = null;
+let _satelliteStylePromise: Promise<StyleSpecification> | null = null;
+function loadSatelliteStyle(): Promise<StyleSpecification> {
   if (_cachedSatelliteStyle) return Promise.resolve(_cachedSatelliteStyle);
   if (!_satelliteStylePromise) {
     _satelliteStylePromise = fetch(satelliteStyleUrl())
       .then((r) => {
         if (!r.ok) throw new Error(`satellite style: ${r.status} ${r.statusText}`);
-        return r.json() as Promise<maplibregl.StyleSpecification>;
+        return r.json() as Promise<StyleSpecification>;
       })
       .then((style) => {
         _cachedSatelliteStyle = style;
@@ -150,7 +152,7 @@ async function addHybridBasemapLayers(
       ...layer,
       id: prefixedId,
       ...('source' in layer && layer.source ? { source: SATELLITE_ID_PREFIX + layer.source } : {}),
-    } as maplibregl.LayerSpecification;
+    } as LayerSpecification;
     map.addLayer(prefixedLayer, beforeLayerId);
     layerIds.push(prefixedId);
   }
@@ -394,7 +396,8 @@ function SiteCreationMap({
       center: initialExtent?.center || [22.977, 1.258],
       zoom: initialExtent?.zoom || 4,
       attributionControl: false,
-      preserveDrawingBuffer: true, // Required for canvas thumbnail capture
+      // Required for canvas thumbnail capture
+      canvasContextAttributes: { preserveDrawingBuffer: true },
     });
 
     map.addControl(new maplibregl.NavigationControl(), 'top-right');
@@ -768,14 +771,16 @@ function SiteCreationMap({
       map.on('mousedown', handleMouseDown);
       map.on('mousemove', handleMouseMove);
       map.on('mouseup', handleMouseUp);
-      map.on('mouseleave', handleMouseLeave);
+      // mouseleave only fires when scoped to a layer; mouseout is the
+      // canvas-wide equivalent this box-selection cancel needs.
+      map.on('mouseout', handleMouseLeave);
 
       return () => {
         map.off('click', handleClick);
         map.off('mousedown', handleMouseDown);
         map.off('mousemove', handleMouseMove);
         map.off('mouseup', handleMouseUp);
-        map.off('mouseleave', handleMouseLeave);
+        map.off('mouseout', handleMouseLeave);
         if (!map.dragPan.isEnabled()) {
           map.dragPan.enable();
         }

--- a/frontend/src/hooks/useMapSync.ts
+++ b/frontend/src/hooks/useMapSync.ts
@@ -3,7 +3,7 @@
  * All MapView instances register their MapLibre maps here.
  * When any map moves, all others are updated to match.
  */
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
 
 type MapEntry = {
   map: maplibregl.Map;

--- a/frontend/src/lib/choroplethPaint.ts
+++ b/frontend/src/lib/choroplethPaint.ts
@@ -1,4 +1,4 @@
-import type maplibregl from 'maplibre-gl';
+import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { ColorScaleType, ZoneStats } from '../types';
 
 /**
@@ -56,16 +56,16 @@ export const CHOROPLETH_VALUE_STATE_KEY = 'v';
  * geometry; `['feature-state', 'v']` for the vector-tile path, where it was
  * joined on afterwards.
  */
-export type ChoroplethValueAccessor = maplibregl.ExpressionSpecification;
+export type ChoroplethValueAccessor = ExpressionSpecification;
 
 /** Reads the value from the feature's own properties (GeoJSON path). */
 export function attributeValueAccessor(attribute: string): ChoroplethValueAccessor {
-  return ['get', attribute] as maplibregl.ExpressionSpecification;
+  return ['get', attribute] as ExpressionSpecification;
 }
 
 /** Reads the value from feature state (vector-tile path). */
 export function featureStateValueAccessor(): ChoroplethValueAccessor {
-  return ['feature-state', CHOROPLETH_VALUE_STATE_KEY] as maplibregl.ExpressionSpecification;
+  return ['feature-state', CHOROPLETH_VALUE_STATE_KEY] as ExpressionSpecification;
 }
 
 export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
@@ -110,12 +110,12 @@ export function buildNormalizedValueExpression(
   min: number,
   range: number,
   scaleType: ColorScaleType
-): maplibregl.ExpressionSpecification {
+): ExpressionSpecification {
   const linearRatio = [
     '/',
     ['-', ['coalesce', value, min], min],
     range,
-  ] as maplibregl.ExpressionSpecification;
+  ] as ExpressionSpecification;
 
   if (scaleType === 'linear') {
     return linearRatio;
@@ -131,7 +131,7 @@ export function buildNormalizedValueExpression(
         ['ln', ['+', 1, ['*', LOGARITHMIC_STRENGTH, ['var', 't']]]],
         Math.log(1 + LOGARITHMIC_STRENGTH),
       ],
-    ] as maplibregl.ExpressionSpecification;
+    ] as ExpressionSpecification;
   }
 
   return [
@@ -143,7 +143,7 @@ export function buildNormalizedValueExpression(
       1,
       ['+', 1, ['^', Math.E, ['*', -LOGISTIC_STEEPNESS, ['-', ['var', 't'], 0.5]]]],
     ],
-  ] as maplibregl.ExpressionSpecification;
+  ] as ExpressionSpecification;
 }
 
 /**
@@ -155,7 +155,7 @@ export function buildFillColorExpression(
   max: number,
   baseColor?: string | null,
   scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | string {
+): ExpressionSpecification | string {
   // When a metadata base color is provided, blend from white (low values)
   // to the base color (high values) instead of using opacity.
   if (baseColor) {
@@ -177,7 +177,7 @@ export function buildFillColorExpression(
       '#FFFFFF',
       1,
       baseColor,
-    ] as maplibregl.ExpressionSpecification;
+    ] as ExpressionSpecification;
   }
 
   const range = max - min;
@@ -192,7 +192,7 @@ export function buildFillColorExpression(
     ['linear'],
     buildNormalizedValueExpression(value, min, range, scaleType),
     ...PRISM_STOPS.flatMap(([t, color]) => [t, color]),
-  ] as maplibregl.ExpressionSpecification;
+  ] as ExpressionSpecification;
 }
 
 export function buildOpacityColorExpression(
@@ -201,7 +201,7 @@ export function buildOpacityColorExpression(
   max: number,
   baseColor: string,
   scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | string {
+): ExpressionSpecification | string {
   // Blend color from white (low values) to the metadata base color
   // (high values). Opacity will be handled separately by layer paint.
   const rgb = hexToRgb(baseColor);
@@ -222,7 +222,7 @@ export function buildOpacityColorExpression(
     '#FFFFFF',
     1,
     baseColor,
-  ] as maplibregl.ExpressionSpecification;
+  ] as ExpressionSpecification;
 }
 
 /**
@@ -233,7 +233,7 @@ export function buildExtrusionExpression(
   min: number,
   max: number,
   scaleType: ColorScaleType = 'linear'
-): maplibregl.ExpressionSpecification | number {
+): ExpressionSpecification | number {
   const range = max - min;
   if (range === 0) {
     return MAX_EXTRUSION_HEIGHT / 2;
@@ -243,7 +243,7 @@ export function buildExtrusionExpression(
     '*',
     buildNormalizedValueExpression(value, min, range, scaleType),
     MAX_EXTRUSION_HEIGHT,
-  ] as maplibregl.ExpressionSpecification;
+  ] as ExpressionSpecification;
 }
 
 /**

--- a/frontend/src/lib/choroplethTiles.ts
+++ b/frontend/src/lib/choroplethTiles.ts
@@ -1,4 +1,5 @@
-import type maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
+import type { VectorSourceSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { CHOROPLETH_VALUE_STATE_KEY } from './choroplethPaint';
 
 /**
@@ -120,7 +121,7 @@ export function resetCatchmentTilesetCache(): void {
  * re-request it once per map instance, and minzoom bounds tile requests to the
  * range that actually contains catchments.
  */
-export function catchmentTileSourceSpec(tileset: CatchmentTileset): maplibregl.VectorSourceSpecification {
+export function catchmentTileSourceSpec(tileset: CatchmentTileset): VectorSourceSpecification {
   return {
     type: 'vector',
     tiles: tileset.tiles,

--- a/frontend/src/lib/mapBounds.ts
+++ b/frontend/src/lib/mapBounds.ts
@@ -1,4 +1,4 @@
-import type maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 
 type TileJSONResponse = {
   bounds?: unknown;

--- a/frontend/src/lib/maplibreWorker.ts
+++ b/frontend/src/lib/maplibreWorker.ts
@@ -1,0 +1,15 @@
+import * as maplibregl from 'maplibre-gl';
+import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?url';
+
+// MapLibre locates its own worker script from import.meta.url of the module
+// it ships as. Vite inlines that module into a single bundled chunk, so the
+// self-located URL points at a file Vite never emits, and the app's SPA
+// fallback route quietly serves index.html in its place - the worker then
+// fails to parse as a module and every vector tile source (choropleth, site
+// boundaries, the vector basemap) goes dark with no console error, because
+// the failure happens inside the worker before it can report anything.
+//
+// Importing the real worker file through Vite's `?url` gives it a proper,
+// content-hashed URL in the build output; handing that to MapLibre here -
+// before any Map is constructed - is what makes it resolvable.
+maplibregl.setWorkerUrl(workerUrl);

--- a/frontend/src/test/choroplethTiles.test.ts
+++ b/frontend/src/test/choroplethTiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 import {
   CATCHMENT_TILE_ID_PROPERTY,
   CATCHMENT_TILE_SOURCE_LAYER,

--- a/frontend/src/test/mapRefetchStorms.test.tsx
+++ b/frontend/src/test/mapRefetchStorms.test.tsx
@@ -112,7 +112,7 @@ class FakeLngLatBounds {
 
 vi.mock('maplibre-gl', () => {
   class NavigationControl {}
-  const api = { Map: FakeMap, NavigationControl, LngLatBounds: FakeLngLatBounds };
+  const api = { Map: FakeMap, NavigationControl, LngLatBounds: FakeLngLatBounds, setWorkerUrl: () => {} };
   return { ...api, default: api };
 });
 

--- a/frontend/src/test/mapSyncView.test.ts
+++ b/frontend/src/test/mapSyncView.test.ts
@@ -10,7 +10,7 @@
  * remembers it.
  */
 import { describe, it, expect } from 'vitest';
-import type maplibregl from 'maplibre-gl';
+import type * as maplibregl from 'maplibre-gl';
 import { registerMap, unregisterMap, getLastMapView } from '../hooks/useMapSync';
 
 /** Minimal stand-in for the handful of methods the registry touches. */

--- a/frontend/src/test/webglContextBudget.test.tsx
+++ b/frontend/src/test/webglContextBudget.test.tsx
@@ -134,7 +134,7 @@ class FakeMap {
 
 vi.mock('maplibre-gl', () => {
   class NavigationControl {}
-  const api = { Map: FakeMap, NavigationControl };
+  const api = { Map: FakeMap, NavigationControl, setWorkerUrl: () => {} };
   return { ...api, default: api };
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,10 @@
-import { copyFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const require = createRequire(import.meta.url);
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // MapLibre's worker script (imported via `?url` in src/lib/maplibreWorker.ts,
 // so Vite gives it a real, content-hashed URL instead of the broken
@@ -19,19 +17,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // source (choropleth, site boundaries, the vector basemap) goes dark with no
 // console error.
 //
-// Copied unhashed to the exact filename MapLibre's relative import expects,
+// Emitted unhashed, to the exact filename MapLibre's relative import expects,
 // next to wherever Vite puts the (hashed) worker file — both live in
 // `assets/`, so a plain sibling filename is enough for it to resolve.
+//
+// Goes through Rollup's own emitFile rather than writing to dist/ by hand: a
+// manual fs write in closeBundle raced Rollup's own output directory setup
+// under Nix's sandboxed build (dist/assets did not exist yet there, though it
+// reliably did in an ordinary local build) — emitFile makes Rollup responsible
+// for the directory existing, the same as it is for every other asset.
 function mapLibreWorkerSharedChunk(): Plugin {
   return {
     name: 'maplibre-worker-shared-chunk',
     apply: 'build',
-    closeBundle() {
+    generateBundle() {
       const maplibreDist = dirname(require.resolve('maplibre-gl/package.json')) + '/dist';
-      copyFileSync(
-        join(maplibreDist, 'maplibre-gl-shared.mjs'),
-        join(__dirname, 'dist/assets/maplibre-gl-shared.mjs'),
-      );
+      this.emitFile({
+        type: 'asset',
+        fileName: 'assets/maplibre-gl-shared.mjs',
+        source: readFileSync(join(maplibreDist, 'maplibre-gl-shared.mjs')),
+      });
     },
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,43 @@
-import { defineConfig } from 'vite';
+import { copyFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// MapLibre's worker script (imported via `?url` in src/lib/maplibreWorker.ts,
+// so Vite gives it a real, content-hashed URL instead of the broken
+// self-located one — see that file) itself imports a second file,
+// `maplibre-gl-shared.mjs`, by a bare relative path baked into MapLibre's own
+// build output. Vite's `?url` only copies the one file that was asked for, so
+// without this the worker's own import 404s — and, because this app's SPA
+// fallback route serves index.html for anything unmatched, that 404 is
+// invisible: the worker just silently fails to start, and every vector tile
+// source (choropleth, site boundaries, the vector basemap) goes dark with no
+// console error.
+//
+// Copied unhashed to the exact filename MapLibre's relative import expects,
+// next to wherever Vite puts the (hashed) worker file — both live in
+// `assets/`, so a plain sibling filename is enough for it to resolve.
+function mapLibreWorkerSharedChunk(): Plugin {
+  return {
+    name: 'maplibre-worker-shared-chunk',
+    apply: 'build',
+    closeBundle() {
+      const maplibreDist = dirname(require.resolve('maplibre-gl/package.json')) + '/dist';
+      copyFileSync(
+        join(maplibreDist, 'maplibre-gl-shared.mjs'),
+        join(__dirname, 'dist/assets/maplibre-gl-shared.mjs'),
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), mapLibreWorkerSharedChunk()],
   server: {
     proxy: {
       '/api': 'http://localhost:8080',

--- a/nix/manifest-lock.json
+++ b/nix/manifest-lock.json
@@ -8,9 +8,9 @@
     }
   },
   "npmDepsHash": {
-    "value": "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=",
+    "value": "sha256-UjGkmOXqjEwkSluatKThLi9KcbXS3ixV5TjBcJc/2T8=",
     "inputs": {
-      "frontend/package-lock.json": "76e3a74d8b65c5333523a173661379b2b5e9549669e3e764c50eeb911f3200a1"
+      "frontend/package-lock.json": "9b361da4c17bd882f3dd6d5d6ba07664272c9c788f198d4ca5c84a58edb91aaa"
     }
   }
 }

--- a/nix/manifest-lock.json
+++ b/nix/manifest-lock.json
@@ -8,9 +8,9 @@
     }
   },
   "npmDepsHash": {
-    "value": "sha256-qCI5cEbDnuC4o4TfHoqZdarFskRRedCWd+ho98c+Tmo=",
+    "value": "sha256-c5G9gLrpajwxL2UiryreHYRci6FbB1Sgclyctr8mNNk=",
     "inputs": {
-      "frontend/package-lock.json": "fa1ceb00ba8fd5eccca28a00b383d8c3882114a9565707ad62abdd35bef82c70"
+      "frontend/package-lock.json": "76e3a74d8b65c5333523a173661379b2b5e9549669e3e764c50eeb911f3200a1"
     }
   }
 }

--- a/subcommands.go
+++ b/subcommands.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kartoza/decision-theatre/internal/datacheck"
 )
@@ -23,6 +26,7 @@ Usage:
   decision-theatre [flags]              Run the application
   decision-theatre check-data [dir]     Check a data directory and report on it
   decision-theatre pack-data [dir]      Check, then build a distributable pack
+  decision-theatre healthcheck          Check that a running server is answering
 
 Run flags:
   --port N              HTTP port (default 8080)
@@ -48,6 +52,8 @@ func runSubcommand(args []string) (handled bool, code int) {
 		return true, cmdCheckData(args[2:])
 	case "pack-data":
 		return true, cmdPackData(args[2:])
+	case "healthcheck":
+		return true, cmdHealthcheck(args[2:])
 	case "help", "--help", "-h":
 		usage()
 		return true, 0
@@ -190,6 +196,48 @@ Flags:
 	if err := datacheck.RenderManifest(os.Stdout, manifest, outPath); err != nil {
 		fmt.Fprintf(os.Stderr, "decision-theatre pack-data: %v\n", err)
 		return 2
+	}
+	return 0
+}
+
+// cmdHealthcheck asks a running server whether it is answering requests. It
+// exists so Docker's HEALTHCHECK can run the binary that is already in the
+// image instead of requiring curl or wget: the release container is built
+// from the Nix flake, which carries only this application's own runtime
+// closure, and adding a second HTTP client just to poll a port this binary
+// already serves would be exactly the second dependency list the flake's
+// container derivation was written to avoid.
+func cmdHealthcheck(args []string) int {
+	fs := flag.NewFlagSet("healthcheck", flag.ExitOnError)
+	port := fs.Int("port", 8080, "Port the server is listening on")
+	timeout := fs.Duration("timeout", 5*time.Second, "How long to wait for a response")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: decision-theatre healthcheck [flags]
+
+Requests /api/health from a server running on this host and exits 0 if it
+answers 200, non-zero otherwise. Intended for Docker's HEALTHCHECK, in place
+of "curl -f http://localhost:PORT/api/health".
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	url := fmt.Sprintf("http://%s/api/health", net.JoinHostPort("127.0.0.1", fmt.Sprint(*port)))
+	client := &http.Client{Timeout: *timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decision-theatre healthcheck: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "decision-theatre healthcheck: %s returned %s\n", url, resp.Status)
+		return 1
 	}
 	return 0
 }


### PR DESCRIPTION
The release image (built by the Nix flake, not deployments/Dockerfile) has never shipped curl, so the HEALTHCHECK in docker-compose.yaml has been failing on every production deploy since that image path went live — reported unhealthy indefinitely even while the app served requests fine.

- Added a decision-theatre healthcheck subcommand (subcommands.go) that does an in-process GET to /api/health — no external HTTP client needed.
- docker-compose.yaml now runs that subcommand instead of curl.
- Dropped curl from deployments/Dockerfile (no longer needed).
- flake.nix: added PATH to the container env so Docker can resolve the bare decision-theatre command name for the healthcheck (the ENTRYPOINT didn't need this since it uses an absolute store path).