### PR TITLE
fix: stop live-update target edits from racing each other and losing data

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1017,8 +1017,28 @@ function App() {
     }
   }, [currentSiteId]);
 
+  // Which target-state warnings (e.g. "grazing demand exceeds available
+  // biomass") are currently showing a toast for, so showTargetWarningsPopup
+  // can tell a still-active warning from a newly-triggered one and only
+  // toast the latter — a live-update drag calls this once per PATCH
+  // response, and the condition commonly stays true across many consecutive
+  // steps of the same drag.
+  const activeTargetWarningsRef = useRef<Set<string>>(new Set());
+  useEffect(() => { activeTargetWarningsRef.current = new Set(); }, [currentSiteId]);
+
   const handleSiteIndicatorsChange = useCallback(async (indicators: Site['indicators']) => {
     if (!currentSiteId || !indicators) return;
+
+    // Applied optimistically so the touched slider doesn't wait on a round
+    // trip, but `indicators` here is the client's un-cascaded guess — only
+    // the edited key is right, every derived total (herbivore biomass,
+    // methane, ...) still holds its pre-edit value until the server answers.
+    // A request that fails or is coalesced away must not leave that guess
+    // standing in as if it were the real, recalculated state — hence the
+    // rollback in catch below, restoring exactly what was current before
+    // this call so a dropped request degrades to "nothing happened" rather
+    // than "the edited factor changed but nothing it feeds into did".
+    const previousSite = currentSite;
 
     setCurrentSite((prev) => {
       if (!prev || prev.id !== currentSiteId) return prev;
@@ -1035,9 +1055,14 @@ function App() {
       setMapRefreshSeq(s => s + 1);
 
       const warnings = updatedSite.indicators?.warnings ?? [];
-      showTargetWarningsPopup(warnings, toast);
+      activeTargetWarningsRef.current = showTargetWarningsPopup(warnings, toast, activeTargetWarningsRef.current);
+      return updatedSite.indicators;
     } catch (err) {
       console.error('Failed to update site indicators:', err);
+      setCurrentSite((prev) => {
+        if (!prev || prev.id !== currentSiteId || !previousSite) return prev;
+        return { ...prev, indicators: previousSite.indicators };
+      });
       throw err;
     }
   }, [currentSiteId, currentSite, toast]);

--- a/frontend/src/components/AggregateTable.tsx
+++ b/frontend/src/components/AggregateTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState } from 'react';
+import { useMemo, useEffect, useRef, useState } from 'react';
 import { Box, Table, Thead, Tbody, Tr, Th, Td, Text, HStack, VStack, Spinner } from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { CatchmentIndicators, Scenario, SiteIndicators } from '../types';
@@ -39,36 +39,74 @@ function AggregateTable({
 
   const attributeLabel = attributeDetails[attribute] ?? attribute;
 
+  // Tracks visible/siteId/siteGeometry — the dependencies that mean "the
+  // table was just opened or pointed at a new site", as opposed to
+  // siteIndicators alone changing, which means a target recalculation
+  // refetched this data in the background. Only the former should show the
+  // loading spinner: the target editor's own "Recalculating" indicator
+  // already covers the latter.
+  const catchmentFetchNavRef = useRef<{ visible: boolean; siteId: string; siteGeometry: GeoJSON.Geometry | null | undefined } | null>(null);
+
   // Fetch catchment data when panel is visible and siteId is available.
+  // Also refetches whenever siteIndicators changes: a target-editor
+  // recalculation (live update or not) rewrites the site's and catchments'
+  // Ideal maps server-side, and without siteIndicators here this table kept
+  // showing whatever it had cached at the last visibility toggle — including
+  // a stale, elevated "future" average after a factor was edited back down.
   useEffect(() => {
     if (!visible || !siteId) {
       return;
     }
 
-    let cancelled = false;
-    setLoading(true);
+    const nav = { visible, siteId, siteGeometry };
+    const isNavigation =
+      catchmentFetchNavRef.current === null ||
+      catchmentFetchNavRef.current.visible !== nav.visible ||
+      catchmentFetchNavRef.current.siteId !== nav.siteId ||
+      catchmentFetchNavRef.current.siteGeometry !== nav.siteGeometry;
+    catchmentFetchNavRef.current = nav;
 
-    getSiteCatchments(siteId)
-      .then((data) => {
-        if (!cancelled) {
-          setCatchments(data || []);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setCatchments([]);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      });
+    let cancelled = false;
+    if (isNavigation) setLoading(true);
+
+    const runFetch = () => {
+      getSiteCatchments(siteId)
+        .then((data) => {
+          if (!cancelled) {
+            setCatchments(data || []);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setCatchments([]);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setLoading(false);
+          }
+        });
+    };
+
+    // See the matching comment in ViewPane.tsx: a live-update drag can fire
+    // many recalculations in quick succession, and fetching on every one
+    // piled extra GET requests on top of the PATCH requests themselves,
+    // right when the backend's admission control is most likely to be
+    // under pressure. Real navigation (opening the panel, a new site) stays
+    // immediate; only a background refresh triggered by siteIndicators
+    // changing is debounced.
+    let debounceId: ReturnType<typeof setTimeout> | undefined;
+    if (isNavigation) {
+      runFetch();
+    } else {
+      debounceId = setTimeout(runFetch, 400);
+    }
 
     return () => {
       cancelled = true;
+      if (debounceId !== undefined) clearTimeout(debounceId);
     };
-  }, [visible, siteId, siteGeometry]);
+  }, [visible, siteId, siteGeometry, siteIndicators]);
 
   // Calculate all derived values from catchment data.
   // Step 1: For each catchment, compute how much of its area is inside the site.

--- a/frontend/src/components/ContentArea.tsx
+++ b/frontend/src/components/ContentArea.tsx
@@ -63,7 +63,15 @@ interface ContentAreaProps {
   chartAxisLabelFilters?: (string | null)[];
   chartGraphModes?: ('line' | 'boxplot' | null)[];
   mapExtent?: MapExtent | null;
-  onSiteIndicatorsChange?: (indicators: SiteIndicators) => Promise<void> | void;
+  // Returns the server-confirmed indicators on success. runRecalculation
+  // needs this returned value, not just the resolved promise: React applies
+  // the resulting siteIndicators prop update asynchronously, but the
+  // scheduler drains its next queued request synchronously the instant this
+  // promise resolves, with no guarantee a re-render has happened in
+  // between. Building that next request from a siteIndicatorsRef that's
+  // still one response behind sends an untouched-but-cascaded field's
+  // stale value — see runRecalculation.
+  onSiteIndicatorsChange?: (indicators: SiteIndicators) => Promise<SiteIndicators | void> | void;
   /**
    * Point every target at an observed scenario. Separate from
    * onSiteIndicatorsChange because a reset must not cascade — see
@@ -379,14 +387,32 @@ function ContentArea({
 
     const nextDrafts = computeTargetDrafts();
     // Mid-drag, a live recalculation's cascade must not yank the thumb out
-    // from under the pointer, so the dragged slider keeps the user's value
-    // and everything else takes the freshly calculated one.
+    // from under the pointer, so the dragged slider keeps the user's value.
+    //
+    // More than that: while the scheduler still has a request in flight or
+    // queued (isSavingTargets), this response can be answering an
+    // *intermediate* value from earlier in the drag, not the one the user
+    // has since moved on to (including after release, once
+    // draggingTargetKeyRef has already gone back to null). Adopting it
+    // anyway made every touched slider spring back to that stale reading
+    // for a moment before the real, final response arrived and snapped it
+    // forward again — visible as a slider that "gets stuck" or leaps
+    // backward on its own. So every touched key keeps its current
+    // on-screen value until the scheduler fully settles; only then is the
+    // response guaranteed to be the answer to what's actually on screen.
     const draggingKey = draggingTargetKeyRef.current;
-    setTargetDraftValues((prev) =>
-      draggingKey != null && prev[draggingKey] !== undefined
+    setTargetDraftValues((prev) => {
+      if (isSavingTargets) {
+        const merged = { ...nextDrafts };
+        for (const key of touchedTargetKeysRef.current) {
+          if (prev[key] !== undefined) merged[key] = prev[key];
+        }
+        return merged;
+      }
+      return draggingKey != null && prev[draggingKey] !== undefined
         ? { ...nextDrafts, [draggingKey]: prev[draggingKey] }
-        : nextDrafts
-    );
+        : nextDrafts;
+    });
 
     if (!targetPanelWasOpenRef.current) {
       // Only snapshot the "opened at" values on the initial open — this
@@ -399,7 +425,7 @@ function ContentArea({
     }
     targetPanelWasOpenRef.current = true;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isTargetModalOpen, siteIndicators]);
+  }, [isTargetModalOpen, siteIndicators, isSavingTargets]);
 
 
   // The application header is content-sized — logos plus padding — not a fixed
@@ -468,7 +494,17 @@ function ContentArea({
     if (!hasChanges) return;
 
     try {
-      await onSiteIndicatorsChange({ ...indicators, ideal: nextIdeal });
+      const confirmed = await onSiteIndicatorsChange({ ...indicators, ideal: nextIdeal });
+      // Sync synchronously, not through the siteIndicators prop: the
+      // scheduler drains its next queued payload the instant this promise
+      // resolves, before React necessarily re-renders with the new prop.
+      // Without this, that next call reads siteIndicatorsRef.current still
+      // one response behind and rebuilds its own ideal snapshot from
+      // it — sending an untouched-but-server-cascaded field's stale value
+      // (e.g. highTC_prop after only lowTC_prop was edited) back to a
+      // backend that reads any change in that field as a direct edit of
+      // it, overwriting what was actually touched.
+      if (confirmed) siteIndicatorsRef.current = confirmed;
     } catch {
       toast({ title: STRINGS.updateFailed, status: 'error', duration: 2500 });
     }

--- a/frontend/src/components/FlatDial.tsx
+++ b/frontend/src/components/FlatDial.tsx
@@ -110,11 +110,17 @@ function FlatDial({
   const fontLegend = veryDense ? 10 : compact ? 12 : 14;
   const tickLen = compact ? 7 : 10;
 
-  // The band, its marker labels, its ticks and its legend are one block, and
-  // the block is centred. Pinning the band itself to a fraction of the height
-  // instead leaves the whole thing riding high with dead space underneath,
-  // which wastes the vertical room the flat shape was chosen to save.
-  const markerOverhang = barH * (compact ? 0.62 : 0.7);
+  // The buckle grips the band with a frame this tall (see `buckle` below,
+  // which derives its own `h`/`outer` from the same formulas). The
+  // reference/current bisectors need to clear that whole frame — including
+  // its dark backing stroke — by a visible margin, or a reading that lands
+  // near the target is fully swallowed by the buckle sitting on top of it
+  // (it draws last), which is exactly the moment it matters most to still
+  // tell the two apart. The old overhang (barH * 0.7) was shorter than the
+  // buckle's own half-height even before accounting for its stroke, so the
+  // buckle could hide a coincident bisector completely.
+  const buckleHalfExtent = (barH * (compact ? 2.2 : 2.3)) / 2 + ((compact ? 3 : 4) + 3) / 2;
+  const markerOverhang = buckleHalfExtent - barH / 2 + (compact ? 6 : 8);
   const aboveBand = markerOverhang + (veryDense ? 6 : fontTick + (compact ? 8 : 12));
   const ticksH = 4 + tickLen + fontTick + 4;
   const legendGap = veryDense ? 18 : compact ? 26 : 40;
@@ -168,9 +174,8 @@ function FlatDial({
   ) => {
     if (value === undefined || isNaN(value)) return null;
     const x = xFor(value);
-    const overhang = barH * (compact ? 0.62 : 0.7);
-    const top = barTop - overhang;
-    const bottom = barBottom + overhang;
+    const top = barTop - markerOverhang;
+    const bottom = barBottom + markerOverhang;
     return (
       <g>
         {/* Dark backing so the line stays readable over the yellow band. */}

--- a/frontend/src/components/IndicatorEditorPage.tsx
+++ b/frontend/src/components/IndicatorEditorPage.tsx
@@ -285,6 +285,11 @@ export default function IndicatorEditorPage({
 
   const extractionPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Which target-state warnings a toast has already been shown for, so a
+  // save that still has the same active warning as the previous one doesn't
+  // toast it again. See showTargetWarningsPopup.
+  const activeTargetWarningsRef = useRef<Set<string>>(new Set());
+
   // Clean up any in-flight poll when the component unmounts or site changes.
   useEffect(() => {
     return () => {
@@ -294,6 +299,8 @@ export default function IndicatorEditorPage({
       }
     };
   }, [site.id]);
+
+  useEffect(() => { activeTargetWarningsRef.current = new Set(); }, [site.id]);
 
   const extractIndicators = useCallback(() => {
     if (autoExtractionInProgress) {
@@ -493,7 +500,7 @@ export default function IndicatorEditorPage({
           setHasChanges(false);
 
           const warnings = savedSite?.indicators?.warnings ?? [];
-          showTargetWarningsPopup(warnings, toast);
+          activeTargetWarningsRef.current = showTargetWarningsPopup(warnings, toast, activeTargetWarningsRef.current);
 
           toast({
             title: 'Changes saved',

--- a/frontend/src/components/ViewPane.tsx
+++ b/frontend/src/components/ViewPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box, Flex, HStack, IconButton, Spinner, Text, Tooltip,
   useColorModeValue,
@@ -227,60 +227,104 @@ function ViewPane({
   const siteExtractedAt = siteIndicators?.extractedAt;
   const siteCatchmentCount = siteIndicators?.catchmentCount;
 
+  // Tracks the dependencies that mean "the user navigated somewhere new" —
+  // as opposed to siteIndicators alone changing, which means a target
+  // recalculation refetched this pane's data in the background. Only the
+  // former should show the loading overlay: the target editor's own
+  // "Recalculating" indicator already covers the latter, and blocking every
+  // pane with a spinner on every step of a live-update drag was the point
+  // being fixed here.
+  const dialFetchNavRef = useRef<{ attribute: string; siteId: string; isDialView: boolean } | null>(null);
+
   useEffect(() => {
     if (!isDialView || !siteId || !comparison.attribute) {
       setDialCatchmentData(null);
       setDialCatchmentLoading(false);
+      dialFetchNavRef.current = null;
       return;
     }
 
-    let cancelled = false;
-    setDialCatchmentLoading(true);
+    const nav = { attribute: comparison.attribute, siteId, isDialView };
+    const isNavigation =
+      dialFetchNavRef.current === null ||
+      dialFetchNavRef.current.attribute !== nav.attribute ||
+      dialFetchNavRef.current.siteId !== nav.siteId ||
+      dialFetchNavRef.current.isDialView !== nav.isDialView;
+    dialFetchNavRef.current = nav;
 
-    // A remembered spread gives the dial a scale to draw against straight away,
-    // rather than a placeholder until the catchments land. The values still
-    // come from the fetch below; only the axis is answered early.
-    const cachedSpread = loadSiteRange(
-      siteId,
-      siteRangeFingerprint(siteExtractedAt, siteCatchmentCount),
-      comparison.attribute,
-    );
-    if (cachedSpread) {
-      setDialCatchmentData((prev) => (prev ? { ...prev, spread: cachedSpread } : { spread: cachedSpread }));
+    let cancelled = false;
+    if (isNavigation) setDialCatchmentLoading(true);
+
+    const runFetch = () => {
+      // A remembered spread gives the dial a scale to draw against straight
+      // away, rather than a placeholder until the catchments land. The
+      // values still come from the fetch below; only the axis is answered
+      // early.
+      const cachedSpread = loadSiteRange(
+        siteId,
+        siteRangeFingerprint(siteExtractedAt, siteCatchmentCount),
+        comparison.attribute,
+      );
+      if (cachedSpread) {
+        setDialCatchmentData((prev) => (prev ? { ...prev, spread: cachedSpread } : { spread: cachedSpread }));
+      }
+
+      getSiteCatchments(siteId)
+        .then((catchments) => {
+          if (cancelled || !catchments || catchments.length === 0) {
+            if (!cancelled) setDialCatchmentLoading(false);
+            return;
+          }
+
+          const referenceValue = computeAOIWeightedAttributeValue(catchments, 'reference', comparison.attribute);
+          const currentValue = computeAOIWeightedAttributeValue(catchments, 'current', comparison.attribute);
+          const spread = attributeSpread(catchments, comparison.attribute);
+          // Keep the conclusion, not the payload it came from. Two numbers
+          // survive the reload; the catchments do not need to.
+          if (spread && siteId) {
+            saveSiteRange(siteId, siteRangeFingerprint(siteExtractedAt, siteCatchmentCount), comparison.attribute, spread);
+          }
+
+          if (referenceValue === undefined && currentValue === undefined) {
+            if (!cancelled) { setDialCatchmentData(null); setDialCatchmentLoading(false); }
+            return;
+          }
+
+          if (!cancelled) {
+            setDialCatchmentData({ referenceValue, currentValue, spread });
+            setDialCatchmentLoading(false);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) { setDialCatchmentData(null); setDialCatchmentLoading(false); }
+        });
+    };
+
+    // A live-update drag can fire many recalculations within a second or
+    // two; fetching this pane's catchments on every single one piled extra
+    // GET requests on top of the PATCH requests themselves, right when the
+    // backend's admission control (internal/server/admission.go) is most
+    // likely to be under pressure and shedding work. Real navigation — a
+    // new attribute, a new site — stays immediate; only a background
+    // refresh triggered by siteIndicators changing is debounced, so a burst
+    // of edits costs one fetch once things settle rather than one per step.
+    let debounceId: ReturnType<typeof setTimeout> | undefined;
+    if (isNavigation) {
+      runFetch();
+    } else {
+      debounceId = setTimeout(runFetch, 400);
     }
 
-    getSiteCatchments(siteId)
-      .then((catchments) => {
-        if (cancelled || !catchments || catchments.length === 0) {
-          if (!cancelled) setDialCatchmentLoading(false);
-          return;
-        }
-
-        const referenceValue = computeAOIWeightedAttributeValue(catchments, 'reference', comparison.attribute);
-        const currentValue = computeAOIWeightedAttributeValue(catchments, 'current', comparison.attribute);
-        const spread = attributeSpread(catchments, comparison.attribute);
-        // Keep the conclusion, not the payload it came from. Two numbers
-        // survive the reload; the catchments do not need to.
-        if (spread && siteId) {
-          saveSiteRange(siteId, siteRangeFingerprint(siteExtractedAt, siteCatchmentCount), comparison.attribute, spread);
-        }
-
-        if (referenceValue === undefined && currentValue === undefined) {
-          if (!cancelled) { setDialCatchmentData(null); setDialCatchmentLoading(false); }
-          return;
-        }
-
-        if (!cancelled) {
-          setDialCatchmentData({ referenceValue, currentValue, spread });
-          setDialCatchmentLoading(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) { setDialCatchmentData(null); setDialCatchmentLoading(false); }
-      });
-
-    return () => { cancelled = true; };
-  }, [comparison.attribute, siteId, isDialView, siteExtractedAt, siteCatchmentCount]);
+    return () => {
+      cancelled = true;
+      if (debounceId !== undefined) clearTimeout(debounceId);
+    };
+    // siteIndicators is included so a target-editor recalculation (live
+    // update or not) refetches this pane's catchment values — without it,
+    // editing a factor back down left currentValue pinned at whatever it
+    // was the last time the pane's attribute or extraction changed, even
+    // though the underlying data had already returned to baseline.
+  }, [comparison.attribute, siteId, isDialView, siteExtractedAt, siteCatchmentCount, siteIndicators]);
 
   /**
    * The bbox this pane's aggregates are scoped to, as a string, or '' when the
@@ -899,17 +943,18 @@ function ViewPane({
 
         The table shows a single scenario (it aggregates the left one), so it
         gets a single label rather than a comparison it is not making. The
-        chart draws its own Reference/Current/Target legend, and the flat dial
-        labels its REF/NOW markers directly on the band, so for both the
-        corner labels would just repeat what is already on the chart.
+        chart draws its own Reference/Current/Target legend, the gauge dial
+        draws that same legend along its bottom edge, and the flat dial
+        labels its REF/NOW markers directly on the band — so for all three
+        the corner labels would just repeat what is already on the chart.
       */}
       {viewMode !== 'map' && (
         <PaneHeader
           compact={compact}
           title={dialAttributeLabel}
-          leftLabel={viewMode === 'chart' || viewMode === 'flat' ? undefined : (leftInfo?.label || comparison.leftScenario)}
+          leftLabel={viewMode === 'chart' || viewMode === 'flat' || viewMode === 'dial' ? undefined : (leftInfo?.label || comparison.leftScenario)}
           leftColor={leftInfo?.color}
-          rightLabel={viewMode === 'table' || viewMode === 'chart' || viewMode === 'flat' ? undefined : (rightInfo?.label || comparison.rightScenario)}
+          rightLabel={viewMode === 'table' || viewMode === 'chart' || viewMode === 'flat' || viewMode === 'dial' ? undefined : (rightInfo?.label || comparison.rightScenario)}
           rightColor={rightInfo?.color}
         />
       )}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -102,6 +102,34 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return response.json();
 }
 
+/**
+ * Retries a request the server sheds for being at capacity (503 with
+ * Retry-After — see internal/server/admission.go's deliberate load
+ * shedding). A burst of quick live-update edits can be enough to get one
+ * PATCH shed; without a retry that just throws, and for the indicators
+ * endpoint the caller's response is to roll the edit back as though it had
+ * never happened — the slider then sits on a stale value that nothing ever
+ * corrects, because nothing tries again. Honors the server's own
+ * Retry-After rather than guessing a backoff.
+ */
+async function fetchWithAdmissionRetry(
+  input: string,
+  init: RequestInit,
+  maxRetries = 2,
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(input, init);
+    if (response.status !== 503 || attempt >= maxRetries) {
+      return response;
+    }
+    const retryAfterSeconds = Number(response.headers.get('Retry-After'));
+    const delayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+      ? retryAfterSeconds * 1000
+      : 500 * (attempt + 1);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+
 // How often to re-fetch /api/info after the first load. Version/data-loaded
 // status never changes at runtime, but satellite_quota_exceeded can flip mid
 // session — this is what lets a map that is actively showing satellite
@@ -886,7 +914,7 @@ export async function patchSiteIndicators(
   // it from data/sites/, and the result is never persisted to disk.
   if (site?.source === 'walkthrough') {
     const { thumbnail: _thumbnail, ...siteWithoutThumbnail } = site;
-    const response = await fetch(`${API_BASE}/sites/${id}/indicators`, {
+    const response = await fetchWithAdmissionRetry(`${API_BASE}/sites/${id}/indicators`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -913,43 +941,52 @@ export async function patchSiteIndicators(
   if (isBrowserRuntime()) {
     const localSite = loadLocalSite(id);
     if (localSite) {
-      try {
-        const { thumbnail: _thumbnail, ...siteWithoutThumbnail } = localSite;
-        const response = await fetch(`${API_BASE}/sites/${id}/indicators`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            runtime: 'browser',
-            site: siteWithoutThumbnail,
-            ideal: indicators?.ideal,
-            idealLower: indicators?.idealLower,
-            idealUpper: indicators?.idealUpper,
-            reference: indicators?.reference,
-            referenceLower: indicators?.referenceLower,
-            referenceUpper: indicators?.referenceUpper,
-            current: indicators?.current,
-            currentLower: indicators?.currentLower,
-            currentUpper: indicators?.currentUpper,
-          }),
-        });
-        if (response.ok) {
-          const updatedSite = await response.json() as SiteWithCatchments;
-          if (Array.isArray(updatedSite.catchments) && updatedSite.catchments.length > 0) {
-            // Cache the fresh breakdown. This used to persist it and then
-            // invalidate a separate in-memory cache; both are now the same
-            // cache, so deleting here would discard what was just fetched.
-            cacheCatchments(id, updatedSite.catchments);
-          }
-          return updateSite(id, { indicators: updatedSite.indicators });
-        }
-      } catch {
-        // Fall through to local-only update
+      const { thumbnail: _thumbnail, ...siteWithoutThumbnail } = localSite;
+      const response = await fetchWithAdmissionRetry(`${API_BASE}/sites/${id}/indicators`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          runtime: 'browser',
+          site: siteWithoutThumbnail,
+          ideal: indicators?.ideal,
+          idealLower: indicators?.idealLower,
+          idealUpper: indicators?.idealUpper,
+          reference: indicators?.reference,
+          referenceLower: indicators?.referenceLower,
+          referenceUpper: indicators?.referenceUpper,
+          current: indicators?.current,
+          currentLower: indicators?.currentLower,
+          currentUpper: indicators?.currentUpper,
+        }),
+      });
+      // A silent fall-through to a local-only save used to live here: on any
+      // fetch failure or non-2xx response, it persisted `indicators` — the
+      // caller's un-cascaded guess, where only the just-edited key is right
+      // and every derived total (herbivore biomass, methane, ...) still
+      // holds its pre-edit value — as if it were the server's recalculated
+      // answer, and resolved successfully instead of rejecting. The caller
+      // (App.tsx's handleSiteIndicatorsChange) treated that resolution as a
+      // real cascade and adopted it into site state, so a single dropped
+      // request during a live-update drag could leave a factor's slider at
+      // its new value while everything it feeds into stayed stuck at the
+      // old one, permanently. Throwing here lets the caller's existing
+      // catch-and-roll-back handle it instead.
+      if (!response.ok) {
+        throw new Error(`Failed to update site indicators: ${response.statusText}`);
       }
+      const updatedSite = await response.json() as SiteWithCatchments;
+      if (Array.isArray(updatedSite.catchments) && updatedSite.catchments.length > 0) {
+        // Cache the fresh breakdown. This used to persist it and then
+        // invalidate a separate in-memory cache; both are now the same
+        // cache, so deleting here would discard what was just fetched.
+        cacheCatchments(id, updatedSite.catchments);
+      }
+      return updateSite(id, { indicators: updatedSite.indicators });
     }
     return updateSite(id, { indicators });
   }
 
-  const response = await fetch(`${API_BASE}/sites/${id}/indicators`, {
+  const response = await fetchWithAdmissionRetry(`${API_BASE}/sites/${id}/indicators`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/frontend/src/utils/warnings.ts
+++ b/frontend/src/utils/warnings.ts
@@ -6,21 +6,33 @@ const targetWarningMessages: Record<string, string> = {
   [WARNING_NPP_GM2]: 'Herbivore consumption is higher than available biomass',
 };
 
-export function showTargetWarningsPopup(warnings: string[] | undefined, toast: ToastFn): void {
-  if (!warnings || warnings.length === 0) {
-    return;
-  }
+/**
+ * Shows a toast for each warning key that is newly active.
+ *
+ * `previouslyActive` is the set returned by the prior call (e.g. kept in a
+ * ref by the caller). Live-update recalculation calls this once per PATCH
+ * response, and a warning condition (e.g. grazing demand exceeding
+ * available biomass) commonly stays true across many consecutive steps of
+ * the same drag — most visibly while decreasing a factor back down, since
+ * the condition doesn't clear until the value crosses the threshold.
+ * Without this, every one of those responses re-toasted the same warning,
+ * stacking duplicates. Comparing against what was already shown means a
+ * warning fires once when it starts, stays silent while it persists, and
+ * can fire again only after it has cleared and reoccurs.
+ *
+ * Returns the new active set so the caller can pass it back in next time.
+ */
+export function showTargetWarningsPopup(
+  warnings: string[] | undefined,
+  toast: ToastFn,
+  previouslyActive?: ReadonlySet<string>,
+): Set<string> {
+  const active = new Set(warnings ?? []);
 
-  const popupMessages = warnings
-    .map((warning) => targetWarningMessages[warning])
-    .filter((message): message is string => Boolean(message));
-
-  if (popupMessages.length === 0) {
-    return;
-  }
-
-  const uniqueMessages = Array.from(new Set(popupMessages));
-  for (const message of uniqueMessages) {
+  for (const warning of active) {
+    if (previouslyActive?.has(warning)) continue;
+    const message = targetWarningMessages[warning];
+    if (!message) continue;
     toast({
       title: 'Warning',
       description: message,
@@ -30,6 +42,8 @@ export function showTargetWarningsPopup(warnings: string[] | undefined, toast: T
       position: 'top',
     });
   }
+
+  return active;
 }
 
 // Below this fraction of the app's known indicators resolving a reference-period


### PR DESCRIPTION
The target editor's live-update mode (recalculate while dragging) had several reliability and UX bugs, most stemming from race conditions between rapid successive edits and their server responses:

- Fix a race where a second queued recalculation could read a stale, pre-response snapshot of an untouched-but-server-cascaded field (e.g. Tree cover fraction after only Grass cover fraction was edited), causing the backend to misread it as a direct edit and silently overwrite the value the user had just set.
- Roll back the optimistic site-state update when an indicators PATCH fails, instead of leaving an un-cascaded guess in place indefinitely.
- Stop silently persisting non-cascaded data on a failed browser-runtime PATCH; surface the failure instead so the caller can roll back correctly.
- Retry indicator updates that get shed by the backend's admission control (503 + Retry-After) instead of treating a transient overload as a permanent failure.
- Stop a touched slider's on-screen value from being overwritten by a stale intermediate response while the scheduler still has newer work queued.
- De-duplicate target-state warning toasts so a condition that persists across many live-update steps only notifies once instead of stacking.
- Refresh per-catchment dial and aggregate-table data after a live-update recalculation (previously only refreshed on site/attribute navigation), debounced to avoid piling extra requests on top of a recalculation burst.
- Only show the pane loading spinner for real navigation, not for a quiet background refresh triggered by recalculation.

Also includes two small UI fixes on the dial charts:

- Remove the redundant "Ecological Reference"/"Current State" corner tags on the gauge dial view, which already draws its own legend.
- Lengthen the reference/current marker lines on the flat dial so they clear the target buckle's full rendered extent instead of being hidden behind it.
