### PR TITLE
fix: unbreak site cloning, indicator search, and live-update defaults

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import DownloadPage from './components/DownloadPage';
 import FeedbackLink from './components/FeedbackLink';
 import ResumeSessionModal from './components/ResumeSessionModal';
 import { editableTargetKeys } from './lib/editableTargets';
+import { clearLiveUpdatePreference } from './lib/liveTargetUpdate';
 import { patchSite, patchSiteIndicators, resetSiteIdeal, useServerInfo, getSite, useFullDomainPrecalculated, primeSiteCatchmentsFromEmbedded, saveLocalSite, useAttributeDetails, useAttributeVariableTypes, useAttributeUserInputs, useAttributeTargetInputs } from './hooks/useApi';
 import { getAppRuntime } from './types/runtime';
 import { showTargetWarningsPopup, showLowDataAvailabilityWarning, computeIndicatorAvailabilityFraction } from './utils/warnings';
@@ -594,6 +595,10 @@ function App() {
   // Handle site created (or updated)
   const handleSiteCreated = useCallback((site: Site) => {
     setEditSite(null); // Clear edit state
+    // A live-update choice made for a previous site is not a statement about
+    // this one, so a freshly created site should get the catchment-count
+    // default rather than inherit whatever was last toggled elsewhere.
+    clearLiveUpdatePreference();
     startBackgroundIndicatorExtraction(site);
     handleOpenSite(site);
     setViewModes((prev) => prev.map((m, i) => (i === 0 ? 'map' : m)));
@@ -1317,6 +1322,7 @@ function App() {
             swiperPosition={swiperPosition}
             onSwiperPositionChange={setSwiperPosition}
             siteIndicators={currentSite?.indicators}
+            siteCatchmentCount={currentSite?.catchmentIds?.length}
             rangeMode={rangeMode}
             mapStatistics={mapStatistics}
             chartGroups={chartGroups}

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -53,6 +53,10 @@ interface ContentAreaProps {
   onSwiperPositionChange?: (position: number) => void;
   // Dial chart props
   siteIndicators?: SiteIndicators | null;
+  // Raw catchment count from the site itself, used to size the live-update
+  // default before indicator extraction has finished and siteIndicators is
+  // still null (extraction runs in the background after site creation).
+  siteCatchmentCount?: number;
   rangeMode?: RangeMode;
   mapStatistics?: MapStatistics | null;
   chartGroups?: (string | null)[];
@@ -190,6 +194,7 @@ function ContentArea({
   swiperPosition,
   onSwiperPositionChange,
   siteIndicators,
+  siteCatchmentCount,
   rangeMode,
   mapStatistics,
   chartGroups,
@@ -230,8 +235,11 @@ function ContentArea({
   // The count the recalculation actually iterates over, straight off the
   // extraction that produced these indicators — the same number the backend
   // rescores on every edit, which is what makes it the right one to size the
-  // default by.
-  const catchmentCount = siteIndicators?.catchmentCount ?? 0;
+  // default by. Extraction runs in the background after site creation, so
+  // siteIndicators can still be null when this panel first mounts; falling
+  // back to the site's raw catchment count keeps the default correct for a
+  // large site in that window instead of defaulting to live update on.
+  const catchmentCount = siteIndicators?.catchmentCount ?? siteCatchmentCount ?? 0;
   const isLiveUpdate = resolveLiveUpdate(catchmentCount, storedLiveUpdate);
 
   const handleLiveUpdateChange = useCallback((enabled: boolean) => {

--- a/frontend/src/components/IndicatorEditorPage.tsx
+++ b/frontend/src/components/IndicatorEditorPage.tsx
@@ -731,6 +731,28 @@ export default function IndicatorEditorPage({
       .sort((a, b) => a.groupName.localeCompare(b.groupName));
   }, [availableIndicatorKeys, attributeDetails, variableTypes]);
 
+  // Shared by the table and the dropdown so both agree on which indicators
+  // actually have data for this site - otherwise the dropdown can offer a
+  // factor that then renders zero rows in the table.
+  const hasIndicatorData = useCallback((key: string) => {
+    if (!localIndicators) return false;
+    const refVal = localIndicators.reference?.[key] ?? null;
+    const curVal = localIndicators.current?.[key] ?? null;
+    const isEditable = userInputs[key] === true;
+    if (refVal === null && curVal === null) return false;
+    if (refVal === 0 && curVal === 0 && !isEditable) return false;
+    return true;
+  }, [localIndicators, userInputs]);
+
+  const dropdownIndicatorGroups = useMemo(() => {
+    return indicatorGroups
+      .map(group => ({
+        groupName: group.groupName,
+        entries: group.entries.filter(entry => hasIndicatorData(entry.key)),
+      }))
+      .filter(group => group.entries.length > 0);
+  }, [indicatorGroups, hasIndicatorData]);
+
   const groupedIndicatorRows = useMemo(() => {
     if (!localIndicators) return [] as { groupName: string; rows: IndicatorRow[] }[];
 
@@ -739,11 +761,7 @@ export default function IndicatorEditorPage({
         const rows = group.entries
           .filter(entry => {
             if (selectedIndicatorKey && entry.key !== selectedIndicatorKey) return false;
-            const refVal = localIndicators.reference?.[entry.key] ?? null;
-            const curVal = localIndicators.current?.[entry.key] ?? null;
-            const isEditable = userInputs[entry.key] === true;
-            if (refVal === null && curVal === null) return false;
-            if (refVal === 0 && curVal === 0 && !isEditable) return false;
+            if (!hasIndicatorData(entry.key)) return false;
             if (!searchFilter) return true;
             const displayLabel = (attributeDetails[entry.key] ?? getIndicatorLabel(entry.key)).toLowerCase();
             return displayLabel.includes(searchFilter.toLowerCase())
@@ -774,9 +792,7 @@ export default function IndicatorEditorPage({
       .filter(group => group.rows.length > 0);
 
     return groups;
-  // useMemo has a missing dependency: 'userInputs'
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing; see the tracking issue
-  }, [attributeDetails, indicatorGroups, localIndicators, searchFilter, selectedIndicatorKey]);
+  }, [attributeDetails, hasIndicatorData, indicatorGroups, localIndicators, searchFilter, selectedIndicatorKey]);
 
   const totalIndicatorRows = useMemo(
     () => groupedIndicatorRows.reduce((sum, group) => sum + group.rows.length, 0),
@@ -963,7 +979,7 @@ export default function IndicatorEditorPage({
                 color="gray.100"
               >
                 <option value="">All indicators</option>
-                {indicatorGroups.map(group => (
+                {dropdownIndicatorGroups.map(group => (
                   <optgroup key={group.groupName} label={group.groupName}>
                     {group.entries.map(entry => (
                       <option key={entry.key} value={entry.key}>

--- a/frontend/src/components/SiteCreationPage.tsx
+++ b/frontend/src/components/SiteCreationPage.tsx
@@ -128,8 +128,12 @@ const EXACT_GEOMETRY_INFERENCE_LIMIT = 150;
 const LOW_DATA_COVERAGE_THRESHOLD = 0.2;
 
 function SiteCreationPage({ onNavigate, onSiteCreated, initialExtent, editSite }: SiteCreationPageProps) {
-  const isEditMode = !!editSite;
-  const [step, setStep] = useState<Step>(() => isEditMode ? 'details' : 'method');
+  // editSite is also used to pre-fill a clone (with id blanked out), so only
+  // treat it as a real edit when it carries an existing site id - otherwise
+  // submission must create a new site rather than updating the original.
+  const hasPrefilledSite = !!editSite;
+  const isEditMode = !!editSite?.id;
+  const [step, setStep] = useState<Step>(() => hasPrefilledSite ? 'details' : 'method');
   const [selectedMethod, setSelectedMethod] = useState<SiteCreationMethod | null>(() =>
     editSite?.creationMethod || null
   );
@@ -428,7 +432,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
       toast({ title: 'Please enter a title', status: 'warning', duration: 3000 });
       return;
     }
-    if (!isEditMode && !geometry) {
+    if (!hasPrefilledSite && !geometry) {
       toast({ title: 'Please complete the boundary', status: 'warning', duration: 3000 });
       return;
     }
@@ -485,7 +489,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
         siteData.catchmentIds = catchmentIdsToPersist;
       }
 
-      const site = isEditMode
+      const site = isEditMode && editSite
         ? await updateSite(editSite.id, siteData as Partial<Site>)
         : await createSite(siteData as Partial<Site>);
 
@@ -506,7 +510,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
       setIsSubmitting(false);
     }
   }, [siteTitle, siteDescription, geometry, boundingBox, selectedCatchmentIds, selectedMethod,
-      isEditMode, editSite, thumbnail, inferCatchmentIdsForGeometry, onSiteCreated, toast]);
+      isEditMode, hasPrefilledSite, editSite, thumbnail, inferCatchmentIdsForGeometry, onSiteCreated, toast]);
 
   const handleSubmitSite = (e: React.FormEvent) => {
     e.preventDefault();
@@ -515,7 +519,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
 
   const handleBack = useCallback(() => {
     if (step === 'details') {
-      if (isEditMode) onNavigate('sites');
+      if (hasPrefilledSite) onNavigate('sites');
       else setStep('geometry');
     } else if (step === 'geometry') {
       setStep('method');
@@ -526,7 +530,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
     } else {
       onNavigate('sites');
     }
-  }, [step, onNavigate, isEditMode]);
+  }, [step, onNavigate, hasPrefilledSite]);
 
   // Step indicator with physics bounce
   const stepIndicators = [
@@ -655,11 +659,11 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
               _hover={{ bg: 'whiteAlpha.100', transform: 'translateX(-4px)' }}
               transition="all 0.2s"
             >
-              {isEditMode || step === 'method' ? 'Back to Sites' : 'Back'}
+              {hasPrefilledSite || step === 'method' ? 'Back to Sites' : 'Back'}
             </Button>
 
             {/* Step indicator - physics bouncing badges */}
-            {!isEditMode && (
+            {!hasPrefilledSite && (
               <HStack spacing={3}>
                 {stepIndicators.map((s, i) => {
                   const isActive = step === s.id;
@@ -947,7 +951,7 @@ const MIN_CATCHMENT_OVERLAP_FRACTION = 0.01;
                 >
                   <VStack spacing={8} align="stretch">
                     {/* Boundary info badge */}
-                    {!isEditMode && (
+                    {!hasPrefilledSite && (
                       <MotionBox
                         initial={{ scale: 0.9, opacity: 0 }}
                         animate={{ scale: 1, opacity: 1 }}


### PR DESCRIPTION
**Site cloning failed in browser runtime**

Cloning pre-fills the create-site form and resubmits it, but `SiteCreationPage` treated any pre-filled `editSite` object as "editing an existing site"- including a clone's placeholder with `id: ''`. Submitting then called`updateSite('', ...)` instead of `createSite(...)`, which in browser runtime throws `Failed to update site: not found` every time, since no site ever has an empty id in localStorage. Edit mode now requires a real site id; a clone without one takes the create path in both runtimes.

**Indicator search dropdown offered indicators with no data**

The indicator table hides factors with no `reference`/`current` value for the site; the search dropdown didn't apply the same filter, so it listed factors that then rendered zero rows with no explanation if selected. Both now share one `hasIndicatorData` check.

**Live-update toggle didn't default off for new large sites**

Two bugs compounded: the catchment count used to pick the live-update default came only from extracted indicators, which populate in the background after site creation — so a fresh site above the 20-catchment threshold still defaulted to live update on until extraction finished. It now falls back to the site's raw catchment count immediately. Separately, an explicit live-update choice made for one site was stored globally and carried over to every site created afterward. Site creation now clears that stored preference so the catchment-based default applies fresh to the new site.