### PR TITLE
fix: stop the Africa tour's chart step from freezing, and flatten its ecosystem-consequences dials

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -795,6 +795,32 @@ function App() {
     return () => window.removeEventListener('dt:demo-go-quad-dial-africa', handler);
   }, []);
 
+  // Same 6-pane, 3-column layout as dt:demo-go-quad-dial-africa above, but as
+  // flat dials (bands rather than gauges) — for the AfricaDemoTour's
+  // "Ecosystem-Scale Consequences" step, which shares its pane set with the
+  // "Intervention" step but wants the flat presentation instead.
+  useEffect(() => {
+    const handler = () => {
+      const base = { leftScenario: 'reference' as const, rightScenario: 'current' as const };
+      const demoPanes: PaneStates = [
+        { ...base, attribute: 'herbs_tot_kgkm2' },
+        { ...base, attribute: 'herbs_totGRAZING_kgkm2' },
+        { ...base, attribute: 'percBurned' },
+        { ...base, attribute: 'CH4_both_kg_km2' },
+        { ...base, attribute: 'NPP_gm2' },
+        { ...base, attribute: 'herbs_fg_kgkm2_Megaherbivores' },
+      ];
+      setLayoutMode('quad');
+      setQuadColumns(3);
+      setIndicatorPaneIndex(null);
+      setPaneStates(demoPanes);
+      setViewModes(demoPanes.map(() => 'flat'));
+      setRangeMode('site');
+    };
+    window.addEventListener('dt:demo-go-quad-flat-africa', handler);
+    return () => window.removeEventListener('dt:demo-go-quad-flat-africa', handler);
+  }, []);
+
   // Listen for demo event to swap the NPP dial for change-in-SOC, for the
   // AfricaDemoTour "ecosystem-scale consequences" step.
   useEffect(() => {

--- a/frontend/src/components/AfricaDemoTour.tsx
+++ b/frontend/src/components/AfricaDemoTour.tsx
@@ -70,7 +70,7 @@ const DEMO_STEPS: DemoStep[] = [
       'Land management decisions never happen in isolation. Over the decades, maximising livestock numbers in an ecosystem has produced undesirable consequences elsewhere. Click the dial button for a multi-panel view of how the current herbivore regime has altered ecosystem functioning.',
     targetId: 'tour-view-modes',
     navigateTo: 'map',
-    autoUiEvent: 'dt:demo-go-quad-dial-africa',
+    autoUiEvent: 'dt:demo-go-quad-flat-africa',
   },
   {
     icon: <FiActivity size={28} />,

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1264,6 +1264,16 @@ function hasWhiskerData(bounds: WhiskerBoundsResponse | null | undefined): boole
 // line by line and keep only what the caller asked for — a handful of named
 // rows, or a running per-column sum/count — so peak memory stays proportional
 // to what is wanted, not to the file on disk.
+// Hands control back to the browser between chunks of row parsing below, so a
+// 147,837-row file doesn't run as one uninterruptible synchronous block — that
+// was blocking the main thread for the several seconds it took to parse
+// Africa's whisker CSVs, freezing the tab on the first chart-view load.
+const WHISKER_ROWS_PER_YIELD = 2000;
+
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function parseWhiskerCSVHeader(headerLine: string): { headers: string[]; catchIdIndex: number } {
   const headers = headerLine.split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
   return { headers, catchIdIndex: headers.findIndex((h) => h.toLowerCase() === 'catchid') };
@@ -1316,6 +1326,7 @@ async function loadWhiskerCSVFileFiltered(
       if (!line) continue;
       const parsed = parseWhiskerCSVRow(line, headers, catchIdIndex);
       if (parsed && wantedIds.has(parsed.catchId)) data[parsed.catchId] = parsed.row;
+      if (i % WHISKER_ROWS_PER_YIELD === 0) await yieldToMain();
     }
     return data;
   } catch {
@@ -1369,6 +1380,7 @@ async function loadWhiskerCSVFileAggregate(
         sums[col] = (sums[col] ?? 0) + val;
         counts[col] = (counts[col] ?? 0) + 1;
       }
+      if (i % WHISKER_ROWS_PER_YIELD === 0) await yieldToMain();
     }
     return { sums, counts };
   } catch {


### PR DESCRIPTION
- Fix UI freeze on the Africa tour's "Changed Herbivore Regimes" step: whisker-bounds CSV parsing (4 files x 147,837 rows) ran as one unbroken synchronous loop, blocking the main thread for several seconds on first chart-view load. Now yields to the browser every 2000 rows so the tab stays responsive.
- Switch the "Ecosystem-Scale Consequences" step to flat dials (bands) instead of round gauges, via a new dt:demo-go-quad-flat-africa event. The later "Intervention" step keeps the round gauges.
